### PR TITLE
Fix error when both required vals missing for app-namespace-prep chart

### DIFF
--- a/helm/application-namespace-prep/templates/authenticator-rolebinding.yml
+++ b/helm/application-namespace-prep/templates/authenticator-rolebinding.yml
@@ -1,7 +1,6 @@
 {{- if .Values.authnRoleBinding.create -}}
 ---
-{{- $config := required "Both authnK8s.namespace and authnK8s.configMap are required" .Values.authnK8s.name }}
-{{- $config := required "Both authnK8s.namespace and authnK8s.configMap are required" .Values.authnK8s.goldenConfigMap }}
+{{- $config := required "Both authnK8s.namespace and authnK8s.configMap are required" .Values.authnK8s }}
 {{- $g := (lookup "v1" "ConfigMap" .Values.authnK8s.namespace .Values.authnK8s.goldenConfigMap).data }}
 apiVersion: {{ include "conjur-prep.rbac-api" . }}
 kind: RoleBinding

--- a/helm/application-namespace-prep/templates/conjur-connect-configmap.yml
+++ b/helm/application-namespace-prep/templates/conjur-connect-configmap.yml
@@ -1,7 +1,6 @@
 {{- if .Values.conjurConfigMap.create }}
 ---
-{{- $config := required "Both authnK8s.namespace and authnK8s.configMap are required" .Values.authnK8s.name }}
-{{- $config := required "Both authnK8s.namespace and authnK8s.configMap are required" .Values.authnK8s.goldenConfigMap }}
+{{- $config := required "Both authnK8s.namespace and authnK8s.configMap are required" .Values.authnK8s }}
 {{- $g := (lookup "v1" "ConfigMap" .Values.authnK8s.namespace .Values.authnK8s.goldenConfigMap).data }}
 apiVersion: v1
 kind: ConfigMap

--- a/helm/application-namespace-prep/values.schema.json
+++ b/helm/application-namespace-prep/values.schema.json
@@ -2,6 +2,10 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "properties": {
         "authnK8s": {
+            "required": [
+                "goldenConfigMap",
+                "namespace"
+            ],
             "properties": {
                 "goldenConfigMap": {
                     "type": "string"


### PR DESCRIPTION
### What does this PR do?
Currently, when both required values are not provided, we see an
obscure nil interface{} pointer error:
```
Error: template: conjur-namespace-prep/templates/conjur-connect-configmap.yml:3:93: executing "conjur-namespace-prep/templates/conjur-connect-configmap.yml" at <.Values.authnK8s.name>: nil pointer evaluating interface {}.name
```

For this case, the error message should be clear that both required
values are needed:
```
Error: execution error at (conjur-namespace-prep/templates/conjur-connect-configmap.yml:3:15): Both authnK8s.namespace and authnK8s.configMap are required
```

### What ticket does this PR close?
Resolves #

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
