### PR TITLE
Update changelog for OCP 4.6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- The `CAKC048` log message now shows the release version for release builds
+  and no longer includes the git commit hash in the log output.
+  [cyberark/conjur-authn-k8s-client#196](https://github.com/cyberark/conjur-authn-k8s-client/issues/196)
+
 ## [0.19.1] - 2021-02-08
 ### Changed
 - The `Authenticate` method now parses the authentication response and writes it
@@ -18,11 +23,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The project Golang version is updated from the end-of-life v1.12 to the latest
   version v1.15.
   [cyberark/conjur-authn-k8s-client#206](https://github.com/cyberark/conjur-authn-k8s-client/issues/206)
-- Improve the error message raised when the username doesn't include the `host/` prefix
-  [cyberark/conjur-authn-k8s-client#212](https://github.com/cyberark/conjur-authn-k8s-client/pull/212)
-- The `CAKC048` log message now shows the release version for release builds
-  and no longer includes the git commit hash in the log output.
-  [cyberark/conjur-authn-k8s-client#196](https://github.com/cyberark/conjur-authn-k8s-client/issues/196)
+- The error message raised when the username doesn't include the `host/` prefix
+  now suggests that the user check this. Previously the error message did not
+  include any information about what was wrong with the username.
+  [PR cyberark/conjur-authn-k8s-client#212](https://github.com/cyberark/conjur-authn-k8s-client/pull/212)
+
+### Added
+- Support for OpenShift 4.6 was certified as of this release.
 
 ## [0.19.0] - 2020-10-08
 ### Added


### PR DESCRIPTION
### What does this PR do?
Adds OCP 4.6 support to changelog
Also moves the fix for #196 to the correct CL section

### What ticket does this PR close?
Resolves #262 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
