### PR TITLE
Update publish to only push to Docker Hub on new version

### DIFF
--- a/bin/build_utils
+++ b/bin/build_utils
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+####
+# Functions to generate version numbers for this project
+####
+
+function version_tag() {
+   echo "$(< VERSION)-$(git rev-parse --short HEAD)"
+}
+
+# generate less specific versions, eg. given 1.2.3 will print 1.2 and 1
+# (note: the argument itself is not printed, append it explicitly if needed)
+function gen_versions() {
+  local version=$1
+  while [[ $version = *.* ]]; do
+    version=${version%.*}
+    echo $version
+  done
+}

--- a/bin/publish
+++ b/bin/publish
@@ -1,24 +1,54 @@
 #!/bin/bash -e
 
-DOCKERHUB_IMAGE_OLD='cyberark/conjur-kubernetes-authenticator'  # backwards-compatible image name
-DOCKERHUB_IMAGE_NEW='cyberark/conjur-authn-k8s-client'
-VERSION_TAG="$(<VERSION)"
+. bin/build_utils
 
 REDHAT_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb/conjur-openshift-authenticator-client'
 
-docker tag conjur-authn-k8s-client:dev "$DOCKERHUB_IMAGE_OLD"
-docker tag conjur-authn-k8s-client:dev "$DOCKERHUB_IMAGE_OLD:$VERSION_TAG"
+readonly REGISTRY="cyberark"
+readonly TAG="$(version_tag)"
+readonly INTERNAL_REGISTRY="registry.tld"
+readonly VERSION="$(cat VERSION)"
 
-docker tag conjur-authn-k8s-client:dev "$DOCKERHUB_IMAGE_NEW"
-docker tag conjur-authn-k8s-client:dev "$DOCKERHUB_IMAGE_NEW:$VERSION_TAG"
+readonly IMAGES=(
+  "conjur-kubernetes-authenticator"
+  "conjur-authn-k8s-client"
+)
 
-docker push $DOCKERHUB_IMAGE_OLD
-docker push "$DOCKERHUB_IMAGE_OLD:$VERSION_TAG"
+readonly TAGS=(
+  "$VERSION"
+  "latest"
+)
 
-docker push $DOCKERHUB_IMAGE_NEW
-docker push "$DOCKERHUB_IMAGE_NEW:$VERSION_TAG"
+# fetching tags is required for git_description to work
+git fetch --tags
+git_description=$(git describe)
+
+for image_name in "${IMAGES[@]}"; do
+  # always push the tag with the commit hash to internal registry
+   echo "Tagging $INTERNAL_REGISTRY/$image_name:${TAG}"
+   docker tag "$image_name:$TAG" "$INTERNAL_REGISTRY/$image_name:$TAG"
+   echo "Pushing $INTERNAL_REGISTRY/$image_name:${TAG}"
+   docker push "$INTERNAL_REGISTRY/$image_name:$TAG"
+
+  # if it’s not a tagged commit, VERSION will have extra characters (i.e. -g666c4b2), so that commit won't be published
+  # only when tag matches the VERSION, push VERSION and latest releases
+  # and x and x.y releases
+  if [ "$git_description" = "v${VERSION}" ]; then
+    echo "Revision $git_description matches version $VERSION exactly. Pushing to Dockerhub..."
+
+    for tag in "${TAGS[@]}" $(gen_versions $VERSION); do
+      echo "Tagging and pushing $REGISTRY/$image_name:$tag"
+      docker tag "$image_name:$TAG" "$REGISTRY/$image_name:$tag"
+      docker push "$REGISTRY/$image_name:$tag"
+    done
+  fi
+done
 
 docker tag conjur-authn-k8s-client:dev-redhat "$REDHAT_IMAGE"
-docker tag conjur-authn-k8s-client:dev-redhat "$REDHAT_IMAGE:$VERSION_TAG"
+docker tag conjur-authn-k8s-client:dev-redhat "$REDHAT_IMAGE:$VERSION"
 
-docker push "$REDHAT_IMAGE:$VERSION_TAG" || { echo 'Red Hat push FAILED!'; exit 0; }  # you can't push the same tag twice to redhat registry, so ignore errors
+ # you can't push the same tag twice to redhat registry, so ignore errors
+if ! docker push "${REDHAT_IMAGE}:${VERSION}"; then
+  echo 'RedHat push FAILED! (maybe the image was pushed already?)'
+  exit 0
+fi


### PR DESCRIPTION
Used https://github.com/cyberark/secretless-broker/commit/56462fbfb64f89900d3ccd8a707e5a5b1273a6e1#diff-66a2901e5a92803e08f503c72520e8a8 as a reference.

Updated `publish` file to only push to Docker Hub if the tag matches `VERSION`. Used an old Secretless commit as a reference. Tested locally, but haven't been able to test to make sure it actually pushes to Docker Hub. 

Issue: https://github.com/cyberark/conjur-authn-k8s-client/issues/69