### PR TITLE
Build and publish a FIPS compliant image of conjur-authn-k8s-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Authenticator client prints its version upon startup (#93)
 
+### Changed
+- The project now uses `goboring/golang` as its base image to be FIPS compliant
+
 ## [0.16.1] - 2020-02-18
 ### Fixed
 - Only publish to DockerHub / RH registry when there is a new version (#72, #74,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as authenticator-client-builder
+FROM goboring/golang:1.12.17b4 as authenticator-client-builder
 MAINTAINER CyberArk Software Ltd.
 
 ENV GOOS=linux \
@@ -23,6 +23,10 @@ RUN go get -u github.com/jstemmer/go-junit-report && \
 RUN go build -a -installsuffix cgo \
     -ldflags="-X github.com/cyberark/conjur-authn-k8s-client/pkg/authenticator.Tag=$TAG" \
     -o authenticator ./cmd/authenticator
+
+# Verify the binary is using BoringCrypto.
+# Outputting to /dev/null so the output doesn't include all the files
+RUN sh -c "go tool nm authenticator | grep '_Cfunc__goboringcrypto_' 1> /dev/null"
 
 # =================== BUSYBOX LAYER ===================
 # this layer is used to get binaries into the main container


### PR DESCRIPTION
Connected to #91 

We want to let customers who require that the binary is built using
FIPS-compliant libraries an image of the conjur-authn-k8s-client.

This commit changes the base image from `golang` to `goboring/golang` and makes the required changes for it to work.

The image names stay the same as before.

It's important to state that the performance of the FIPS-compliant version is the same as the original one, as can be seen [here](https://github.com/cyberark/conjur-authn-k8s-client/pull/112).