### PR TITLE
Update to log into RedHat registry with project API key

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        sh './bin/publish'
+        sh 'summon ./bin/publish'
       }
     }
   }

--- a/bin/publish
+++ b/bin/publish
@@ -50,9 +50,14 @@ done
 if [ "$git_description" = "v${VERSION}" ]; then
   docker tag conjur-authn-k8s-client:dev-redhat "$REDHAT_IMAGE:$VERSION"
 
-   # you can't push the same tag twice to redhat registry, so ignore errors
-  if ! docker push "${REDHAT_IMAGE}:${VERSION}"; then
-    echo 'RedHat push FAILED! (maybe the image was pushed already?)'
-    exit 0
+  if docker login scan.connect.redhat.com -u unused -p $REDHAT_API_KEY; then
+    # you can't push the same tag twice to redhat registry, so ignore errors
+    if ! docker push "${REDHAT_IMAGE}:${VERSION}"; then
+      echo 'RedHat push FAILED! (maybe the image was pushed already?)'
+      exit 0
+    fi
+  else
+    echo 'Failed to log in to scan.connect.redhat.com'
+    exit 1
   fi
 fi

--- a/secrets.yml
+++ b/secrets.yml
@@ -1,0 +1,1 @@
+REDHAT_API_KEY: !var redhat/projects/conjur-authn-k8s-client/api-key


### PR DESCRIPTION
Redhat's scan registry uses paths to separate projects and each
project has a different API key to use.  Now that there are multiple
projects, executor-wide login for the registry no longer works and
each build needs to do the corresponding login.