### PR TITLE
Update Go version to 1.15

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,32 @@
+# CVE-2020-1971
+# The X.509 GeneralName type is a generic type for representing different types
+# of names. One of those name types is known as EDIPartyName. OpenSSL provides a
+# function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME
+# to see if they are equal or not. This function behaves incorrectly when both
+# GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash
+# may occur leading to a possible denial of service attack. 
+# OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes:
+#
+# 1) Comparing CRL distribution point names between an available CRL and a CRL
+#    distribution point embedded in an X509 certificate.
+#
+# 2) When verifying that a timestamp response token signer matches the timestamp
+#    authority name (exposed via the API functions TS_RESP_verify_response and
+#    TS_RESP_verify_token) If an attacker can control both items being compared
+#    then that attacker could trigger a crash.
+#
+# All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Fixed in OpenSSL
+# 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).
+#
+# In order to support FIPS with OpenSSL we are required to use OpenSSL version
+# 1.0.2 until OpenSSL supports the FIPS module in newer versions. The latest
+# available version to us is 1.0.2u, which does not include this fix.
+#
+# We've determined that we are not impacted by this vulnerability because:
+# - we do not directly perform CRL checks in the Conjur or DAP software
+# - we do not enable automatic CRL checks in openssl tools
+# - we do not call any of the impacted OpenSSL APIs or any of the APIs that expose
+#   impacted behavior.
+#
+# Performed by @micahlee, approved by @andytinkham
+CVE-2020-1971

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   to the token file, without the need to call `ParseAuthenticationResponse`.
   This change breaks the API.
   [cyberark/conjur-authn-k8s-client#180](https://github.com/cyberark/conjur-authn-k8s-client/issues/180)
+- The project Golang version is updated from the end-of-life v1.12 to the latest
+  version v1.15.
+  [cyberark/conjur-authn-k8s-client#206](https://github.com/cyberark/conjur-authn-k8s-client/issues/206)
 
 ## [0.19.0] - 2020-10-08
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM goboring/golang:1.12.17b4 as authenticator-client-builder
+FROM goboring/golang:1.15.6b5 as authenticator-client-builder
 MAINTAINER CyberArk Software Ltd.
 
 ENV GOOS=linux \

--- a/Dockerfile.junit
+++ b/Dockerfile.junit
@@ -1,4 +1,4 @@
-FROM golang:1.12.0-alpine3.9
+FROM golang:1.15-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-junit-processor"
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.12.0-alpine3.9
+FROM golang:1.15-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-test-runner"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cyberark/conjur-authn-k8s-client
 
-go 1.12
+go 1.15
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/pkg/utils/environment_variable_test.go
+++ b/pkg/utils/environment_variable_test.go
@@ -159,7 +159,7 @@ func TestEnvironmentVariable(t *testing.T) {
 			expectedError := fmt.Errorf(
 				"CAKC010 Failed to parse %s. Reason: %s",
 				envVarName,
-				"time: invalid duration SOME_ENV_VAR_VALUE",
+				"time: invalid duration \"SOME_ENV_VAR_VALUE\"",
 			)
 
 			Convey("Raises a proper error", func() {


### PR DESCRIPTION
### What does this PR do?
Bumps the Go version used in the project to v1.15.

### What ticket does this PR close?
Resolves #206 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
