### PR TITLE
Update Dockerfile MAINTAINER to CyberArk Software Ltd.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ FROM busybox
 
 # =================== MAIN CONTAINER ===================
 FROM alpine:latest as authenticator-client
-MAINTAINER CyberArk Software, Inc.
+MAINTAINER CyberArk Software Ltd.
 
 # copy a few commands from busybox
 COPY --from=busybox /bin/tar /bin/tar
@@ -79,7 +79,7 @@ ENTRYPOINT [ "/usr/local/bin/authenticator" ]
 
 # =================== MAIN CONTAINER (REDHAT) ===================
 FROM registry.access.redhat.com/rhel as authenticator-client-redhat
-MAINTAINER CyberArk Software, Inc.
+MAINTAINER CyberArk Software Ltd.
 
     # Add Limited user
 RUN groupadd -r authenticator \


### PR DESCRIPTION
The Dockerfile was inconsistent in terms of how they name the MAINTAINER. This PR updates the MAINTAINER to `CyberArk Software Ltd.` because this is how we reference ourselves in the [official site](https://www.cyberark.com/)