### PR TITLE
Fixes an unbound variable error when using the edge tag

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -5,6 +5,13 @@
 REDHAT_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb/conjur-openshift-authenticator-client'
 
 readonly REGISTRY="cyberark"
+
+if [[ $1 = "--edge" ]]; then
+    tag=edge
+    push_conjur-k8s-cluster-test
+    exit 0
+fi
+
 # We take the version from the TAG_NAME variable - removing the "v" prefix
 readonly VERSION="${TAG_NAME//"v"}"
 
@@ -19,12 +26,6 @@ readonly TAGS=(
   "$VERSION"
   "latest"
 )
-
-if [[ $1 = "--edge" ]]; then
-    tag=edge
-    push_conjur-k8s-cluster-test
-    exit 0
-fi
 
 if [[ -z "${TAG_NAME:-}" ]]; then
   echo "This script should only run in a tag-triggered build controlled by the JenkinsFile"


### PR DESCRIPTION
### What does this PR do?
When Jenkins is running on master, getting an 
[2021-05-04T17:23:14.455Z] + summon ./bin/publish --edge

[2021-05-04T17:23:14.455Z] ./bin/publish: line 9: TAG_NAME: unbound variable

script returned exit code 1

This fixes the error by moving the --edge logic above the TAG_NAME

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
