### PR TITLE
Authenticate hosts without application identity in the id

### DIFF
--- a/pkg/authenticator/config/username_test.go
+++ b/pkg/authenticator/config/username_test.go
@@ -9,35 +9,36 @@ import (
 func TestUsername(t *testing.T) {
 	Convey("NewUsername", t, func() {
 		Convey("Given a valid host's username", func() {
-			username := "host/path/to/policy/namespace/resource_type/resource_id"
-			expectedPrefix := "host.path.to.policy"
-			expectedSuffix := "namespace.resource_type.resource_id"
+			Convey("that is longer than 4 parts", func() {
+				username := "host/path/to/policy/namespace/resource_type/resource_id"
+				expectedPrefix := "host.path.to.policy"
+				expectedSuffix := "namespace.resource_type.resource_id"
 
-			usernameStruct, err := NewUsername(username)
-			Convey("Finishes without raising an error", func() {
-				So(err, ShouldBeNil)
+				usernameStruct, err := NewUsername(username)
+				Convey("Finishes without raising an error", func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey("The suffix include the last 3 parts", func() {
+					So(usernameStruct.Prefix, ShouldEqual, expectedPrefix)
+					So(usernameStruct.Suffix, ShouldEqual, expectedSuffix)
+				})
 			})
 
-			Convey("Splits the username as expected", func() {
-				So(usernameStruct.Prefix, ShouldEqual, expectedPrefix)
-				So(usernameStruct.Suffix, ShouldEqual, expectedSuffix)
-			})
-		})
+			Convey("that is shorter than 4 parts", func() {
+				username := "host/policy/host_id"
+				expectedPrefix := "host.policy"
+				expectedSuffix := "host_id"
 
-		Convey("Given a username that doesn't have the machine identity inside it", func() {
-			username := "host/username"
+				usernameStruct, err := NewUsername(username)
+				Convey("Finishes without raising an error", func() {
+					So(err, ShouldBeNil)
+				})
 
-			_, err := NewUsername(username)
-			Convey("Raises an invalid username error", func() {
-				So(err.Error(), ShouldStartWith, "CAKC032E")
-			})
-
-			// Test a username that has a 2-part machine identity instead of 3
-			username = "host/namespace/resource_type"
-
-			_, err = NewUsername(username)
-			Convey("Raises the same error", func() {
-				So(err.Error(), ShouldStartWith, "CAKC032E")
+				Convey("The suffix includes only the host id", func() {
+					So(usernameStruct.Prefix, ShouldEqual, expectedPrefix)
+					So(usernameStruct.Suffix, ShouldEqual, expectedSuffix)
+				})
 			})
 		})
 


### PR DESCRIPTION
Connected to cyberark/conjur#1260

Prior to this commit, we assumed that the application identity of the
host was defined in the host id, with a 3-part suffix. Now that the
Conjur server accepts authentication of hosts that have their
application identity defined in annotations, we need to modify the
client to remove the restriction on the host id. Additionally, this
commit changed the suffix from having the last 3 parts of the id to have
 the actual id, while the prefix has the policy id.

 To maintain backwards compatibility with an old Conjur server, we need
 to support a suffix that includes the 3-part application identity (and
 as mentioned earlier, the suffix should include the host-id which in
 this case is the 3-part application identity). In such a case, we take
 the last 3 parts of the host id as the suffix so it will have the
 application identity as the id.