### PR TITLE
No longer send client cert in authenticate request

### DIFF
--- a/pkg/authenticator/authenticator.go
+++ b/pkg/authenticator/authenticator.go
@@ -179,7 +179,6 @@ func (auth *Authenticator) Authenticate() ([]byte, error) {
 		auth.Config.ConjurVersion,
 		auth.Config.Account,
 		auth.Config.Username,
-		certPEMBlock,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/authenticator/requests.go
+++ b/pkg/authenticator/requests.go
@@ -31,7 +31,7 @@ func LoginRequest(authnURL string, conjurVersion string, csrBytes []byte) (*http
 }
 
 // AuthenticateRequest sends an authenticate request
-func AuthenticateRequest(authnURL string, conjurVersion string, account string, username string, cert []byte) (*http.Request, error) {
+func AuthenticateRequest(authnURL string, conjurVersion string, account string, username string) (*http.Request, error) {
 	var authenticateURL string
 	var err error
 	var req *http.Request
@@ -44,16 +44,10 @@ func AuthenticateRequest(authnURL string, conjurVersion string, account string, 
 
 	log.Printf("making authn request to %s", authenticateURL)
 
-	if conjurVersion == "5" {
-		body := bytes.NewReader(cert)
-		req, err = http.NewRequest("POST", authenticateURL, body)
-	} else {
-		req, err = http.NewRequest("POST", authenticateURL, nil)
-	}
-
-	if err != nil {
+	if req, err = http.NewRequest("POST", authenticateURL, nil); err != nil {
 		return nil, err
 	}
+
 	req.Header.Set("Content-Type", "text/plain")
 
 	return req, nil


### PR DESCRIPTION
We had been sending the client cert in the header and in the body for v5 Conjur.
This commit updates it to no longer send the cert in the request body.

I have verified that this works by deploying Conjur 5.2.2 patched with `conjur-possum_1.3.1.12-177c34d_amd64.deb` to GKE using `kubernetes-conjur-deploy` and then running `kubernetes-conjur-demo` using a build of this branch of the k8s authenticator.

To test yourself:
- Deploy any recent build of Conjur to GKE using `kubernetes-conjur-deploy`
- Build this branch of the authenticator client locally by running `./bin/build`
- Deploy the demo apps by running the version of the demo [in my related PR](https://github.com/conjurdemos/kubernetes-conjur-demo/pull/31/) with `LOCAL_AUTHENTICATOR=true` in your environment