### PR TITLE
Add note in CHANGELOG for NewFromEnv signature change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Moved all AccessToken related work to a separate package
 - Moved all log related work to the `log` package
+- NewFromEnv **signature has changed** - method does not take input parameters 
+  anymore and is using default values for `tokenFilePath` & `clientCertPath`.
+  These parameters can also be set as environment variables:
+    - `tokenFilePath` can be set with `CONJUR_AUTHN_TOKEN_FILE`
+    - `clientCertPath` can be set with `CONJUR_CLIENT_CERT_PATH`
 
 ## [0.13.0] - 2019-03-08
 


### PR DESCRIPTION
NewFromEnv method does not take input parameters anymore and is using default values for `tokenFilePath` & `clientCertPath`. This PR adds a note about this to the CHANGELOG. 

We changed this in 0.14.0 so it is added under that section in the CHANGELOG.

This change happened as part of [this PR](https://github.com/cyberark/conjur-authn-k8s-client/pull/40)