### PR TITLE
Only push to redhat when tag matches version

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -22,6 +22,7 @@ readonly TAGS=(
 git fetch --tags
 git_description=$(git describe)
 
+# tagging and pushing to dockerhub
 for image_name in "${IMAGES[@]}"; do
    echo "Tagging $REGISTRY/$image_name:$TAG"
    docker tag conjur-authn-k8s-client:dev "$image_name:$TAG"
@@ -36,6 +37,7 @@ for image_name in "${IMAGES[@]}"; do
       echo "Tagging and pushing $REGISTRY/$image_name:$tag"
       docker tag "$image_name:$TAG" "$REGISTRY/$image_name:$tag"
       docker push "$REGISTRY/$image_name:$tag"
+      
       echo "Tagging and pushing $REGISTRY/$image_name:latest"
       docker tag "$image_name:$TAG" "$REGISTRY/$image_name:latest"
       docker push "$REGISTRY/$image_name:latest"
@@ -43,11 +45,14 @@ for image_name in "${IMAGES[@]}"; do
   fi
 done
 
-docker tag conjur-authn-k8s-client:dev-redhat "$REDHAT_IMAGE"
-docker tag conjur-authn-k8s-client:dev-redhat "$REDHAT_IMAGE:$VERSION"
+# tagging and pushing to redhat container registry
+# only push when the tag matches the VERSION
+if [ "$git_description" = "v${VERSION}" ]; then
+  docker tag conjur-authn-k8s-client:dev-redhat "$REDHAT_IMAGE:$VERSION"
 
- # you can't push the same tag twice to redhat registry, so ignore errors
-if ! docker push "${REDHAT_IMAGE}:${VERSION}"; then
-  echo 'RedHat push FAILED! (maybe the image was pushed already?)'
-  exit 0
+   # you can't push the same tag twice to redhat registry, so ignore errors
+  if ! docker push "${REDHAT_IMAGE}:${VERSION}"; then
+    echo 'RedHat push FAILED! (maybe the image was pushed already?)'
+    exit 0
+  fi
 fi


### PR DESCRIPTION
Update to only push to RedHat container registry when the tag matches the version
We suspect RedHat will fail the push when there is already an image with the same tag, but
it's still better to avoid overwriting the original image (pushed when the tag was originally added)
with another image n commits past the tag.