### PR TITLE
Remove temporary TAG value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ENV GOOS=linux \
     GOARCH=amd64 \
     CGO_ENABLED=1
 
-# this value changes in ./bin/build
-ARG TAG="dev"
+# this value is set in ./bin/build
+ARG TAG
 
 WORKDIR /opt/conjur-authn-k8s-client
 COPY . /opt/conjur-authn-k8s-client


### PR DESCRIPTION
There is no use in setting the TAG argument to `dev` as it is set in
`./bin/build`. It is more accurate to leave it blank and say that it is
set in `./bin/build` rather than setting it to some value and saying
that the value will change.

This change will reduce understandment complexity.
