### PR TITLE
Add App-Deploy charts 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.sw[po]
 
 test
+
+temp
+
+helm/kubernetes-cluster-prep/files/conjur-cert.pem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,15 @@ For general contribution and community guidelines, please see the [community rep
 
 ## Testing
 
+### Test Suites
+
 To run the test suite, run `./bin/build` and `./bin/test`.
+
+### Demo Workflow 
+
+To run a sample deployment of the Helm charts located in `/helm`, run `./bin/test-workflow`. This
+will download and run the `conjur-oss-helm-chart` project example, then consecutively install the 
+`helm/kubernetes-cluster-prep`, `helm/application-namespace-prep`, and `helm/app-deploy` charts, in that order.
 
 ## Releases
 

--- a/bin/test-workflow
+++ b/bin/test-workflow
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+cd "$(dirname "$0")/.." || ( echo "cannot cd into parent dir" && exit 1 )
+
+function announce() {
+    echo "
+    ===================
+    ${1}
+    ===================
+    "
+}
+
+# Install Conjur in our cluster, and load policies
+mkdir -p temp &2> /dev/null
+pushd temp
+    git clone https://github.com/cyberark/conjur-oss-helm-chart.git &2> /dev/null
+
+    pushd conjur-oss-helm-chart/examples/kubernetes-in-docker
+        announce "Installing Conjur-OSS"
+        helm uninstall conjur-oss
+        ./start
+    popd
+popd
+
+namespace="app-test"
+
+pushd helm
+    # Prepare our cluster with conjur and authnK8s credentials in a golden configmap
+    pushd kubernetes-cluster-prep
+        announce "Installing cluster prep chart"
+        helm uninstall cluster-prep -n conjur-oss
+
+        ./bin/get-conjur-cert.sh -v -i -u https://conjur-oss.conjur-oss.svc.cluster.local
+
+        helm install cluster-prep . -n conjur-oss  --wait \
+            --set conjur.account="myConjurAccount" \
+            --set conjur.applianceUrl="https://conjur-oss.conjur-oss.svc.cluster.local" \
+            --set conjur.certificateFilePath="files/conjur-cert.pem" \
+            --set authnK8s.authenticatorID="my-authenticator-id"
+    popd
+
+    # Prepare a given namespace with a subset of credentials from the golden configmap
+    pushd application-namespace-prep
+        announce "Installing application namespace prep chart"
+        helm uninstall namespace-prep -n $namespace
+
+        helm install namespace-prep . -n $namespace  --wait \
+            --set authnK8s.goldenConfigMap="authn-k8s-configmap" \
+            --set authnK8s.namespace="conjur-oss"
+    popd
+
+    # Deploy a given app with yet another subset of the subset of our golden configmap, allowing
+    # connection to Conjur
+    pushd app-deploy
+        announce "Installing application chart"
+        helm uninstall app -n $namespace
+
+        helm install app . -n $namespace --wait \
+            --set global.conjur.conjurConnConfigMap="conjur-connect-configmap" \
+            --set app-summon-sidecar.conjur.authnLogin="host/conjur/authn-k8s/my-authenticator-id/apps/test-app-summon-sidecar"
+    popd
+popd

--- a/helm/app-deploy/Chart.yaml
+++ b/helm/app-deploy/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: conjur-cluster-prep
+home: https://www.conjur.org
+version: 0.1.0
+description: A Helm chart for preparing a Kubernetes cluster to use
+             the Conjur Kubernetes authenticator (authn-k8s)
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
+keywords:
+  - security
+  - "secrets management"
+sources:
+  - https://github.com/cyberark/conjur-authn-k8s-client
+  - https://github.com/cyberark/conjur-oss-helm-chart
+  - https://github.com/cyberark/conjur
+maintainers:
+  - name: Conjur Maintainers
+    email: conj_maintainers@cyberark.com

--- a/helm/app-deploy/Chart.yaml
+++ b/helm/app-deploy/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
-name: conjur-cluster-prep
+name: App-Deploy
 home: https://www.conjur.org
 version: 0.1.0
-description: A Helm chart for preparing a Kubernetes cluster to use
-             the Conjur Kubernetes authenticator (authn-k8s)
+description: A Helm chart deploying an application with a Summon sidecar
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
 keywords:
   - security
@@ -15,3 +14,8 @@ sources:
 maintainers:
   - name: Conjur Maintainers
     email: conj_maintainers@cyberark.com
+    
+dependencies:
+    - name: app-summon-sidecar
+      repository: "file://charts/app-summon-sidecar"
+      version: ">= 0.0.1"

--- a/helm/app-deploy/README.md
+++ b/helm/app-deploy/README.md
@@ -1,0 +1,1 @@
+# Helm Chart for Deploying Some Conjur-Enabled Applications

--- a/helm/app-deploy/charts/app-summon-sidecar/Chart.yaml
+++ b/helm/app-deploy/charts/app-summon-sidecar/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: conjur-cluster-prep
+home: https://www.conjur.org
+version: 0.1.0
+description: A Helm chart for preparing a Kubernetes cluster to use
+             the Conjur Kubernetes authenticator (authn-k8s)
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
+keywords:
+  - security
+  - "secrets management"
+sources:
+  - https://github.com/cyberark/conjur-authn-k8s-client
+  - https://github.com/cyberark/conjur-oss-helm-chart
+  - https://github.com/cyberark/conjur
+maintainers:
+  - name: Conjur Maintainers
+    email: conj_maintainers@cyberark.com

--- a/helm/app-deploy/charts/app-summon-sidecar/Chart.yaml
+++ b/helm/app-deploy/charts/app-summon-sidecar/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
-name: conjur-cluster-prep
+name: app-summon-sidecar
 home: https://www.conjur.org
 version: 0.1.0
-description: A Helm chart for preparing a Kubernetes cluster to use
-             the Conjur Kubernetes authenticator (authn-k8s)
+description: A Helm chart deploying an application with a Summon sidecar
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
 keywords:
   - security

--- a/helm/app-deploy/charts/app-summon-sidecar/README.md
+++ b/helm/app-deploy/charts/app-summon-sidecar/README.md
@@ -1,0 +1,2 @@
+# Helm Chart to Deploy an Application that uses Summon and a Conjur Authenticator Client sidecar
+

--- a/helm/app-deploy/charts/app-summon-sidecar/templates/NOTES.txt
+++ b/helm/app-deploy/charts/app-summon-sidecar/templates/NOTES.txt
@@ -1,0 +1,12 @@
+The Conjur/Authenticator Namespace preparation is complete.
+The following have been deployed:
+{{ if .Values.authnK8s.configMap.create }}
+A Golden ConfigMap
+{{ end }}
+{{ if .Values.authnK8s.clusterRole.create }}
+An authenticator ClusterRole
+{{ end }}
+{{ if .Values.authnK8s.serviceAccount.create }}
+An authenticator ServiceAccount
+{{ end }}
+

--- a/helm/app-deploy/charts/app-summon-sidecar/templates/NOTES.txt
+++ b/helm/app-deploy/charts/app-summon-sidecar/templates/NOTES.txt
@@ -1,12 +1,8 @@
-The Conjur/Authenticator Namespace preparation is complete.
+The Application deployment is complete.
 The following have been deployed:
-{{ if .Values.authnK8s.configMap.create }}
-A Golden ConfigMap
+{{ if .Values.conjur.authnConfigMap.create }}
+- A Conjur authentication configmap
 {{ end }}
-{{ if .Values.authnK8s.clusterRole.create }}
-An authenticator ClusterRole
+{{ if .Values.create }}
+- An authnK8s application with a summon sidecar
 {{ end }}
-{{ if .Values.authnK8s.serviceAccount.create }}
-An authenticator ServiceAccount
-{{ end }}
-

--- a/helm/app-deploy/charts/app-summon-sidecar/templates/conjur_authn_configmap.yaml
+++ b/helm/app-deploy/charts/app-summon-sidecar/templates/conjur_authn_configmap.yaml
@@ -13,5 +13,5 @@ metadata:
       helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 data:
     # authn-k8s Configuration 
-    conjurAuthnLogin: {{ required "A valid conjurAuthnLogin is required!" .Values.conjur.authnLogin }}
+    conjurAuthnLogin: {{ required "A valid conjur.authnLogin is required!" .Values.conjur.authnLogin }}
 {{- end }}

--- a/helm/app-deploy/charts/app-summon-sidecar/templates/conjur_authn_configmap.yaml
+++ b/helm/app-deploy/charts/app-summon-sidecar/templates/conjur_authn_configmap.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.conjur.authnConfigMap.create -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: {{ .Values.conjur.authnConfigMap.name }}
+    labels:
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      app.kubernetes.io/name: authn-configmap
+      app.kubernetes.io/component: "app-conjur-authn-config"
+      app.kubernetes.io/instance: {{ .Release.Namespace }}
+      app.kubernetes.io/part-of: "authn-k8s-app-config"
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+data:
+    # authn-k8s Configuration 
+    conjurAuthnLogin: {{ required "A valid conjurAuthnLogin is required!" .Values.conjur.authnLogin }}
+{{- end }}

--- a/helm/app-deploy/charts/app-summon-sidecar/templates/test-app-summon-sidecar.yml
+++ b/helm/app-deploy/charts/app-summon-sidecar/templates/test-app-summon-sidecar.yml
@@ -1,0 +1,97 @@
+{{- if has "authn-k8s" .Values.authenticators -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-summon-sidecar
+  labels:
+    app: test-app-summon-sidecar
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: test-app-summon-sidecar
+  type: {{ .Values.global.appServiceType }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-app-summon-sidecar
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app-summon-sidecar
+  name: test-app-summon-sidecar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-summon-sidecar
+  template:
+    metadata:
+      labels:
+        app: test-app-summon-sidecar
+    spec:
+      serviceAccountName: test-app-summon-sidecar
+      containers:
+      - image: {{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}
+        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+        name: test-app
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /pets
+            port: http
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        env:
+          - name: CONJUR_AUTHN_TOKEN_FILE
+            value: /run/conjur/access-token
+        envFrom:
+          - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+        volumeMounts:
+          - mountPath: /run/conjur
+            name: conjur-access-token
+            readOnly: true
+      - image: {{ .Values.authnClient.image.repository }}:{{ .Values.authnClient..image.tag }}
+        imagePullPolicy: {{ .Values.authnClient.image.pullPolicy }}
+        name: authenticator
+        env:
+          - name: CONTAINER_MODE
+            value: sidecar
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: CONJUR_AUTHN_LOGIN
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Values.conjur.authnConfigMap }}
+                key: conjurAuthnLogin
+        envFrom:
+          - configMapRef:
+            name: {{ .Values.global.conjur.connConfigMap }}
+        volumeMounts:
+          - mountPath: /run/conjur
+            name: conjur-access-token
+      imagePullSecrets:
+        - name: dockerpullsecret
+      volumes:
+        - name: conjur-access-token
+          emptyDir:
+            medium: Memory
+{{ end -}}

--- a/helm/app-deploy/charts/app-summon-sidecar/templates/test-app-summon-sidecar.yml
+++ b/helm/app-deploy/charts/app-summon-sidecar/templates/test-app-summon-sidecar.yml
@@ -1,4 +1,4 @@
-{{- if has "authn-k8s" .Values.authenticators -}}
+{{- if .Values.create -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -37,7 +37,7 @@ spec:
     spec:
       serviceAccountName: test-app-summon-sidecar
       containers:
-      - image: {{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}
+      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
         imagePullPolicy: {{ .Values.app.image.pullPolicy }}
         name: test-app
         ports:
@@ -53,13 +53,13 @@ spec:
           - name: CONJUR_AUTHN_TOKEN_FILE
             value: /run/conjur/access-token
         envFrom:
-          - configMapRef:
+        - configMapRef:
             name: {{ .Values.global.conjur.conjurConnConfigMap }}
         volumeMounts:
           - mountPath: /run/conjur
             name: conjur-access-token
             readOnly: true
-      - image: {{ .Values.authnClient.image.repository }}:{{ .Values.authnClient..image.tag }}
+      - image: {{ printf "%s:%s" .Values.authnClient.image.repository .Values.authnClient.image.tag }}
         imagePullPolicy: {{ .Values.authnClient.image.pullPolicy }}
         name: authenticator
         env:
@@ -80,11 +80,11 @@ spec:
           - name: CONJUR_AUTHN_LOGIN
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.conjur.authnConfigMap }}
+                name: {{ .Values.conjur.authnConfigMap.name }}
                 key: conjurAuthnLogin
         envFrom:
-          - configMapRef:
-            name: {{ .Values.global.conjur.connConfigMap }}
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
         volumeMounts:
           - mountPath: /run/conjur
             name: conjur-access-token

--- a/helm/app-deploy/charts/app-summon-sidecar/values.yaml
+++ b/helm/app-deploy/charts/app-summon-sidecar/values.yaml
@@ -1,0 +1,20 @@
+# Default values for the Application Namespace Prep Helm chart
+# This is a YAML-formatted file.
+
+app:
+  image:
+    repository: "cyberark/test-app-summon-sidecar"
+    tag: "latest"
+    pullPolicy: "always"
+ 
+authnClient:
+  image:
+    repository: "cyberark/authn-k8s-client"
+    tag: "latest"
+    pullPolicy: "always"
+
+conjur:
+  authnConfigMap:
+    create: true
+    name: "conjur-authn-configmap"
+  authnLogin:

--- a/helm/app-deploy/charts/app-summon-sidecar/values.yaml
+++ b/helm/app-deploy/charts/app-summon-sidecar/values.yaml
@@ -3,18 +3,21 @@
 
 app:
   image:
-    repository: "cyberark/test-app-summon-sidecar"
-    tag: "latest"
-    pullPolicy: "always"
+    repository: "localhost:5000/test-sidecar-app"
+    tag: "conjur-oss"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
  
 authnClient:
   image:
-    repository: "cyberark/authn-k8s-client"
+    repository: "cyberark/conjur-authn-k8s-client"
     tag: "latest"
-    pullPolicy: "always"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
 
 conjur:
   authnConfigMap:
     create: true
     name: "conjur-authn-configmap"
+  # host/conjur/authn-k8s/<authenticator-ID>/<conjur-policy-layer-or-group>/<app-host-id>
   authnLogin:

--- a/helm/app-deploy/values.yaml
+++ b/helm/app-deploy/values.yaml
@@ -3,17 +3,26 @@
 
 global:
   conjur:
-    conjurConnConfigMap: "conjur-conn-configmap"
+    # name of the chart created by the application-namespace-prep chart
+    conjurConnConfigMap: "conjur-connect-configmap"
 
   appServiceType: "NodePort"
 
 # Authenticator types to deploy and test. Multiple authenticator types
 # can be selected. All enabled authenticator types (along with their
 # associated sample application container) will be deployed to the
-# same application Namespace. The default is to enable only an authn-k8s
+# same application Namespace. The default (app-summon-sidecar) is to enable only an authn-k8s
 # sidecar container. Uncomment authenticator types as desired.
-authenticators:
-  - authn-k8s
-  #- secretless-broker
-  #- secrets-provider-init
-  #- secrets-provider-standalone
+app-summon-sidecar:
+  create: true
+  conjur:
+    authnLogin:
+
+# secretless-broker:
+#   create: true
+
+# secrets-provider-init:
+#   create: true
+
+# secrets-provider-standalone:
+#   create: true

--- a/helm/app-deploy/values.yaml
+++ b/helm/app-deploy/values.yaml
@@ -1,0 +1,19 @@
+# Default values for Application Deploy Helm chart
+# This is a YAML-formatted file.
+
+global:
+  conjur:
+    conjurConnConfigMap: "conjur-conn-configmap"
+
+  appServiceType: "NodePort"
+
+# Authenticator types to deploy and test. Multiple authenticator types
+# can be selected. All enabled authenticator types (along with their
+# associated sample application container) will be deployed to the
+# same application Namespace. The default is to enable only an authn-k8s
+# sidecar container. Uncomment authenticator types as desired.
+authenticators:
+  - authn-k8s
+  #- secretless-broker
+  #- secrets-provider-init
+  #- secrets-provider-standalone

--- a/helm/application-namespace-prep/values.yaml
+++ b/helm/application-namespace-prep/values.yaml
@@ -9,7 +9,7 @@ authnRoleBinding:
 
 conjurConfigMap:
   create: true
-  name: conjur-configmap
+  name: conjur-connect-configmap
 
 test:
   mock:

--- a/helm/kubernetes-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/kubernetes-cluster-prep/bin/get-conjur-cert.sh
@@ -181,7 +181,7 @@ function get_domain_name() {
 function get_openssl_pod() {
     openssl_deployment="$1"
 
-    kubectl get pod -l "run=$openssl_deployment" -o jsonpath='{.items[*].metadata.name}'
+    kubectl get pod -l "app=$openssl_deployment" -o jsonpath='{.items[*].metadata.name}'
 }
 
 function ensure_openssl_pod_created() {
@@ -196,7 +196,7 @@ function ensure_openssl_pod_created() {
         # Remember that we need to clean up the deployment that we just created
         deployment_was_created=true
         # Wait for Pod to be ready
-        kubectl wait --for=condition=ready pod -l "run=$openssl_deployment"
+        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment"
     fi
 }
 


### PR DESCRIPTION
### What does this PR do?
- adds `bin/test-workflow` to run the conjur-oss helm demo, then run through the sequential installation process for our new helm charts. It "Just Works"™️
- Introduces the `app-test` charts, verifying functionality of our cluster and namespace prep charts.
- standardized default values across our namespace, cluster, and app charts, to allow for "out of the box" deployment

### What ticket does this PR close?
Resolves #238 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
