### PR TITLE
Add UT tests for AccessToken delete interface

### DIFF
--- a/pkg/storage/access_token_file_test.go
+++ b/pkg/storage/access_token_file_test.go
@@ -92,7 +92,7 @@ func TestAccessTokenFile(t *testing.T) {
 			err := tokenInFile.Write(dataActual)
 			So(err, ShouldEqual, nil)
 
-			_, err = tokenInFile.Read()
+			dataFromRead, err := tokenInFile.Read()
 			So(err, ShouldEqual, nil)
 
 			err = tokenInFile.Delete()
@@ -101,6 +101,13 @@ func TestAccessTokenFile(t *testing.T) {
 			// Check that file is not exits
 			_, err = os.Stat("/tmp/accessTokenFileDel1")
 			So(err, ShouldNotEqual, nil)
+
+			// Both input & output arrays should be cleared from memory
+			empty := make([]byte, len(dataActual))
+			eq := reflect.DeepEqual(dataActual, empty)
+			So(eq, ShouldEqual, true)
+			eq = reflect.DeepEqual(dataFromRead, empty)
+			So(eq, ShouldEqual, true)
 		})
 
 		Convey("Returns no error if Data input is nil", func() {

--- a/pkg/storage/access_token_memory_test.go
+++ b/pkg/storage/access_token_memory_test.go
@@ -56,11 +56,18 @@ func TestAccessTokenMemory(t *testing.T) {
 			err := tokenInMemory.Write(dataActual)
 			So(err, ShouldEqual, nil)
 
-			_, err = tokenInMemory.Read()
+			dataFromRead, err := tokenInMemory.Read()
 			So(err, ShouldEqual, nil)
 
 			err = tokenInMemory.Delete()
 			So(err, ShouldEqual, nil)
+
+			// Both input & output arrays should be cleared from memory
+			empty := make([]byte, len(dataActual))
+			eq := reflect.DeepEqual(dataActual, empty)
+			So(eq, ShouldEqual, true)
+			eq = reflect.DeepEqual(dataFromRead, empty)
+			So(eq, ShouldEqual, true)
 		})
 
 		Convey("Returns no error if Data input is nil", func() {


### PR DESCRIPTION
Add UT tests for delete interface 
- Both arrays as input to write(data []byte) and output from read() should be cleared from memory after delete()