### PR TITLE
WIP: Escape on backslashes

### DIFF
--- a/pkg/secrets/k8s/k8s_secrets.go
+++ b/pkg/secrets/k8s/k8s_secrets.go
@@ -188,7 +188,7 @@ func generateStringDataEntry(stringDataEntriesMap map[string][]byte) ([]byte, er
 	entries := make([][]byte, len(stringDataEntriesMap))
 	// Parse every key-value pair in the map to a "key:value" byte array
 	for key, value := range stringDataEntriesMap {
-		value = escapeDataEntry(value)
+		value = escapedSecret(value)
 		entry = utils.ByteSlicePrintf(
 			`"%v":"%v"`,
 			"%v",
@@ -232,6 +232,8 @@ func generateStringDataEntry(stringDataEntriesMap map[string][]byte) ([]byte, er
 	return stringDataEntry, nil
 }
 
-func escapeDataEntry(value []byte) ([]byte) {
-	return bytes.ReplaceAll(value, []byte("\\"), []byte("\\\\"))
+// Escape secrets with backslashes
+// Otherwise, patching K8s secrets will fail because backslashes in Conjur secret are not escaped
+func escapedSecret(secretByte []byte) ([]byte) {
+	return bytes.ReplaceAll(secretByte, []byte("\\"), []byte("\\\\"))
 }

--- a/pkg/secrets/k8s/k8s_secrets.go
+++ b/pkg/secrets/k8s/k8s_secrets.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"bytes"
 	"fmt"
 	log "github.com/cyberark/conjur-authn-k8s-client/pkg/logging"
 	secretsConfig "github.com/cyberark/conjur-authn-k8s-client/pkg/secrets/config"
@@ -185,11 +186,12 @@ func generateStringDataEntry(stringDataEntriesMap map[string][]byte) ([]byte, er
 	entries := make([][]byte, len(stringDataEntriesMap))
 	// Parse every key-value pair in the map to a "key:value" byte array
 	for key, value := range stringDataEntriesMap {
+		stringDataEntriesMap[key] = bytes.Replace(value, []byte("\\"), []byte("\\\\"), -1)
 		entry = utils.ByteSlicePrintf(
 			`"%v":"%v"`,
 			"%v",
 			[]byte(key),
-			value,
+			stringDataEntriesMap[key],
 		)
 		entries[index] = entry
 		index++
@@ -211,7 +213,6 @@ func generateStringDataEntry(stringDataEntriesMap map[string][]byte) ([]byte, er
 				entries[i+1],
 			)
 		}
-
 		// Clear secret from memory
 		entries[i] = nil
 	}
@@ -225,6 +226,5 @@ func generateStringDataEntry(stringDataEntriesMap map[string][]byte) ([]byte, er
 
 	// Clear secret from memory
 	entriesCombined = nil
-
 	return stringDataEntry, nil
 }

--- a/pkg/secrets/k8s/k8s_secrets_test.go
+++ b/pkg/secrets/k8s/k8s_secrets_test.go
@@ -1,13 +1,13 @@
 package k8s
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	log "github.com/cyberark/conjur-authn-k8s-client/pkg/logging"
+	. "github.com/smartystreets/goconvey/convey"
 	"reflect"
-	"testing"
 	"regexp"
 	"sort"
 	"strings"
+	"testing"
 )
 
 func TestKubernetesSecrets(t *testing.T) {
@@ -37,6 +37,26 @@ func TestKubernetesSecrets(t *testing.T) {
 				stringDataEntryExpectedSorted := strings.Split(match[1], ",")
 				sort.Strings(stringDataEntryExpectedSorted)
 				eq := reflect.DeepEqual(stringDataEntryActualSorted, stringDataEntryExpectedSorted)
+				So(eq, ShouldEqual, true)
+			})
+		})
+
+		Convey("Given a map of data entries and a secret with backslashes", func() {
+			m := make(map[string][]byte)
+			// need to simulate a conjur secret, with 1 backslash, so we use unicode to simulate this
+			m["user"] = []byte("super\u005csecret");
+			DataEntry, err := generateStringDataEntry(m);
+
+			Convey("Finishes without raising an error", func() {
+				So(err, ShouldEqual, nil)
+			})
+
+			Convey("Returns proper password with escaped characters", func() {
+				// before sending secret to k8s there are two backslashes
+				// k8s cuts off the second backslash so here we are expecting two
+				stringDataEntryExpected := `{"stringData":{"user":"super\\secret"}}`
+				stringDataEntryActual := string(DataEntry)
+				eq := reflect.DeepEqual(stringDataEntryActual, stringDataEntryExpected)
 				So(eq, ShouldEqual, true)
 			})
 		})

--- a/pkg/secrets/k8s/k8s_secrets_test.go
+++ b/pkg/secrets/k8s/k8s_secrets_test.go
@@ -1,24 +1,25 @@
 package k8s
 
 import (
-	log "github.com/cyberark/conjur-authn-k8s-client/pkg/logging"
-	. "github.com/smartystreets/goconvey/convey"
 	"reflect"
 	"regexp"
 	"sort"
 	"strings"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	log "github.com/cyberark/conjur-authn-k8s-client/pkg/logging"
 )
 
 func TestKubernetesSecrets(t *testing.T) {
 	Convey("generateStringDataEntry", t, func() {
 
 		Convey("Given a map of data entries", func() {
-			m := make(map[string][]byte)
-			m["user"] = []byte("dummy_user")
-			m["password"] = []byte("dummy_password")
-			m["address"] = []byte("dummy_address")
-			DataEntry, err := generateStringDataEntry(m)
+			dataEntries := make(map[string][]byte)
+			dataEntries["user"] = []byte("dummy_user")
+			dataEntries["password"] = []byte("dummy_password")
+			dataEntries["address"] = []byte("dummy_address")
+			stringDataEntry, err := generateStringDataEntry(dataEntries)
 
 			Convey("Finishes without raising an error", func() {
 				So(err, ShouldEqual, nil)
@@ -26,7 +27,7 @@ func TestKubernetesSecrets(t *testing.T) {
 
 			Convey("Convert the data entry map to a stringData entry in the form of a comma separate byte array", func() {
 				stringDataEntryExpected := `{"stringData":{"user":"dummy_user","password":"dummy_password","address":"dummy_address"}}`
-				stringDataEntryActual := string(DataEntry)
+				stringDataEntryActual := string(stringDataEntry)
 				// Sort actual and expected, because output order can change
 				re := regexp.MustCompile("\\:{(.*?)\\}")
 				// Regex example: {"stringData":{"user":"dummy_user","password":"dummy_password"}} => {"user":"dummy_user","password":"dummy_password"}
@@ -42,30 +43,51 @@ func TestKubernetesSecrets(t *testing.T) {
 		})
 
 		Convey("Given a map of data entries and a secret with backslashes", func() {
-			m := make(map[string][]byte)
-			// need to simulate a conjur secret, with 1 backslash, so we use unicode to simulate this
-			m["user"] = []byte("super\u005csecret");
-			DataEntry, err := generateStringDataEntry(m);
+			dataEntries := make(map[string][]byte)
+			// simulates a Conjur secret with 1 backslash with unicode
+			dataEntries["user"] = []byte("super\u005csecret");
+			escapedDataEntry, err := generateStringDataEntry(dataEntries);
 
 			Convey("Finishes without raising an error", func() {
 				So(err, ShouldEqual, nil)
 			})
 
 			Convey("Returns proper password with escaped characters", func() {
-				// before sending secret to k8s there are two backslashes
-				// k8s cuts off the second backslash so here we are expecting two
+				// returned 2x backslashes because k8s trims the second backslash
+				// to mimic this, we are expecting two backslashes
 				stringDataEntryExpected := `{"stringData":{"user":"super\\secret"}}`
-				stringDataEntryActual := string(DataEntry)
+				stringDataEntryActual := string(escapedDataEntry)
+				eq := reflect.DeepEqual(stringDataEntryActual, stringDataEntryExpected)
+				So(eq, ShouldEqual, true)
+			})
+		})
+
+		// a more complex use-case where the secret contains a combination of backslashes and the unicode escape sequence for backslashes
+		Convey("Given a map of data entries and a secret with unicode and backslashes", func() {
+			dataEntries := make(map[string][]byte)
+			// simulates a Conjur secret with 1 backslash with unicode
+			dataEntries["user"] = []byte("\u005c\u005ca\\u005c\u005cb\u005cc\u005c");
+			escapedDataEntry, err := generateStringDataEntry(dataEntries);
+
+			Convey("Finishes without raising an error", func() {
+				So(err, ShouldEqual, nil)
+			})
+
+			Convey("Returns proper password with escaped characters", func() {
+				// before sending a secret to K8s, each secret will be escaped with an additional backslash
+				// K8s trims the second backslash so in order to mimic this, we are expecting two backslashes
+				stringDataEntryExpected := `{"stringData":{"user":"\\\\a\\u005c\\b\\c\\"}}`
+				stringDataEntryActual := string(escapedDataEntry)
 				eq := reflect.DeepEqual(stringDataEntryActual, stringDataEntryExpected)
 				So(eq, ShouldEqual, true)
 			})
 		})
 
 		Convey("Given an empty map of data entries", func() {
-			m := make(map[string][]byte)
+			dataEntries := make(map[string][]byte)
 
 			Convey("Raises an error that the map input should not be empty", func() {
-				_, err := generateStringDataEntry(m)
+				_, err := generateStringDataEntry(dataEntries)
 				So(err.Error(), ShouldEqual, log.CAKC039E)
 			})
 		})


### PR DESCRIPTION
This PR adds logic to escape backslashes before being patched
That way, when a secret contains \, our implementation will not fail
- [x] \ are escaped
- [x] UTs have been added

NOTE: do not MERGE! We are moving repos for CA and these changes will be cherry-picked over to the new repo