### PR TITLE
Extract env var value read into a util

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ questions, please contact us on [Discourse](https://discuss.cyberarkcommons.org/
 - `CONJUR_AUTHN_URL`: URL pointing to authenticator service endpoint
 - `CONJUR_AUTHN_LOGIN`: Host login for pod e.g. `namespace/service_account/some_service_account`
 - `CONJUR_SSL_CERTIFICATE`: Public SSL cert for Conjur connection
-- `CONJUR_TOKEN_TIMEOUT`: Timeout for fetching a new token (defaults to 6 minutes). In most cases, this variable should not be modified.
+- `CONJUR_TOKEN_TIMEOUT`: Timeout for fetching a new token (defaults to 6 minutes). 
+                          In most cases, this variable should not be modified. The value should be in a
+                          format that can be parsed with [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) (e.g "6m0s")
 
 Flow:
 

--- a/pkg/log/log_messages.go
+++ b/pkg/log/log_messages.go
@@ -22,7 +22,7 @@ const CAKC006E string = "CAKC006E Error reading access token, reason: data is em
 const CAKC007E string = "CAKC007E At least one of CONJUR_SSL_CERTIFICATE and CONJUR_CERT_FILE must be provided"
 const CAKC008E string = "CAKC008E Namespace or podname can't be empty namespace=%v podname=%v"
 const CAKC009E string = "CAKC009E Environment variable '%s' must be provided"
-const CAKC010E string = "CAKC010E Failed to parse CONJUR_TOKEN_TIMEOUT. Reason: %s"
+const CAKC010E string = "CAKC010E Failed to parse %s. Reason: %s"
 const CAKC011E string = "CAKC011E Client certificate not found at '%s'"
 const CAKC012E string = "CAKC012E Failed to read client certificate file: %s"
 const CAKC013E string = "CAKC013E Failed parsing certificate file '%s'. Reason: %s"
@@ -46,7 +46,6 @@ const CAKC030E string = "CAKC030E Failed to generate RSA keypair. Reason: %s"
 const CAKC031E string = "CAKC031E Retransmission backoff exhausted"
 const CAKC032E string = "CAKC032E Username %s is invalid"
 const CAKC033E string = "CAKC033E Timed out after waiting for %d seconds for file to exist: %s"
-const CAKC034E string = "CAKC034E Failed to parse CONJUR_CLIENT_CERT_RETRY_COUNT_LIMIT. Reason: %s"
 
 // INFO MESSAGES
 const CAKC001I string = "CAKC001I Successfully authenticated"

--- a/pkg/utils/environment_variable.go
+++ b/pkg/utils/environment_variable.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/cyberark/conjur-authn-k8s-client/pkg/log"
+)
+
+// GetEnvFunc is a function that returns a value for an environment variable
+type GetEnvFunc func(envVarName string) string
+
+// defaultGetEnv is the default GetEnvFunc. It uses the standard OS Getenv.
+var defaultGetEnvFunc = os.Getenv
+
+// IntFromEnvOrDefault extracts the value of the given environment variable,
+// or the default value if the environment variable is not defined, and returns
+// it as an int object
+func IntFromEnvOrDefault(
+	envVarName string,
+	defaultValue string,
+	getEnv GetEnvFunc,
+) (int, error) {
+	value := envVarValueOrDefault(envVarName, defaultValue, getEnv)
+	valueInt, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, log.RecordedError(log.CAKC010E, envVarName, err.Error())
+	}
+
+	return valueInt, nil
+}
+
+// DurationFromEnvOrDefault extracts the value of the given environment variable,
+// or the default value if the environment variable is not defined, and returns
+// it as a time.Duration object
+func DurationFromEnvOrDefault(
+	envVarName string,
+	defaultValue string,
+	getEnv GetEnvFunc,
+) (time.Duration, error) {
+	value := envVarValueOrDefault(envVarName, defaultValue, getEnv)
+	valueDuration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, log.RecordedError(log.CAKC010E, envVarName, err.Error())
+	}
+
+	return valueDuration, nil
+}
+
+func envVarValueOrDefault(envVarName string, defaultValue string, getEnv GetEnvFunc) string {
+	if getEnv == nil {
+		getEnv = defaultGetEnvFunc
+	}
+	value := getEnv(envVarName)
+	if len(value) > 0 {
+		return value
+	}
+
+	return defaultValue
+}

--- a/pkg/utils/environment_variable_test.go
+++ b/pkg/utils/environment_variable_test.go
@@ -1,0 +1,170 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	envVarName              = "SOME_ENV_VAR"
+	intValueStr             = "20"
+	expectedIntValue        = 20
+	defaultIntValueStr      = "10"
+	defaultIntValue         = 10
+	durationValueStr        = "20m0s"
+	expectedDurationValue   = 20 * time.Minute
+	defaultDurationValueStr = "10m0s"
+	defaultDurationValue    = 10 * time.Minute
+	InvalidValueStr         = "SOME_ENV_VAR_VALUE"
+)
+
+// mockGetEnv structure is used to implement a getEnvFunc function that
+// returns a canned value that is set when the structure is initialized.
+type mockGetEnv struct {
+	value string
+}
+
+// newMockGetEnv creates and initializes a mockGetEnv structure
+func newMockGetEnv(value string) mockGetEnv {
+	return mockGetEnv{value}
+}
+
+// getEnv implements the getEnvFunc type for a mockGetEnv struct
+func (m mockGetEnv) getEnv(name string) string {
+	return m.value
+}
+
+func TestEnvironmentVariable(t *testing.T) {
+	Convey("IntFromEnvOrDefault", t, func() {
+		Convey("When parsing an int value", func() {
+			Convey("That was retrieved from the env", func() {
+				mockGetEnv := newMockGetEnv(intValueStr)
+				intValue, err := IntFromEnvOrDefault(
+					envVarName,
+					defaultIntValueStr,
+					mockGetEnv.getEnv,
+				)
+
+				Convey("Finishes without raising an error", func() {
+					So(err, ShouldEqual, nil)
+				})
+
+				Convey("Parses the value into an int", func() {
+					So(
+						intValue,
+						ShouldResemble,
+						expectedIntValue,
+					)
+				})
+			})
+
+			Convey("That was given as a default value", func() {
+				mockGetEnv := newMockGetEnv("")
+				intValue, err := IntFromEnvOrDefault(
+					envVarName,
+					defaultIntValueStr,
+					mockGetEnv.getEnv,
+				)
+
+				Convey("Finishes without raising an error", func() {
+					So(err, ShouldEqual, nil)
+				})
+
+				Convey("Parses the value into an int", func() {
+					So(
+						intValue,
+						ShouldResemble,
+						defaultIntValue,
+					)
+				})
+			})
+		})
+
+		Convey("When parsing a non-int value", func() {
+			mockGetEnv := newMockGetEnv(InvalidValueStr)
+			_, err := IntFromEnvOrDefault(
+				envVarName,
+				defaultIntValueStr,
+				mockGetEnv.getEnv,
+			)
+
+			expectedError := fmt.Errorf(
+				"CAKC010E Failed to parse %s. Reason: %s",
+				envVarName,
+				"strconv.Atoi: parsing \"SOME_ENV_VAR_VALUE\": invalid syntax",
+			)
+
+			Convey("Raises a proper error", func() {
+				So(err, ShouldResemble, expectedError)
+			})
+		})
+	})
+
+	Convey("DurationFromEnvOrDefault", t, func() {
+		Convey("When parsing a duration value", func() {
+			Convey("That was retrieved from the env", func() {
+				mockGetEnv := newMockGetEnv(durationValueStr)
+				durationValue, err := DurationFromEnvOrDefault(
+					envVarName,
+					defaultDurationValueStr,
+					mockGetEnv.getEnv,
+				)
+
+				Convey("Finishes without raising an error", func() {
+					So(err, ShouldEqual, nil)
+				})
+
+				Convey("Parses the value into a duration", func() {
+					So(
+						durationValue,
+						ShouldResemble,
+						expectedDurationValue,
+					)
+				})
+			})
+
+			Convey("That was given as a default value", func() {
+				mockGetEnv := newMockGetEnv("")
+				durationValue, err := DurationFromEnvOrDefault(
+					envVarName,
+					defaultDurationValueStr,
+					mockGetEnv.getEnv,
+				)
+
+				Convey("Finishes without raising an error", func() {
+					So(err, ShouldEqual, nil)
+				})
+
+				Convey("Parses the value into a duration", func() {
+					So(
+						durationValue,
+						ShouldResemble,
+						defaultDurationValue,
+					)
+				})
+			})
+		})
+
+		Convey("When parsing a non-duration value", func() {
+			mockGetEnv := newMockGetEnv(InvalidValueStr)
+			_, err := DurationFromEnvOrDefault(
+				envVarName,
+				defaultDurationValueStr,
+				mockGetEnv.getEnv,
+			)
+
+			expectedError := fmt.Errorf(
+				"CAKC010E Failed to parse %s. Reason: %s",
+				envVarName,
+				"time: invalid duration SOME_ENV_VAR_VALUE",
+			)
+
+			Convey("Raises a proper error", func() {
+				So(err, ShouldResemble, expectedError)
+			})
+		})
+	})
+}


### PR DESCRIPTION
We would like to better UT the logic of reading a value from the env
and defaulting to a default value if it's not present. We also have the
logic that transforms this env var value into an int or a duration (and
maybe more in the future) and it is best that this logic is UTed and is
implemented in its own util. This improves the readability of the
config.go file and of the util functions themselves.

This will also let us use these utils in other projects that consume the
authn-client without implementing them there as well.
