### PR TITLE
Bump 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.19.0] - 2020-10-08
 ### Added
 - Users can set the `DEBUG` environment variable to run the client in debug mode and view more log messages.
   [cyberark/conjur-authn-k8s-client#134](https://github.com/cyberark/conjur-authn-k8s-client/issues/134)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,5 @@ go 1.12
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
-	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa h1:RDBNVkRviHZtvDvId8XSGPu3rmpmSe+wKRcEWNgsfWU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=

--- a/pkg/authenticator/version.go
+++ b/pkg/authenticator/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the authn-k8s-client
-var Version = "0.18.1"
+var Version = "0.19.0"
 
 // Tag field denotes the specific build type for the client. It may
 // be replaced by compile-time variables if needed to provide the git

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"testing"
 
-	"github.com/smartystreets/assertions/should"
-
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -38,7 +36,7 @@ func TestAuthenticator(t *testing.T) {
 
 			Debug("message")
 
-			So(logBuffer.Len(), should.Equal, 0)
+			So(logBuffer.Len(), ShouldEqual, 0)
 		})
 
 		Convey("Calling Debug logs the message after Calling EnableDebugMode", func() {


### PR DESCRIPTION
### What does this PR do?
- Bumps version to 0.19.0
  - We bump the MINOR version as the changes in this version do not make incompatible API changes and add functionality in a 
     backwards compatible manner.
- Removes an unnecessary dependency