### PR TITLE
Scan also main image as it's now based on alpine

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,10 +31,18 @@ pipeline {
       }
     }
 
-    // Cannot scan dev image as it's based on busybox and trivy can't determine
-    // the OS
-    stage("Scan redhat image") {
+    stage("Scan images") {
       parallel {
+        stage ("Scan main image for fixable vulns") {
+          steps {
+            scanAndReport("conjur-authn-k8s-client:dev", "HIGH", false)
+          }
+        }
+        stage ("Scan main image for total vulns") {
+          steps {
+            scanAndReport("conjur-authn-k8s-client:dev", "NONE", true)
+          }
+        }
         stage ("Scan redhat image for fixable vulns") {
           steps {
             scanAndReport("conjur-authn-k8s-client-redhat:dev", "HIGH", false)


### PR DESCRIPTION
We changed the base image of the authenticator client from `scratch`
to `alpine` to run with a limited user in the Docker image, instead of
the root user.

This change enables us to scan the image as we can determine now the OS.

Implementation option - we could also have this code instead:
```
script {
          def tasks = [:]
          ["conjur-authn-k8s-client", "conjur-authn-k8s-client-redhat"].each { image ->
            tasks["Scan {image} for fixable vulns"] = {
              scanAndReport("{image}:dev", "HIGH", false)
            }
            tasks["Scan {image} for total vulns"] = {
              scanAndReport("{image}:dev", "NONE", true)
            }
          }
          parallel tasks
        }
```

but i think that the suggested code is better as it's more readable and the duplication is not too strong. Let me know if you think otherwise.