### PR TITLE
Adding the Heml test container to DockerHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,3 +121,36 @@ LABEL version="$VERSION"
 LABEL release="$VERSION"
 LABEL summary="Conjur OpenShift Authentication Client for use with Conjur"
 LABEL description="The authentication client required to expose secrets from a Conjur server to applications running within OpenShift"
+
+# =================== CONTAINER FOR HELM TEST ===================
+
+FROM alpine:3.12 as k8s-cluster-test
+
+# Install packages for testing
+RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl
+
+# Install bats-core in /usr/local
+RUN curl -#L https://github.com/bats-core/bats-core/archive/master.zip | unzip - && \
+    bash bats-core-master/install.sh /usr/local && \
+    rm -rf ./bats-core-master
+
+# Install bats-support, bats-assert, and bats-files libraries
+# These need to be source at run time, e.g.:
+#    source '/bats/bats-support/load.bash'
+#    source '/bats/bats-assert/load.bash'
+#    source '/bats/bats-file/load.bash'
+RUN git clone https://github.com/ztombol/bats-support /bats/bats-support
+RUN git clone https://github.com/ztombol/bats-assert /bats/bats-assert
+RUN git clone https://github.com/ztombol/bats-file /bats/bats-file
+
+RUN mkdir -p /tests
+WORKDIR /tests
+
+LABEL name="conjur-k8s-cluster-test"
+LABEL vendor="CyberArk"
+LABEL version="$VERSION"
+LABEL release="$VERSION"
+LABEL summary="Conjur Kubernetes test client for use with Helm"
+LABEL description="The Conjur test client that is used with Helm test to validate the configuration created by Helm"
+
+ENTRYPOINT ["sleep", "infinity"]

--- a/bin/build
+++ b/bin/build
@@ -24,4 +24,10 @@ docker build --tag "${IMAGE_NAME}-redhat:${TAG}" \
              --target "authenticator-client-redhat" \
              .
 
+docker build --tag conjur-k8s-cluster-test:${TAG} \
+             --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
+             --build-arg VERSION="$VERSION" \
+             --target "k8s-cluster-test" \
+             .
+
 echo "---"

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -36,3 +36,12 @@ function git_tag_suffix() {
 function git_commit_short() {
   git rev-parse --short HEAD
 }
+
+function push_conjur-k8s-cluster-test() {
+    echo "Pushing Helm test image to Dockerhub..."
+    source_image=conjur-k8s-cluster-test:dev
+    destination_image_name=conjur-k8s-cluster-test
+    echo "Tagging and pushing $REGISTRY/$destination_image_name:$tag"
+    docker tag $source_image "$REGISTRY/$destination_image_name:$tag"
+    docker push "$REGISTRY/$destination_image_name:$tag"
+}

--- a/bin/publish
+++ b/bin/publish
@@ -20,6 +20,12 @@ readonly TAGS=(
   "latest"
 )
 
+if [[ $1 = "--edge" ]]; then
+    tag=edge
+    push_conjur-k8s-cluster-test
+    exit 0
+fi
+
 if [[ -z "${TAG_NAME:-}" ]]; then
   echo "This script should only run in a tag-triggered build controlled by the JenkinsFile"
   exit 1
@@ -49,3 +55,8 @@ else
   echo 'Failed to log in to scan.connect.redhat.com'
   exit 1
 fi
+
+for tag in "${TAGS[@]}" $(gen_versions "$VERSION"); do
+    push_conjur-k8s-cluster-test
+done
+


### PR DESCRIPTION
### What does this PR do?
This adds building and pushing the Helm test container to DockerHub.
The container will be pushed with the edge tag to get it in the repository before a build label is created.

This is split from the Helm test commit to get the image in place first so the helm test can be tested
against the new image.

### What ticket does this PR close?
Resolves #287 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
