### PR TITLE
Builds fail only on fixable HIGH & CRITICAL vulns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,8 +34,17 @@ pipeline {
     // Cannot scan dev image as it's based on busybox and trivy can't determine
     // the OS
     stage("Scan redhat image") {
-      steps {
-        scanAndReport("conjur-authn-k8s-client-redhat:dev", "NONE")
+      parallel {
+        stage ("Scan redhat image for fixable vulns") {
+          steps {
+            scanAndReport("conjur-authn-k8s-client-redhat:dev", "HIGH", false)
+          }
+        }
+        stage ("Scan redhat image for total vulns") {
+          steps {
+            scanAndReport("conjur-authn-k8s-client-redhat:dev", "NONE", true)
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Adds parallel trivy scanning - one for only potential vulns with fixes available and one for all detected potential vulns. Build failures occur only on potential vulns with fixes. Because this currently has no fixable potential vulns, I bumped the threshold to HIGH so we'll get build failures if new HIGH or CRITICAL potential vulnerabilities are discovered. 

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>