### PR TITLE
Remove duplication of RH image instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,11 +52,8 @@ follow the instructions in this section.
 
 ### Publish the git release
 1. In the GitHub UI, create a release from the new tag and copy the change log
-   for the new version into the GitHub release description.
-1. The Jenkins pipeline auto-publishes new images to DockerHub, but to publish
-   the Red Hat certified image you will need to visit its
-   [management page](https://connect.redhat.com/project/795581/view) and
-   manually publish the image.
+   for the new version into the GitHub release description. The Jenkins pipeline 
+   will auto-publish new images to DockerHub.
    
 ### Publish the Red Hat image
 1. Visit the [Red Hat project page](https://connect.redhat.com/project/795581/view) once the images have


### PR DESCRIPTION
The instruction for releasing a new RH image was duplicated.