### PR TITLE
Enhance logger with log levels, debug mode and microseconds resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Log messages now show microseconds, for clarity and easier troubleshooting.
+  ([cyberark/conjur-authn-k8s-client#164](https://github.com/cyberark/conjur-authn-k8s-client/issues/164))
 
 ## [0.18.1] - 2020-09-13
 ### Fixed

--- a/cmd/authenticator/main.go
+++ b/cmd/authenticator/main.go
@@ -12,12 +12,8 @@ import (
 	"github.com/cyberark/conjur-authn-k8s-client/pkg/log"
 )
 
-// logging
-var errLogger = log.ErrorLogger
-var infoLogger = log.InfoLogger
-
 func main() {
-	infoLogger.Printf(log.CAKC014I, authenticator.FullVersionName)
+	log.Info(log.CAKC014I, authenticator.FullVersionName)
 
 	var err error
 
@@ -42,7 +38,7 @@ func main() {
 
 	err = backoff.Retry(func() error {
 		for {
-			infoLogger.Printf(log.CAKC006I, authn.Config.Username)
+			log.Info(log.CAKC006I, authn.Config.Username)
 			resp, err := authn.Authenticate()
 			if err != nil {
 				return log.RecordedError(log.CAKC016E)
@@ -57,7 +53,7 @@ func main() {
 				os.Exit(0)
 			}
 
-			infoLogger.Printf(log.CAKC013I, authn.Config.TokenRefreshTimeout)
+			log.Info(log.CAKC013I, authn.Config.TokenRefreshTimeout)
 
 			fmt.Println()
 			time.Sleep(authn.Config.TokenRefreshTimeout)
@@ -73,6 +69,6 @@ func main() {
 }
 
 func printErrorAndExit(errorMessage string) {
-	errLogger.Printf(errorMessage)
+	log.Error(errorMessage)
 	os.Exit(1)
 }

--- a/pkg/authenticator/client.go
+++ b/pkg/authenticator/client.go
@@ -24,7 +24,7 @@ func newHTTPSClient(CACert []byte, certPEMBlock, keyPEMBlock []byte) (*http.Clie
 	if certPEMBlock != nil && keyPEMBlock != nil {
 		cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
 		if err != nil {
-			return nil, log.RecordedError(log.CAKC017E, err.Error())
+			return nil, log.RecordedError(log.CAKC017E, err)
 		}
 
 		tlsConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {

--- a/pkg/authenticator/config/config.go
+++ b/pkg/authenticator/config/config.go
@@ -71,7 +71,7 @@ func FromEnv(readFileFunc ReadFileFunc) (*Config, error) {
 	// Load CA cert from Environment
 	config.SSLCertificate, err = readSSLCert(readFileFunc)
 	if err != nil {
-		return nil, log.RecordedError(log.CAKC021E, err.Error())
+		return nil, log.RecordedError(log.CAKC021E, err)
 	}
 
 	// Load Username from Environment

--- a/pkg/authenticator/requests.go
+++ b/pkg/authenticator/requests.go
@@ -20,11 +20,11 @@ func LoginRequest(authnURL string, conjurVersion string, csrBytes []byte, userna
 		authenticateURL = fmt.Sprintf("%s/inject_client_cert", authnURL)
 	}
 
-	log.InfoLogger.Printf(log.CAKC011I, authenticateURL)
+	log.Info(log.CAKC011I, authenticateURL)
 
 	req, err := http.NewRequest("POST", authenticateURL, bytes.NewBuffer(csrBytes))
 	if err != nil {
-		return nil, log.RecordedError(log.CAKC024E, err.Error())
+		return nil, log.RecordedError(log.CAKC024E, err)
 	}
 	req.Header.Set("Content-Type", "text/plain")
 	req.Header.Set("Host-Id-Prefix", usernamePrefix)
@@ -44,10 +44,10 @@ func AuthenticateRequest(authnURL string, conjurVersion string, account string, 
 		authenticateURL = fmt.Sprintf("%s/%s/%s/authenticate", authnURL, account, url.QueryEscape(username))
 	}
 
-	log.InfoLogger.Printf(log.CAKC012I, authenticateURL)
+	log.Info(log.CAKC012I, authenticateURL)
 
 	if req, err = http.NewRequest("POST", authenticateURL, nil); err != nil {
-		return nil, log.RecordedError(log.CAKC023E, err.Error())
+		return nil, log.RecordedError(log.CAKC023E, err)
 	}
 
 	req.Header.Set("Content-Type", "text/plain")
@@ -60,7 +60,7 @@ func readBody(resp *http.Response) ([]byte, error) {
 
 	responseBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, log.RecordedError(log.CAKC022E, err.Error())
+		return nil, log.RecordedError(log.CAKC022E, err)
 	}
 
 	return responseBytes, err

--- a/pkg/log/log_messages.go
+++ b/pkg/log/log_messages.go
@@ -65,3 +65,6 @@ const CAKC014I string = "CAKC014I Kubernetes Authenticator Client v%s starting u
 const CAKC015I string = "CAKC015I Loaded client certificate successfully from %s"
 const CAKC016I string = "CAKC016I Deleted client certificate from memory"
 const CAKC017I string = "CAKC017I Waiting for file %s to become available..."
+
+// DEBUG MESSAGES
+const CAKC001D string = "CAKC001D Debug mode is enabled"

--- a/pkg/utils/environment_variable.go
+++ b/pkg/utils/environment_variable.go
@@ -25,7 +25,7 @@ func IntFromEnvOrDefault(
 	value := envVarValueOrDefault(envVarName, defaultValue, getEnv)
 	valueInt, err := strconv.Atoi(value)
 	if err != nil {
-		return 0, log.RecordedError(log.CAKC010E, envVarName, err.Error())
+		return 0, log.RecordedError(log.CAKC010E, envVarName, err)
 	}
 
 	return valueInt, nil
@@ -42,7 +42,7 @@ func DurationFromEnvOrDefault(
 	value := envVarValueOrDefault(envVarName, defaultValue, getEnv)
 	valueDuration, err := time.ParseDuration(value)
 	if err != nil {
-		return 0, log.RecordedError(log.CAKC010E, envVarName, err.Error())
+		return 0, log.RecordedError(log.CAKC010E, envVarName, err)
 	}
 
 	return valueDuration, nil

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -32,7 +32,7 @@ func WaitForFile(
 
 	err := backoff.Retry(func() error {
 		if limitedBackOff.RetryCount() > 0 {
-			log.InfoLogger.Printf(log.CAKC017I, path)
+			log.Info(log.CAKC017I, path)
 		}
 
 		return verifyFileExistsFunc(path)


### PR DESCRIPTION
### What does this PR do?
Enhance logger with the following abilities:
1. Log levels (DEBUG, INFO, WARN, ERROR).
   This allows better understanding of the logs, and writing logs in more
   precise level.
2. Debug mode that allows turning DEBUG log level on and off.
   This allows adding detailed logs that will not be written in production, but
   can be added for investigation.
3. Add microseconds to logs timestamp.
   Since authn client operation can be finished in less than a second, logs
   time resolution of seconds is not enough to understand steps duration.

### What ticket does this PR close?
Connected to #164

### Checklists

#### Change log
- [x] The CHANGELOG has been updated

#### Test coverage
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation

Example of the logs after the change:
```
INFO:  2020/09/15 08:50:21.682962 main.go:16: CAKC014I Kubernetes Authenticator Client v0.18.1-aa8a2bc starting up...
INFO:  2020/09/15 08:50:21.743570 main.go:41: CAKC006I Authenticating as user 'host/conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/*'
INFO:  2020/09/15 08:50:21.743620 authenticator.go:197: CAKC005I Trying to login Conjur...
INFO:  2020/09/15 08:50:21.743638 authenticator.go:116: CAKC007I Logging in as user 'host/conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/*'
INFO:  2020/09/15 08:50:21.744518 requests.go:23: CAKC011I Login request to: https://conjur-oss.local-conjur.svc.cluster.local/authn-k8s/authn-dev-env/inject_client_cert
INFO:  2020/09/15 08:50:21.919623 authenticator.go:159: CAKC015I Loaded client certificate successfully from /etc/conjur/ssl/client.pem
INFO:  2020/09/15 08:50:21.919925 authenticator.go:171: CAKC016I Deleted client certificate from memory
INFO:  2020/09/15 08:50:21.919968 authenticator.go:203: CAKC002I Logged in
INFO:  2020/09/15 08:50:21.920062 authenticator.go:186: CAKC008I Cert expires: 2020-09-18 08:50:21 +0000 UTC
INFO:  2020/09/15 08:50:21.920103 authenticator.go:187: CAKC009I Current date: 2020-09-15 08:50:21.9199884 +0000 UTC
INFO:  2020/09/15 08:50:21.920114 authenticator.go:188: CAKC010I Buffer time:  30s
INFO:  2020/09/15 08:50:21.920331 requests.go:47: CAKC012I Authn request to: https://conjur-oss.local-conjur.svc.cluster.local/authn-k8s/authn-dev-env/cucumber/host%2Fconjur%2Fauthn-k8s%2Fauthn-dev-env%2Fapps%2Flocal-secrets-provider%2F%2A%2F%2A/authenticate
INFO:  2020/09/15 08:50:21.959541 authenticator.go:266: CAKC001I Successfully authenticated
INFO:  2020/09/15 08:50:21.959592 main.go:56: CAKC013I Waiting for 6m0s to re-authenticate
```

Example of the logs with error:
```
INFO:  2020/09/15 08:59:22.455179 main.go:16: CAKC014I Kubernetes Authenticator Client v0.18.1-aa8a2bc starting up...
INFO:  2020/09/15 08:59:22.520417 main.go:41: CAKC006I Authenticating as user 'host/conjur/authn-k8s/authn-dev-env/apps/INVALID/*/*'
INFO:  2020/09/15 08:59:22.520478 authenticator.go:197: CAKC005I Trying to login Conjur...
INFO:  2020/09/15 08:59:22.520498 authenticator.go:116: CAKC007I Logging in as user 'host/conjur/authn-k8s/authn-dev-env/apps/INVALID/*/*'
INFO:  2020/09/15 08:59:22.521067 requests.go:23: CAKC011I Login request to: https://conjur-oss.local-conjur.svc.cluster.local/authn-k8s/authn-dev-env/inject_client_cert
ERROR: 2020/09/15 08:59:22.540936 authenticator.go:136: CAKC029E Received invalid response to certificate signing request. Reason: status code 401, 
ERROR: 2020/09/15 08:59:22.541207 authenticator.go:200: CAKC015E Login failed
ERROR: 2020/09/15 08:59:22.541229 main.go:44: CAKC016E Failed to authenticate
```