### PR TITLE
Exit program only in main

### DIFF
--- a/pkg/storage/storage_handler.go
+++ b/pkg/storage/storage_handler.go
@@ -7,7 +7,6 @@ import (
 	secretsHandlers "github.com/cyberark/conjur-authn-k8s-client/pkg/secrets/handlers"
 	log "github.com/cyberark/conjur-authn-k8s-client/pkg/sidecar/logging"
 	storageConfigProvider "github.com/cyberark/conjur-authn-k8s-client/pkg/storage/config"
-	"os"
 )
 
 // TODO: understand why we need underscore here, otherwise "Storage_Handler is not a type"
@@ -23,7 +22,7 @@ func NewStorageHandler(storageConfig storageConfigProvider.Config) (StorageHandl
 	secretsConfig, err := secretsConfigProvider.NewFromEnv()
 	if err != nil {
 		errLogger.Printf("Failure creating secrets config: %s", err.Error())
-		os.Exit(1)
+		return nil, err
 	}
 
 	var accessTokenHandler access_token.AccessTokenHandler
@@ -52,7 +51,7 @@ func NewStorageHandler(storageConfig storageConfigProvider.Config) (StorageHandl
 	} else {
 		// although this is checked when creating `storageConfig.StoreType` we check this here for code clarity and future dev guard
 		errLogger.Printf("Store type %s is invalid", storageConfig.StoreType)
-		os.Exit(1)
+		return nil, err
 	}
 
 	return &Storage_Handler{


### PR DESCRIPTION
We should exit the program only in `main.go` to better handle errors. This PR returns `nil` to main in every place we exited explicitly outside of main