### PR TITLE
Change CODEOWNERS to PalmTree / C&I teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
-* @cyberark/conjur-core-team @conjurinc/conjur-core-team @conjurdemos/conjur-core-team
+* @cyberark/community-and-integrations-team
+* @cyberark/palmtree
 
 # Changes to .trivyignore require Security Architect approval
 .trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
-* @cyberark/community-and-integrations-team
-* @cyberark/palmtree
+* @cyberark/community-and-integrations-team @cyberark/palmtree
 
 # Changes to .trivyignore require Security Architect approval
 .trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects


### PR DESCRIPTION
### What does this PR do?
Updates CODEOWNERS from @cyberark/conjur-core-team to @cyberark/community-and-integrations-team and @cyberark/palmtree, since the latter two groups are in practice the primary maintainers of this content.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
