### PR TITLE
Perform all authentication flow in Authenticate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The `Authenticate` method now parses the authentication response and writes it
+  to the token file, without the need to call `ParseAuthenticationResponse`.
+  This change breaks the API.
+  [cyberark/conjur-authn-k8s-client#180](https://github.com/cyberark/conjur-authn-k8s-client/issues/180)
 
 ## [0.19.0] - 2020-10-08
 ### Added

--- a/cmd/authenticator/main.go
+++ b/cmd/authenticator/main.go
@@ -38,14 +38,9 @@ func main() {
 
 	err = backoff.Retry(func() error {
 		for {
-			resp, err := authn.Authenticate()
+			err := authn.Authenticate()
 			if err != nil {
 				return log.RecordedError(log.CAKC016)
-			}
-
-			err = authn.ParseAuthenticationResponse(resp)
-			if err != nil {
-				return log.RecordedError(log.CAKC020)
 			}
 
 			if authn.Config.ContainerMode == "init" {

--- a/pkg/authenticator/authenticator.go
+++ b/pkg/authenticator/authenticator.go
@@ -200,16 +200,44 @@ func (auth *Authenticator) IsCertExpired() bool {
 	return currentDate.Add(bufferTime).After(certExpiresOn)
 }
 
-// Authenticate sends Conjur an authenticate request and returns
-// the response data. Also manages state of certificates.
-func (auth *Authenticator) Authenticate() ([]byte, error) {
+// Authenticate sends Conjur an authenticate request and writes the response
+// to the token file (after decrypting it if needed). It also manages state of
+// certificates.
+func (auth *Authenticator) Authenticate() error {
 	log.Info(log.CAKC040, auth.Config.Username)
 
+	err := auth.loginIfNeeded()
+	if err != nil {
+		return err
+	}
+
+	authenticationResponse, err := auth.sendAuthenticationRequest()
+	if err != nil {
+		return err
+	}
+
+	parsedResponse, err := auth.parseAuthenticationResponse(authenticationResponse)
+	if err != nil {
+		return err
+	}
+
+	err = auth.AccessToken.Write(parsedResponse)
+	if err != nil {
+		return err
+	}
+
+	log.Info(log.CAKC035)
+	return nil
+}
+
+// loginIfNeeded checks if we need to send a login request to Conjur and sends
+// one if needed
+func (auth *Authenticator) loginIfNeeded() error {
 	if !auth.IsLoggedIn() {
 		log.Debug(log.CAKC039)
 
 		if err := auth.Login(); err != nil {
-			return nil, log.RecordedError(log.CAKC015)
+			return log.RecordedError(log.CAKC015)
 		}
 
 		log.Debug(log.CAKC036)
@@ -219,12 +247,19 @@ func (auth *Authenticator) Authenticate() ([]byte, error) {
 		log.Debug(log.CAKC038)
 
 		if err := auth.Login(); err != nil {
-			return nil, err
+			return err
 		}
 
 		log.Debug(log.CAKC037)
 	}
 
+	return nil
+}
+
+// sendAuthenticationRequest reads the cert from memory and uses it to send
+// an authentication request to the Conjur server. It also validates the response
+// code before returning its body
+func (auth *Authenticator) sendAuthenticationRequest() ([]byte, error) {
 	privDer := x509.MarshalPKCS1PrivateKey(auth.privateKey)
 	keyPEMBlock := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privDer})
 
@@ -258,9 +293,9 @@ func (auth *Authenticator) Authenticate() ([]byte, error) {
 	return readBody(resp)
 }
 
-// ParseAuthenticationResponse takes the response from the Authenticate
-// request, decrypts if needed, and writes to the token file
-func (auth *Authenticator) ParseAuthenticationResponse(response []byte) error {
+// parseAuthenticationResponse takes the response from the Authenticate
+// request, decrypts if needed, and returns it
+func (auth *Authenticator) parseAuthenticationResponse(response []byte) ([]byte, error) {
 	var content []byte
 	var err error
 
@@ -268,19 +303,13 @@ func (auth *Authenticator) ParseAuthenticationResponse(response []byte) error {
 	if auth.Config.ConjurVersion == "4" {
 		content, err = decodeFromPEM(response, auth.PublicCert, auth.privateKey)
 		if err != nil {
-			return err
+			return nil, log.RecordedError(log.CAKC020)
 		}
 	} else if auth.Config.ConjurVersion == "5" {
 		content = response
 	}
 
-	err = auth.AccessToken.Write(content)
-	if err != nil {
-		return err
-	}
-
-	log.Info(log.CAKC035)
-	return nil
+	return content, nil
 }
 
 // generateSANURI returns the formatted uri(SPIFFEE format for now) for the certificate.

--- a/pkg/authenticator/authenticator.go
+++ b/pkg/authenticator/authenticator.go
@@ -131,7 +131,7 @@ func (auth *Authenticator) Login() error {
 		return log.RecordedError(log.CAKC028, err)
 	}
 
-	err = EmptyResponse(resp)
+	err = validateResponse(resp)
 	if err != nil {
 		return log.RecordedError(log.CAKC029, err)
 	}
@@ -250,7 +250,12 @@ func (auth *Authenticator) Authenticate() ([]byte, error) {
 		return nil, log.RecordedError(log.CAKC027, err)
 	}
 
-	return DataResponse(resp)
+	err = validateResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return readBody(resp)
 }
 
 // ParseAuthenticationResponse takes the response from the Authenticate

--- a/pkg/authenticator/requests.go
+++ b/pkg/authenticator/requests.go
@@ -55,6 +55,7 @@ func AuthenticateRequest(authnURL string, conjurVersion string, account string, 
 	return req, nil
 }
 
+// readBody returns the response body
 func readBody(resp *http.Response) ([]byte, error) {
 	defer resp.Body.Close()
 
@@ -66,20 +67,10 @@ func readBody(resp *http.Response) ([]byte, error) {
 	return responseBytes, err
 }
 
-// DataResponse checks the HTTP status of the response. If it's less than
+// validateResponse checks the HTTP status of the response. If it's less than
 // 300, it returns the response body as a byte array. Otherwise it returns
 // a NewError.
-func DataResponse(resp *http.Response) ([]byte, error) {
-	if resp.StatusCode < 300 {
-		return readBody(resp)
-	}
-	return nil, NewError(resp)
-}
-
-// EmptyResponse checks the HTTP status of the response. If it's less than
-// 300, it returns without an error. Otherwise it returns
-// a NewError.
-func EmptyResponse(resp *http.Response) error {
+func validateResponse(resp *http.Response) error {
 	if resp.StatusCode < 300 {
 		return nil
 	}


### PR DESCRIPTION
Consumers of the authn-client library currently need to first call the
`Authenticate` method, get the output and call the method
`ParseAuthenticationResponse` with it. This adds redundant complexity
to the flow and can be reduced easily by letting the `Authenticate`
method perform the whole flow by itself. The impact can be seen in
`main.go` (and will affect other consumers such as the secrets-provider
and secretless).

Note that if we perform this change we will need to bump the MAJOR version as this breaks compatibility of the library.