### PR TITLE
Updating get-conjur-cert.sh

### DIFF
--- a/helm/kubernetes-cluster-prep/README.md
+++ b/helm/kubernetes-cluster-prep/README.md
@@ -106,7 +106,8 @@ The steps are as follows:
    instance.
 
    This script can be used for Conjur instances that are either internal
-   or external to the Kubernetes cluster.
+   or external to the Kubernetes cluster. For external Conjur instances
+   there is a requirement to have OpenSSL installed.
 
    The  syntax for this command is as follows:
 


### PR DESCRIPTION
There are a few issues with the get-conjur-cert.sh that need to be fixed.

- When using the -f option if the path is relative, the file destination is relative
  to the script directory, not the users directory.
- For the external case, it would be nice to check if openssl was installed to tell
  the user why it's failing.
- Depending on the kubectl version, kubectl run might make a depoyment or pod,
  it should always be deployment.
- Verify should work if there is a http:// prefix on the URL or not.

### What does this PR do?

Fixes the above issues.

### What ticket does this PR close?
Resolves #278 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
