### PR TITLE
Trigger a `kubernetes-conjur-demo` build after `master` build success

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,13 @@ pipeline {
   }
 
   post {
+    success {
+      script {
+        if (env.BRANCH_NAME == 'master') {
+          build (job:'conjurdemos--kubernetes-conjur-demo/master', wait: false)
+        }
+      }
+    }
     always {
       cleanupAndNotify(currentBuild.currentResult)
     }


### PR DESCRIPTION
We would like to get an immediate feedback on a failure of a `master`
build of the project. As we don't have integration tests that run as
part of the build, our current way to get the feedback is by running
`kubernetes-conjur-demo` with the latest build.

By triggering `kubernetes-conjur-demo` to run after a successful
`master` build of this project it will be easier to pin point to a
change in case of a failure.
