### PR TITLE
Allow more than 1 k8s secret to map to a single Conjur secret

### DIFF
--- a/pkg/secrets/handlers/secrets_handler_k8s.go
+++ b/pkg/secrets/handlers/secrets_handler_k8s.go
@@ -72,7 +72,7 @@ func (secretsHandlerK8sUseCase SecretsHandlerK8sUseCase) HandleSecrets() error {
 	return nil
 }
 
-func getVariableIDsToRetrieve(pathMap map[string]string) ([]string, error) {
+func getVariableIDsToRetrieve(pathMap map[string][]string) ([]string, error) {
 	var variableIDs []string
 
 	if len(pathMap) == 0 {
@@ -96,10 +96,12 @@ func updateK8sSecretsMapWithConjurSecrets(k8sSecretsMap *k8s.K8sSecretsMap, conj
 			return fmt.Errorf("failed to update k8s k8sSecretsHandler map: %s", err)
 		}
 
-		locationInK8sSecretsMap := strings.Split(k8sSecretsMap.PathMap[variableId], ":")
-		k8sSecretName := locationInK8sSecretsMap[0]
-		k8sSecretDataEntryKey := locationInK8sSecretsMap[1]
-		k8sSecretsMap.K8sSecrets[k8sSecretName][k8sSecretDataEntryKey] = secret
+		for _, locationInK8sSecretsMap := range k8sSecretsMap.PathMap[variableId] {
+			locationInK8sSecretsMap := strings.Split(locationInK8sSecretsMap, ":")
+			k8sSecretName := locationInK8sSecretsMap[0]
+			k8sSecretDataEntryKey := locationInK8sSecretsMap[1]
+			k8sSecretsMap.K8sSecrets[k8sSecretName][k8sSecretDataEntryKey] = secret
+		}
 
 		// Clear secret from memory
 		empty := make([]byte, len(secret))

--- a/pkg/secrets/handlers/secrets_handler_k8s_test.go
+++ b/pkg/secrets/handlers/secrets_handler_k8s_test.go
@@ -12,11 +12,12 @@ func TestSecretsHandlerK8sUseCase(t *testing.T) {
 	Convey("getVariableIDsToRetrieve", t, func() {
 
 		Convey("Given a non-empty pathMap", func() {
-			m := make(map[string]string)
-			m["account/var_path1"] = "secret1:key1"
-			m["account/var_path2"] = "secret1:key2"
+			pathMap := make(map[string][]string)
+
+			pathMap["account/var_path1"] = []string{"secret1:key1"}
+			pathMap["account/var_path2"] = []string{"secret1:key2"}
 			variableIDsExpected := []string{"account/var_path1", "account/var_path2"}
-			variableIDsActual, err := getVariableIDsToRetrieve(m)
+			variableIDsActual, err := getVariableIDsToRetrieve(pathMap)
 
 			Convey("Finishes without raising an error", func() {
 				So(err, ShouldEqual, nil)
@@ -32,10 +33,10 @@ func TestSecretsHandlerK8sUseCase(t *testing.T) {
 		})
 
 		Convey("Given an empty pathMap", func() {
-			m := make(map[string]string)
+			pathMap := make(map[string][]string)
 
 			Convey("Raises an error that the map input is empty", func() {
-				_, err := getVariableIDsToRetrieve(m)
+				_, err := getVariableIDsToRetrieve(pathMap)
 				So(err.Error(), ShouldEqual, "error map should not be empty")
 			})
 		})
@@ -53,8 +54,8 @@ func TestSecretsHandlerK8sUseCase(t *testing.T) {
 			k8sSecretsMap := make(map[string]map[string][]byte)
 			k8sSecretsMap["mysecret"] = newDataEntriesMap
 
-			pathMap := make(map[string]string)
-			pathMap["allowed/username"] = "mysecret:username"
+			pathMap := make(map[string][]string)
+			pathMap["allowed/username"] = []string{"mysecret:username"}
 
 			k8sSecretsStruct := k8s.K8sSecretsMap{k8sSecretsMap, pathMap}
 			err := updateK8sSecretsMapWithConjurSecrets(&k8sSecretsStruct, conjurSecrets)
@@ -72,6 +73,37 @@ func TestSecretsHandlerK8sUseCase(t *testing.T) {
 				empty := make([]byte, len(secret))
 				eq := reflect.DeepEqual(k8sSecretsStruct.K8sSecrets["mysecret"]["username"], secret)
 				eq = reflect.DeepEqual(conjurSecrets["account:variable:allowed/username"], empty)
+				So(eq, ShouldEqual, true)
+			})
+		})
+
+		Convey("Given 2 k8s secrets that need the same Conjur secret", func() {
+			secret := []byte{'s', 'u', 'p', 'e', 'r'}
+			conjurSecrets := make(map[string][]byte)
+			conjurSecrets["account:variable:allowed/username"] = secret
+
+			dataEntriesMap := make(map[string][]byte)
+			dataEntriesMap["username"] = []byte("allowed/username")
+
+			k8sSecretsMap := make(map[string]map[string][]byte)
+			k8sSecretsMap["secret"] = dataEntriesMap
+			k8sSecretsMap["another-secret"] = dataEntriesMap
+
+			pathMap := make(map[string][]string)
+			pathMap["allowed/username"] = []string{"secret:username", "another-secret:username"}
+
+			k8sSecretsStruct := k8s.K8sSecretsMap{k8sSecretsMap, pathMap}
+			err := updateK8sSecretsMapWithConjurSecrets(&k8sSecretsStruct, conjurSecrets)
+
+			Convey("Finishes without raising an error", func() {
+				So(err, ShouldEqual, nil)
+			})
+
+			Convey("Replaces both Variable IDs in k8sSecretsMap to their corresponding secret values without errors", func() {
+				eq := reflect.DeepEqual(k8sSecretsStruct.K8sSecrets["secret"]["username"], secret)
+				So(eq, ShouldEqual, true)
+
+				eq = reflect.DeepEqual(k8sSecretsStruct.K8sSecrets["another-secret"]["username"], secret)
 				So(eq, ShouldEqual, true)
 			})
 		})

--- a/pkg/secrets/k8s/k8s_secrets.go
+++ b/pkg/secrets/k8s/k8s_secrets.go
@@ -38,7 +38,7 @@ type K8sSecretsMap struct {
 
 	// Maps a conjur variable id to its place in the k8sSecretsMap. This object helps us to replace
 	// the variable IDs with their corresponding secret value in the map
-	PathMap map[string]string
+	PathMap map[string][]string
 }
 
 func (secrets K8sSecretsHandler) RetrieveK8sSecrets() (*K8sSecretsMap, error) {
@@ -46,7 +46,7 @@ func (secrets K8sSecretsHandler) RetrieveK8sSecrets() (*K8sSecretsMap, error) {
 	requiredK8sSecrets := secrets.Config.RequiredK8sSecrets
 
 	k8sSecrets := make(map[string]map[string][]byte)
-	pathMap := make(map[string]string)
+	pathMap := make(map[string][]string)
 
 	for _, secretName := range requiredK8sSecrets {
 		k8sSecret, err := retrieveK8sSecret(namespace, secretName)
@@ -70,7 +70,7 @@ func (secrets K8sSecretsHandler) RetrieveK8sSecrets() (*K8sSecretsMap, error) {
 					newDataEntriesMap[k8sSecretKey] = []byte(conjurVariableId)
 
 					// This map will help us later to swap the variable id with the secret value
-					pathMap[conjurVariableId] = fmt.Sprintf("%s:%s", secretName, k8sSecretKey)
+					pathMap[conjurVariableId] = append(pathMap[conjurVariableId], fmt.Sprintf("%s:%s", secretName, k8sSecretKey))
 				}
 			}
 		}


### PR DESCRIPTION
We had a bug where if more than 1 k8s secret were mapped to a single conjur secret we updated only one of them. This commit fixes that