### PR TITLE
Load cert from file if it exists

### DIFF
--- a/design/templates/solution_design.md
+++ b/design/templates/solution_design.md
@@ -1,0 +1,71 @@
+# Solution Design - Template
+[//]: # (Change the title above from "Template" to your design's title) 
+
+## Table of Contents
+[//]: # (You can use this tool to generate a TOC - https://ecotrust-canada.github.io/markdown-toc/) 
+
+## Glossary
+[//]: # (Describe terms that will be used throughout the design)
+[//]: # (You can use this tool to generate a table - https://www.tablesgenerator.com/markdown_tables#)
+
+| **Term** | **Description** |
+|----------|-----------------|
+|          |                 |
+|          |                 |
+
+## Useful links
+[//]: # (Add links that may be useful for the reader)
+
+## Background
+[//]: # (Give relevant background for the designed feature. What is the motivation for this solution?)
+
+## Issue description
+[//]: # (Elaborate on the issue you are writing a solution for)
+
+## Solution
+[//]: # (Elaborate on the solution you are suggesting in this page. Address the functional requirements and the non functional requirements that this solution is addressing. If there are a few options considered for the solution, mention them and explain why the actual solution was chosen over them. Add an execution plan when relevant. It doesn't have to be a full breakdown of the feature, but just a recommendation to how the solution should be approached.)
+
+### Design
+[//]: # (Add any diagrams, charts and explanations about the design aspect of the solution. Elaborate also about the expected user experience for the feature)
+
+### Backwards compatibility
+[//]: # (Address how you are going to handle backwards compatibility, if necessary)
+
+### Performance
+[//]: # (Elaborate on whether your solution will affect the product's performance, and how)
+
+### Affected Components
+[//]: # (Address the components that will be affected by your solution [Conjur, DAP, clients, integrations, etc.])
+
+## Security
+[//]: # (Are there any security issues with your solution and how do you plan to mitigate them? Even if you mentioned them somewhere in the doc it may be convenient for the security architect review to have them centralized here)
+
+## Test Plan
+[//]: # (Fill in the table below to depict the tests that should run to validate your solution)
+[//]: # (You can use this tool to generate a table - https://www.tablesgenerator.com/markdown_tables#)
+
+| **Title** | **Given** | **When** | **Then** | **Comment** |
+|-----------|-----------|----------|----------|-------------|
+|           |           |          |          |             |
+|           |           |          |          |             |
+
+## Logs
+[//]: # (Fill in the table below to depict the log messages that can enhance the supportability of your solution)
+[//]: # (You can use this tool to generate a table - https://www.tablesgenerator.com/markdown_tables#)
+
+| **Scenario** | **Log message** | **Log level** 
+|--------------|-----------------|--------------|
+|              |                 |              |
+|              |                 |              |
+
+### Audit 
+[//]: # (Does this solution require additional audit messages?)
+
+## Documentation
+[//]: # (Add notes on what should be documented in this solution. Elaborate on where this should be documented. If the change is in open-source projects, we may need to update the docs in github too. If it's in Conjur and/or DAP mention which products are affected by it)
+
+## Open questions
+[//]: # (Add any question that is still open. It makes it easier for the reader to have the open questions accumulated here istead of them being acattered along the doc)
+
+## Implementation plan
+[//]: # (Break the solution into tasks)


### PR DESCRIPTION
### What does this PR do?
The Login method sends a login request to the server and then tries to
read the cert file from the path where it should be injected to by the
server.

However, in case it is still not there then we fail and retry to login
but it's possible that the file is already there from the previous
request. In this case, we don't need to send another login request to
the server and we can read it from the path.

This will reduce the load on the server as we will have less requests to
 it.

#### Change log
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] The changes in this PR do not require tests

#### Documentation
- [X] This PR does not require updating any documentation

#### Manual tests
- [X] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
