### PR TITLE
Adds Helm UT and schema validity tests for cluster prep chart

### DIFF
--- a/helm/common/utils.sh
+++ b/helm/common/utils.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+colorize="${COLORIZE:-true}"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly BLUE='\033[0;34m'
+readonly NOCOLOR='\033[0m'
+readonly ANNOUNCE_COLOR="$BLUE"
+
+# Set the current text color if colorizing is enabled.
+function set_color() {
+    if [ "$colorize" = true ]; then
+        echo -e "$1"
+    else
+        echo -e ""
+    fi
+}
+
+# If colorizing is enabled, temporarily set the text color, print a string,
+# and then reset the text color, without any intervening newlines. This can
+# be useful for printing just a word or a portion of a line in color. If
+# colorizing is disabled, it simply prints the string.
+function color_text() {
+    if [ "$colorize" = true ]; then
+        echo -en "$1"
+    fi
+    echo "${@:2}"
+    if "$colorize"; then
+        echo -en "$NOCOLOR"
+    fi
+}
+
+# Print a string inside leading and trailing lines of dashes. If colorizing
+# is enabled, print everything in the ANNOUNCE_COLOR.
+function announce() {
+  set_color "$ANNOUNCE_COLOR"
+  echo "---------------------------------------------------------------------"
+  echo -e "$@"
+  echo "---------------------------------------------------------------------"
+  set_color "$NOCOLOR"
+}
+
+# Print a string inside leading and trailing lines of '=' characters. If
+# colorizing is enabled, print everything in a given color.
+function banner() {
+  set_color "$1"
+  echo "====================================================================="
+  echo -e "${@:2}"
+  echo "====================================================================="
+  set_color "$NOCOLOR"
+}
+
+# Compare two semantic versions, and return the oldest of the two.
+function oldest_version() {
+  v1=$1
+  v2=$2
+
+  echo "$(printf '%s\n' "$v1" "$v2" | sort -V | head -n1)"
+}
+
+# Return true if a given semantic version is the same as or newer than
+# a given minimum acceptable version. Return false otherwise.
+function meets_min_version() {
+  actual_version=$1
+  min_version=$2
+
+  oldest="$(oldest_version $actual_version $min_version)"
+  if [ "$oldest" = "$min_version" ]; then
+    true
+  else
+    false
+  fi
+}

--- a/helm/kubernetes-cluster-prep/test-schema
+++ b/helm/kubernetes-cluster-prep/test-schema
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+# This script tests the restrictions on chart values
+# as defined in the 'values.schema.json' file.
+#
+# Requirements:
+#   - Helm v3.5.3 or later
+
+cd "$(dirname "$0")"
+
+source ../common/utils.sh
+
+readonly MIN_HELM_VERSION="3.5.3"
+
+# Default required settings
+readonly DEFAULT_URL_SETTING="conjur.applianceUrl=https://conjur.example.com"
+readonly DEFAULT_CERT_FILE_SETTING="conjur.certificateFilePath=files/test-cert.pem"
+readonly DEFAULT_AUTHN_ID_SETTING="authnK8s.authenticatorID=my-authenticator-id"
+
+readonly EXPECT_FAILURE=true
+
+# Global test state
+num_passed=0
+num_failed=0
+test_failed=false
+
+function conjur_url_test() {
+    helm lint . --strict \
+        --set "conjur.applianceUrl=$1" \
+        --set "$DEFAULT_CERT_FILE_SETTING" \
+        --set "$DEFAULT_AUTHN_ID_SETTING"
+}
+
+function cert_file_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_URL_SETTING" \
+        --set "conjur.certificateFilePath=$1" \
+        --set "$DEFAULT_AUTHN_ID_SETTING"
+}
+
+function cert_base64_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_URL_SETTING" \
+        --set "conjur.certificateBase64=$1" \
+        --set "$DEFAULT_AUTHN_ID_SETTING"
+}
+
+function serviceaccount_name_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_URL_SETTING" \
+        --set "$DEFAULT_CERT_FILE_SETTING" \
+        --set "$DEFAULT_AUTHN_ID_SETTING" \
+        --set "authnK8s.serviceAccount.name=$1"
+}
+
+function clusterrole_name_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_URL_SETTING" \
+        --set "$DEFAULT_CERT_FILE_SETTING" \
+        --set "$DEFAULT_AUTHN_ID_SETTING" \
+        --set "authnK8s.clusterrole.name=$1"
+}
+
+function invert_exit_status() {
+    exit_status="$1"
+    if [ "$exit_status" -ne 0 ]; then
+        echo 0
+    else
+        echo 1
+    fi
+}
+
+function update_results() {
+    exit_status="$1"
+    failure_expected="${2:-false}"
+    if [ "$failure_expected" = true ]; then
+        echo "FAILURE EXPECTED"
+        exit_status="$(invert_exit_status $exit_status)"
+    fi
+    if [ "$exit_status" -eq 0 ]; then
+        color_text "$GREEN" "Test Case PASSED!"
+        let "num_passed=num_passed+1"
+    else
+        color_text "$RED" "Test Case FAILED!"
+        let "num_failed=num_failed+1"
+        test_failed=true
+    fi
+}
+
+function display_final_results() {
+    if [ "$num_failed" -eq 0 ]; then
+        result_text="Test PASSED!"
+        result_color="$GREEN"
+    else
+        result_text="Test FAILED!"
+        result_color="$RED"
+    fi
+    banner "$result_color" \
+        "$result_text\n" \
+        "   Passed test cases: $num_passed" \
+        "   Failed test cases: $num_failed"
+}
+
+function check_helm_version() {
+    helm_version="$(helm version --template {{.Version}} | sed 's/^v//')"
+    if ! meets_min_version $helm_version $MIN_HELM_VERSION; then
+        echo "helm version $helm_version is invalid. Version must be $MIN_HELM_VERSION or newer"
+        exit 1
+    fi
+}
+
+function main() {
+
+    check_helm_version
+
+    announce "Appliance URL that begins with 'https://' is accepted"
+    conjur_url_test "https://"
+    update_results "$?" 
+
+    announce "Appliance URL that begins with "HTTPS://" is accepted"
+    conjur_url_test "https://"
+    update_results "$?" 
+
+    announce "Appliance URL that is an internal Kubernetes address is accepted"
+    conjur_url_test "https://conjur.conjur-namespace.svc.cluster.local"
+    update_results "$?" 
+
+    announce "Appliance URL that is an IPv4 address is accepted"
+    conjur_url_test "https://192.0.2.1:443"
+    update_results "$?" 
+
+    announce "Appliance URL that is an IPv6 address is accepted"
+    conjur_url_test "https://[2001:DB8::1]:443"
+    update_results "$?" 
+
+    announce "Appliance URL that has an endpoint is accepted"
+    conjur_url_test "https://conjur.example.com/som-endpoint"
+    update_results "$?" 
+
+    announce "Appliance URL that uses HTTP is rejected"
+    conjur_url_test "http://conjur.example.com"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Appliance URL that contains underscores is rejected"
+    conjur_url_test "http://hostname_with_userscores"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Conjur cert file beginning with 'files/' is accepted"
+    cert_file_test "files/conjur-cert.pem"
+    update_results "$?"
+
+    announce "Conjur cert file beginning with 'tests/' is accepted"
+    cert_file_test "tests/test-cert.pem"
+    update_results "$?"
+
+    announce "Conjur cert file beginning with 'foo/' is rejected"
+    cert_file_test "foo/foobar.pem"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Base64-encoded Conjur cert with all valid characters is accepted"
+    cert_base64_test "LS0abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/=="
+    update_results "$?"
+
+    announce "Base64-encoded Conjur cert containing a comma is rejected"
+    cert_base64_test "LS0abcd,ABCD0123/=="
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Base64-encoded Conjur cert containing a space is rejected"
+    cert_base64_test "LS0abcd ABCD0123/=="
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "ConfigMap name with dashes is accepted"
+    clusterrole_name_test "name-with-dashes"
+    update_results "$?"
+
+    announce "ConfigMap name with underscores is rejected"
+    serviceaccount_name_test "name_with_underscores"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "ServiceAccount name with dotted name is accepted"
+    serviceaccount_name_test "dotted.serviceaccount.name"
+    update_results "$?"
+
+    announce "ServiceAccount name with upper case characters is rejected"
+    serviceaccount_name_test "NameWithUpperCase"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "ServiceAccount name with less than 253 characters is accepted"
+    serviceaccount_name_test "name-with-253-chars----------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130-------140-------150-------160-------170-------180-------190-------200-------210-------220-------230-------240-------250"
+    update_results "$?"
+
+    announce "ServiceAccount name with 253 characters is rejected"
+    serviceaccount_name_test "name-with-more-than-253-chars----------40--------50--------60--------70--------80--------90--------100-------110-------120--------130-------140-------150-------160-------170-------180-------190-------200-------210-------220-------230-------240-------2503"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    display_final_results
+}
+
+main "$@"

--- a/helm/kubernetes-cluster-prep/test-unit
+++ b/helm/kubernetes-cluster-prep/test-unit
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Runs a Helm unit test using the 'helm-unittest' Helm plugin.
+# Reference: https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md
+
+# Install the 'helm-unittest' plugin if it hasn't been install already
+if [[ ! "$(helm plugin list | awk '/^unittest\t/{print $1}')" ]]; then
+    echo "Installing 'helm-unittest' Helm plugin"
+    helm plugin install https://github.com/quintush/helm-unittest
+fi
+
+# Run a Helm unit test
+helm unittest . --helm3

--- a/helm/kubernetes-cluster-prep/tests/clusterrole_test.yaml
+++ b/helm/kubernetes-cluster-prep/tests/clusterrole_test.yaml
@@ -1,0 +1,49 @@
+suite: test clusterrole
+templates:
+  - clusterrole.yaml
+tests:
+  #=======================================================================
+  - it: should not create a ClusterRole if ClusterRole creation
+        is disabled
+  #=======================================================================
+    set:
+      authnK8s.clusterRole.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  #=======================================================================
+  - it: should use default ClusterRole name when it is not set
+        explicitly
+  #=======================================================================
+    set:
+      # Enable ClusterRole creation
+      authnK8s.clusterRole.create: true
+
+    asserts:
+      # Confirm that a ClusterRole has been created
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+
+      # Confirm that default ClusterRole name has been used
+      - equal:
+          path: metadata.name
+          value: "authn-k8s-clusterrole"
+
+  #=======================================================================
+  - it: should allow ClusterRole name to be set explicitly
+  #=======================================================================
+    set:
+      # Enable ClusterRole creation
+      authnK8s.clusterRole.create: true
+
+      # Set ClusterRole name explicitly
+      authnK8s.clusterRole.name: "my-awesome-clusterrole"
+
+    asserts:
+      # Confirm that configured ClusterRole name has been used
+      - equal:
+          path: metadata.name
+          value: "my-awesome-clusterrole"

--- a/helm/kubernetes-cluster-prep/tests/golden_configmap_test.yaml
+++ b/helm/kubernetes-cluster-prep/tests/golden_configmap_test.yaml
@@ -1,0 +1,251 @@
+suite: test golden_configmap
+
+templates:
+  - golden_configmap.yaml
+
+defaults: &defaultRequired
+  conjur.applianceUrl: "https://conjur.example.com"
+  conjur.certificateFilePath: "tests/test-cert.pem"
+  authnK8s.authenticatorID: "my-authenticator-id"
+
+tests:
+  #=======================================================================
+  - it: should not create a ConfigMap if ConfigMap creation is disabled
+  #=======================================================================
+    set:
+      authnK8s.configMap.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  #=======================================================================
+  - it: should use default values when those values are not set explicitly
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+    asserts:
+      # Confirm that a ConfigMap has been created
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+
+      # Confirm that configured required values have been used
+      - equal:
+          path: data.authnK8sAuthenticatorID
+          value: "my-authenticator-id"
+      - equal:
+          path: data.conjurApplianceUrl
+          value: "https://conjur.example.com"
+      - matchRegex:
+          path: data.conjurSslCertificate
+          pattern: "^-----BEGIN CERTIFICATE-----[[:space:]]MIIDhDCC"
+      - matchRegex:
+          path: data.conjurSslCertificate
+          pattern: "[[:space:]]gw==[[:space:]]-----END CERTIFICATE-----[[:space:]]$"
+      - matchRegex:
+          path: data.conjurSslCertificateBase64
+          pattern: "^LS[0-9a-zA-Z=]*JUSUZJQ0FURS0tLS0tCg==$"
+
+      # Confirm that default values have been used
+      - equal:
+          path: metadata.name
+          value: authn-k8s-configmap
+      - equal:
+          path: data.authnK8sClusterRole
+          value: authn-k8s-clusterrole
+      - equal:
+         path: data.authnK8sNamespace
+         value: NAMESPACE
+      - equal:
+          path: data.authnK8sServiceAccount
+          value: authn-k8s-serviceaccount
+      - equal:
+          path: data.conjurAccount
+          value: default
+
+  #=======================================================================
+  - it: should fail if Conjur Appliance URL is not set
+  #=======================================================================
+    set:
+      # Set required values except conjur.applianceUrl
+      conjur.certificateFilePath: "tests/test-cert.pem"
+      authnK8s.authenticatorID: "my-authenticator-id"
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "A valid conjur.applianceUrl is required!"
+
+  #=======================================================================
+  - it: should allow Conjur account to be set explicitly
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Set explicit Conjur account
+      conjur.account: "my-conjur-account"
+
+    asserts:
+      - equal:
+          path: data.conjurAccount
+          value: "my-conjur-account"
+
+  #=======================================================================
+  - it: should fail if neither Conjur certificate file path nor
+        base64-encoded Conjur certificate are set
+  #=======================================================================
+    set:
+      # Set required values except Conjur certificate values
+      conjur.applianceUrl: "https://conjur.example.com"
+      authnK8s.authenticatorID: "my-authenticator-id"
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "Either conjur.certificateFilePath or conjur.certificateBase64 are required!"
+
+  #=======================================================================
+  - it: should fail if both Conjur certificate file path and
+        base64-encoded Conjur certificate are set
+  #=======================================================================
+    set:
+      # Set required values, including mutually exclusive certificate settings
+      <<: *defaultRequired
+      conjur.certificateBase64: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQUpOMk11Vmx0alpMWmVyRk50YklZend3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQXhNTlkyOXVhblZ5TFc5emN5MWpZVEFlRncweU1UQXpNakF4TlRRNU1UTmFGdzB5TWpBegpNakF4TlRRNU1UTmFNQmd4RmpBVUJnTlZCQU1URFdOdmJtcDFjaTF2YzNNdFkyRXdnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRQ3Z6cWVMTmZSRUM1OEdwcEZYNmtlbWUzYUNSdDlJRlRPOGhZR0IKVU5xQVJTb3hrNlJobC9nQ1ZZSVdRMHF3bEFzR0lOR2x3Wmw1ZS9YSlRGU2lQRUZqd05wZStDTHdCUThuWi9CRwpscVVvYnozb1ZiUkdaTEV0L3ZlYkVJTVNYTklhSGRyWThWY0pnR2VoazBGczhaQ1RodC9UcGc5My96MHkydnJqCnpXR2hLek9lK3NrRFFISU5IbGk2YWo2MUdQa1VIVFljYlVDcnZua2JnYXRON0w2VjJrbVFaejMzOFp5aUVsSHgKU3o0VkdmdnhBYXJkY2U0eTF0a1FzRThDNERFMjNVSFEyNVVtU0dnWCtjL0grNkludklvZzZoY25hOWFzRytOUQorL1NRenRDUFRidEx4YjFzd3ZjYnN0WnV2VXlwNUlha3hKZnpSV25YTkJYUk9WdlJBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFHRGFaRHpkaVZCMi82Unluc2NRUQpsanRkQmJwV1BFYlNwT1dNWGRndmVUSHhzU0pLQk5yR3YzQnpPZjViSkxVdVp1eGJ2ZjFJZjJvam91c2JIR3VJCkJHdTBZc2lCcGYrNUx4Vjd4dTJ3NWdiSXpWZnJZUUtDU3lKU052d0NwKzBHNXFocTlqRlFFY2xsd05yK1lrUkkKY212WUN6b2lNRFlZNkNzblM3SHc4OGZSOTZhaWFndnRRVXB5YXNMdWVscnpUc05VTlU1b2I3SktMeE1oMExwego1WnRyZWw1M0kxQzFXeEtIZTN0UlRBU2UxVEdzZW9aazhHS1A3OC96L0JwS05SUllGVmJkVkJldk5uYlJjZFlICncxYzFvdEN4UEF6ZXNrRitYR0JCem9yNWdkVyt3KzB4SG9aejVVSTJpQ1B4aGp6d1BjQXJWQ1F3V0xLd3NDK04KZ3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "Only one of 'certificateFilePath' or 'certificateBase64' may be set!"
+
+  #=======================================================================
+  - it: should allow certificate file beginning with 'tests/'
+  #=======================================================================
+    set:
+      # Set required values except Conjur certificate values
+      conjur.applianceUrl: "https://conjur.example.com"
+      authnK8s.authenticatorID: "my-authenticator-id"
+
+      # Set certificate as a base-64 encoded value
+      conjur.certificateFilePath: "tests/test-cert.pem"
+
+    asserts:
+      - matchRegex:
+          path: data.conjurSslCertificate
+          pattern: "^-----BEGIN CERTIFICATE-----[[:space:]]MIIDhDCC"
+      - matchRegex:
+          path: data.conjurSslCertificate
+          pattern: "[[:space:]]gw==[[:space:]]-----END CERTIFICATE-----[[:space:]]$"
+      - matchRegex:
+          path: data.conjurSslCertificateBase64
+          pattern: "^LS[0-9a-zA-Z=]*JUSUZJQ0FURS0tLS0tCg==$"
+
+  #=======================================================================
+  - it: should allow Conjur certificate to be set as Base-64 encoded value
+  #=======================================================================
+    set:
+      # Set required values except Conjur certificate values
+      conjur.applianceUrl: "https://conjur.example.com"
+      authnK8s.authenticatorID: "my-authenticator-id"
+
+      # Set certificate as a base-64 encoded value
+      conjur.certificateBase64: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQUpOMk11Vmx0alpMWmVyRk50YklZend3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQXhNTlkyOXVhblZ5TFc5emN5MWpZVEFlRncweU1UQXpNakF4TlRRNU1UTmFGdzB5TWpBegpNakF4TlRRNU1UTmFNQmd4RmpBVUJnTlZCQU1URFdOdmJtcDFjaTF2YzNNdFkyRXdnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRQ3Z6cWVMTmZSRUM1OEdwcEZYNmtlbWUzYUNSdDlJRlRPOGhZR0IKVU5xQVJTb3hrNlJobC9nQ1ZZSVdRMHF3bEFzR0lOR2x3Wmw1ZS9YSlRGU2lQRUZqd05wZStDTHdCUThuWi9CRwpscVVvYnozb1ZiUkdaTEV0L3ZlYkVJTVNYTklhSGRyWThWY0pnR2VoazBGczhaQ1RodC9UcGc5My96MHkydnJqCnpXR2hLek9lK3NrRFFISU5IbGk2YWo2MUdQa1VIVFljYlVDcnZua2JnYXRON0w2VjJrbVFaejMzOFp5aUVsSHgKU3o0VkdmdnhBYXJkY2U0eTF0a1FzRThDNERFMjNVSFEyNVVtU0dnWCtjL0grNkludklvZzZoY25hOWFzRytOUQorL1NRenRDUFRidEx4YjFzd3ZjYnN0WnV2VXlwNUlha3hKZnpSV25YTkJYUk9WdlJBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFHRGFaRHpkaVZCMi82Unluc2NRUQpsanRkQmJwV1BFYlNwT1dNWGRndmVUSHhzU0pLQk5yR3YzQnpPZjViSkxVdVp1eGJ2ZjFJZjJvam91c2JIR3VJCkJHdTBZc2lCcGYrNUx4Vjd4dTJ3NWdiSXpWZnJZUUtDU3lKU052d0NwKzBHNXFocTlqRlFFY2xsd05yK1lrUkkKY212WUN6b2lNRFlZNkNzblM3SHc4OGZSOTZhaWFndnRRVXB5YXNMdWVscnpUc05VTlU1b2I3SktMeE1oMExwego1WnRyZWw1M0kxQzFXeEtIZTN0UlRBU2UxVEdzZW9aazhHS1A3OC96L0JwS05SUllGVmJkVkJldk5uYlJjZFlICncxYzFvdEN4UEF6ZXNrRitYR0JCem9yNWdkVyt3KzB4SG9aejVVSTJpQ1B4aGp6d1BjQXJWQ1F3V0xLd3NDK04KZ3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+
+    asserts:
+      - matchRegex:
+          path: data.conjurSslCertificate
+          pattern: "^-----BEGIN CERTIFICATE-----[[:space:]]MIIC/TCC"
+      - matchRegex:
+          path: data.conjurSslCertificate
+          pattern: "[[:space:]]gw==[[:space:]]-----END CERTIFICATE-----[[:space:]]$"
+      - matchRegex:
+          path: data.conjurSslCertificateBase64
+          pattern: "^LS0tLS1.*LS0tCg==$"
+
+  #=======================================================================
+  - it: should fail if authenticator ID is not set
+  #=======================================================================
+    set:
+      # Set required values except conjur.authenticatorID
+      conjur.applianceUrl: "https://conjur.example.com"
+      conjur.certificateFilePath: "tests/test-cert.pem"
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "A valid authnK8s.authenticatorID is required!"
+
+  #=======================================================================
+  - it: should allow ConfigMap name to be set explicitly
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Set explicit Conjur account
+      authnK8s.configMap.name: "my-awesome-configmap"
+
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "my-awesome-configmap"
+
+  #=======================================================================
+  - it: should allow ClusterRole name to be set explicitly
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Set explicit Conjur account
+      authnK8s.clusterRole.name: "my-awesome-clusterrole"
+
+    asserts:
+      - equal:
+          path: data.authnK8sClusterRole
+          value: "my-awesome-clusterrole"
+
+  #=======================================================================
+  - it: should fail if ClusterRole creation is disabled and ClusterRole
+        name is not set
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Disable ClusterRole creation, but don't set ClusterRole name
+      authnK8s.clusterRole.create: false
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "A valid authnK8s.clusterRole.name is required!"
+
+  #=======================================================================
+  - it: should allow ServiceAccount name to be set explicitly
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Set explicit Conjur account
+      authnK8s.serviceAccount.name: "my-awesome-serviceaccount"
+
+    asserts:
+      - equal:
+          path: data.authnK8sServiceAccount
+          value: "my-awesome-serviceaccount"
+
+  #=======================================================================
+  - it: should fail if ServiceAccount creation is disabled and
+        ServiceAccount name is not set
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Disable ClusterRole creation, but don't set ClusterRole name
+      authnK8s.serviceAccount.create: false
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "A valid authnK8s.serviceAccount.name is required!"

--- a/helm/kubernetes-cluster-prep/tests/serviceaccount_test.yaml
+++ b/helm/kubernetes-cluster-prep/tests/serviceaccount_test.yaml
@@ -1,0 +1,49 @@
+suite: test serviceaccount
+templates:
+  - serviceaccount.yaml
+tests:
+  #=======================================================================
+  - it: should not create a ServiceAccount if ServiceAccount creation
+        is disabled
+  #=======================================================================
+    set:
+      authnK8s.serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  #=======================================================================
+  - it: should use default ServiceAccount name when it is not set
+        explicitly
+  #=======================================================================
+    set:
+      # Enable ServiceAccount creation
+      authnK8s.serviceAccount.create: true
+
+    asserts:
+      # Confirm that a ServiceAccount has been created
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+
+      # Confirm that default ServiceAccount name has been used
+      - equal:
+          path: metadata.name
+          value: "authn-k8s-serviceaccount"
+
+  #=======================================================================
+  - it: should allow ServiceAccount name to be set explicitly
+  #=======================================================================
+    set:
+      # Enable ServiceAccount creation
+      authnK8s.serviceAccount.create: true
+
+      # Set ServiceAccount name explicitly
+      authnK8s.serviceAccount.name: "my-awesome-serviceaccount"
+
+    asserts:
+      # Confirm that configured ServiceAccount name has been used
+      - equal:
+          path: metadata.name
+          value: "my-awesome-serviceaccount"

--- a/helm/kubernetes-cluster-prep/values.schema.json
+++ b/helm/kubernetes-cluster-prep/values.schema.json
@@ -8,17 +8,17 @@
                 },
                 "applianceUrl": {
                     "type": "string",
-                    "regex": "(^https:\/\/(.*))|(.*)"
+                    "pattern": "(^https:\/\/(.*))|(^HTTPS:\/\/(.*))"
                 },
                 "certificateFilePath": {
                     "type": "string",
                     "minLength": 1,
-                    "regex": "(^files\/(.*))|(^tests\/(.*))"
+                    "pattern": "(^files\/(.*))|(^tests\/(.*))"
                 },
                 "certificateBase64": {
                     "type": "string",
                     "minLength": 1,
-                    "regex": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+                    "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
                 }
             }
         },
@@ -34,7 +34,7 @@
                         },
                         "name": {
                             "type": "string",
-                            "maxLength": 253
+                            "maxLength": 252
                         }
                     }
                 },
@@ -45,7 +45,8 @@
                         },
                         "name": {
                             "type": "string",
-                            "maxLength": 253
+                            "maxLength": 252,
+                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
                         }
                     }
                 },
@@ -56,7 +57,8 @@
                         },
                         "name": {
                             "type": "string",
-                            "maxLength": 253
+                            "maxLength": 252,
+                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
                         }
                     }
                 }


### PR DESCRIPTION
### What does this PR do?

This change adds the following:
- Helm unit tests that use the `helm-unittest' Helm plugin for testing chart logic.
- Helm lint tests that tests the schema validation that is performed on chart values as defined in the `values.schema.json` file.
- Some fixes and added patterns for schema validation

### What ticket does this PR close?
Resolves #234
### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
