### PR TITLE
Move authentication logs from backoff to auth methods

### DIFF
--- a/cmd/authenticator/main.go
+++ b/cmd/authenticator/main.go
@@ -38,8 +38,6 @@ func main() {
 
 	err = backoff.Retry(func() error {
 		for {
-			log.Info(log.CAKC040, authn.Config.Username)
-
 			resp, err := authn.Authenticate()
 			if err != nil {
 				return log.RecordedError(log.CAKC016)
@@ -49,8 +47,6 @@ func main() {
 			if err != nil {
 				return log.RecordedError(log.CAKC020)
 			}
-
-			log.Info(log.CAKC035)
 
 			if authn.Config.ContainerMode == "init" {
 				os.Exit(0)

--- a/pkg/authenticator/authenticator.go
+++ b/pkg/authenticator/authenticator.go
@@ -203,6 +203,8 @@ func (auth *Authenticator) IsCertExpired() bool {
 // Authenticate sends Conjur an authenticate request and returns
 // the response data. Also manages state of certificates.
 func (auth *Authenticator) Authenticate() ([]byte, error) {
+	log.Info(log.CAKC040, auth.Config.Username)
+
 	if !auth.IsLoggedIn() {
 		log.Debug(log.CAKC039)
 
@@ -254,7 +256,6 @@ func (auth *Authenticator) Authenticate() ([]byte, error) {
 // ParseAuthenticationResponse takes the response from the Authenticate
 // request, decrypts if needed, and writes to the token file
 func (auth *Authenticator) ParseAuthenticationResponse(response []byte) error {
-
 	var content []byte
 	var err error
 
@@ -273,6 +274,7 @@ func (auth *Authenticator) ParseAuthenticationResponse(response []byte) error {
 		return err
 	}
 
+	log.Info(log.CAKC035)
 	return nil
 }
 


### PR DESCRIPTION
Some log messages should be part of the authentication methods so that
they are shown also when other projects consume the authn library.

For example, the secrets-provider calls the method `authn.Authenticate()`.
in the current implementation, we will not log the message
`Authenticating as user '%s'` as it's written in the backoff loop which
is not consumed in the secrets provider. Moving these messages into the
methods will let the consuming projects have them.