### PR TITLE
Reset expBackoff after we wait for TokenRefreshTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Username formatting now correctly only prints FullUsername field ([#126](https://github.com/cyberark/conjur-authn-k8s-client/issues/126))
+- Timeout for token retrievals is now correctly reset in consequent failures
+  ([cyberark/conjur-authn-k8s-client#158](https://github.com/cyberark/conjur-authn-k8s-client/issues/158))
 
 ### Changed
 - Wait slightly for the client certificate file to exist after login before

--- a/cmd/authenticator/main.go
+++ b/cmd/authenticator/main.go
@@ -57,13 +57,13 @@ func main() {
 				os.Exit(0)
 			}
 
-			// Reset exponential backoff
-			expBackoff.Reset()
-
 			infoLogger.Printf(log.CAKC013I, authn.Config.TokenRefreshTimeout)
 
 			fmt.Println()
 			time.Sleep(authn.Config.TokenRefreshTimeout)
+
+			// Reset exponential backoff
+			expBackoff.Reset()
 		}
 	}, expBackoff)
 


### PR DESCRIPTION
Connected to #158 

Prior to this commit, we hit the reset button on the expBackoff clock
before waiting the token refresh timeout. This means that the next
interval will start 6 minutes (by default) into the clock and only one
cycle will run (as we exceed the max elapsed time of 2 minutes).

Resetting the clock after the timeout waits ensures that the next cycle
will run for at most 2 minutes as intended.

Here is a log that shows the failure, in which we run only once before crashing (logs are written from bottom to top):
```
{"log":"ERROR: 2020/09/07 07:58:57 main.go:76: CAKC031E Retransmission backoff exhausted\n","stream":"stderr","time":"2020-09-07T07:58:57.784828076Z"}
{"log":"ERROR: 2020/09/07 07:58:57 main.go:48: CAKC016E Failed to authenticate\n","stream":"stderr","time":"2020-09-07T07:58:57.784823538Z"}
{"log":"ERROR: 2020/09/07 07:58:57 authenticator.go:233: CAKC027E Failed to send https authenticate request or receive response. Reason:...\n","stream":"stderr","time":"2020-09-07T07:58:57.784781083Z"}
{"log":"INFO: 2020/09/07 07:58:47 requests.go:47: CAKC012I Authn request to: ...\n","stream":"stdout","time":"2020-09-07T07:58:47.784448565Z"}
{"log":"INFO: 2020/09/07 07:58:47 authenticator.go:183: CAKC010I Buffer time:  30s\n","stream":"stdout","time":"2020-09-07T07:58:47.783685174Z"}
{"log":"INFO: 2020/09/07 07:58:47 authenticator.go:182: CAKC009I Current date: 2020-09-07 07:58:47.783493151 +0000 UTC\n","stream":"stdout","time":"2020-09-07T07:58:47.783680325Z"}
{"log":"INFO: 2020/09/07 07:58:47 authenticator.go:181: CAKC008I Cert expires: 2020-09-09 05:28:18 +0000 UTC\n","stream":"stdout","time":"2020-09-07T07:58:47.783676009Z"}
{"log":"INFO: 2020/09/07 07:58:47 main.go:45: CAKC006I Authenticating as user '...'\n","stream":"stdout","time":"2020-09-07T07:58:47.7836441Z"}
{"log":"\n","stream":"stdout","time":"2020-09-07T07:52:47.783548198Z"}
{"log":"INFO: 2020/09/07 07:52:47 main.go:63: CAKC013I Waiting for 6m0s to re-authenticate\n","stream":"stdout","time":"2020-09-07T07:52:47.783544229Z"} 
```

You can see that we start a new wait (CAKC013I) and this happens after we run expBackoff.Reset(). So we are supposed to run a new backoff cycle that will run for up to 2 minutes before crashing. However, we run only one time and finish the backoff before writing CAKC031E Retransmission backoff exhausted to the log.

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
