### PR TITLE
Add top level test script for linting helm charts and execute as part of CI

### DIFF
--- a/Dockerfile.helm-test
+++ b/Dockerfile.helm-test
@@ -1,0 +1,29 @@
+# =================== CONTAINER FOR HELM TEST ===================
+
+FROM alpine:3.12 as conjur-k8s-helm-test
+
+# Install packages for testing
+RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl
+
+# Install helm
+RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+
+# Install helm unittest plugin
+RUN mv /etc/os-release /etc/os-release.bak && \
+    touch /etc/os-release && \
+    helm plugin install https://github.com/quintush/helm-unittest && \
+    mv /etc/os-release.bak /etc/os-release
+
+RUN mkdir -p /conjur-authn-k8s-client
+WORKDIR /conjur-authn-k8s-client
+
+LABEL name="conjur-k8s-helm-test"
+LABEL vendor="CyberArk"
+LABEL version="$VERSION"
+LABEL release="$VERSION"
+LABEL summary="Conjur Kubernetes test image for running Helm tests"
+LABEL description="The Conjur test image that is used with Helm test to validate the configuration created by Helm"
+
+COPY . .
+
+ENTRYPOINT ["/conjur-authn-k8s-client/bin/test-helm"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,10 @@ pipeline {
         stage('Application Namespace-Prep Schema') {
           steps { sh './bin/validate-schema ./helm/application-namespace-prep/values.schema.json'}
         }
+
+        stage('Helm Charts') {
+          steps { sh './bin/test-helm-in-docker' }
+        }
       }
     }
 

--- a/bin/test-helm
+++ b/bin/test-helm
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eo pipefail
+
+cd "$(dirname "$0")/.." || ( echo "cannot cd into parent dir" && exit 1 )
+
+function pushd() {
+    command pushd "$@" > /dev/null
+}
+
+function popd() {
+    command popd "$@" > /dev/null
+}
+
+pushd helm
+    pushd kubernetes-cluster-prep
+        ./test-lint
+        ./test-schema
+        ./test-unit
+    popd
+
+    pushd application-namespace-prep
+        ./test-lint
+        ./test-schema
+        ./test-unit
+    popd
+
+    pushd app-deploy
+        ./test-lint
+    popd
+popd

--- a/bin/test-helm-in-docker
+++ b/bin/test-helm-in-docker
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eo pipefail
+
+echo "Building helm test image..."
+docker build -f Dockerfile.helm-test -t conjur-k8s-helm-test:dev .
+
+echo "Running helm tests..."
+docker run --rm -t conjur-k8s-helm-test:dev

--- a/helm/app-deploy/test-lint
+++ b/helm/app-deploy/test-lint
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Helm lint tests for the App Deploy Helm chart and subcharts.
+
+source ../common/utils.sh
+
+function pushd() {
+    command pushd "$@" > /dev/null
+}
+
+function popd() {
+    command popd "$@" > /dev/null
+}
+
+banner $BOLD "Running Helm lint for chart \"app-deploy\""
+helm lint .
+
+pushd charts
+    announce "Running Helm lint for subchart \"app-summon-sidecar\""
+    pushd app-summon-sidecar
+        helm lint . --set conjur.authnLogin="exampleLogin"
+    popd
+popd

--- a/helm/application-namespace-prep/test-lint
+++ b/helm/application-namespace-prep/test-lint
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+source ../common/utils.sh
+
+banner $BOLD "Running Helm lint for chart \"application-namespace-prep\""
 helm lint . \
     --set authnK8s.goldenConfigMap="authn-k8s-configmap" \
     --set authnK8s.namespace="app-test" \

--- a/helm/application-namespace-prep/test-schema
+++ b/helm/application-namespace-prep/test-schema
@@ -32,7 +32,7 @@ function authenticator_missing_namespace_test() {
 }
 
 function main() {
-
+    banner $BOLD "Running Helm schema tests for chart \"application-namespace-prep\""
     check_helm_version
 
     announce "Basic test with both the ConfigMap and Namespace supplied "
@@ -48,6 +48,9 @@ function main() {
     update_results "$?" "$EXPECT_FAILURE"
 
     display_final_results
+    if [ "$num_failed" -ne 0 ]; then
+        exit 1
+    fi
 }
 
 main "$@"

--- a/helm/application-namespace-prep/test-unit
+++ b/helm/application-namespace-prep/test-unit
@@ -5,4 +5,5 @@
 
 source ../common/utils.sh
 
+banner $BOLD "Running Helm unit tests for chart \"application-namespace-prep\""
 run_helm_unittest

--- a/helm/common/utils.sh
+++ b/helm/common/utils.sh
@@ -6,6 +6,7 @@ readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
 readonly BLUE='\033[0;34m'
 readonly NOCOLOR='\033[0m'
+readonly BOLD='\e[1m'
 readonly ANNOUNCE_COLOR="$BLUE"
 readonly MIN_HELM_VERSION="3.5.3"
 readonly EXPECT_FAILURE=true

--- a/helm/kubernetes-cluster-prep/test-lint
+++ b/helm/kubernetes-cluster-prep/test-lint
@@ -2,15 +2,20 @@
 
 # Helm lint tests for the Conjur Kubernetes cluster prep Helm chart.
 
+source ../common/utils.sh
+
+banner $BOLD "Running Helm lint for chart \"kubernetes-cluster-prep\""
+
 # Run Helm lint with a Conjur certificate file
-helm lint \
+announce "With a Conjur certificate file"
+helm lint . \
     --set conjur.applianceUrl="https://conjur.example.com" \
     --set conjur.certificateFilePath="tests/test-cert.pem" \
     --set authnK8s.authenticatorID="my-authenticator-id"
 
 # Run Helm lint with a base64-encoded Conjur certificate
-helm lint \
+announce "With a base64-encoded Conjur certificate"
+helm lint . \
     --set conjur.applianceUrl="https://conjur.example.com" \
     --set conjur.certificateBase64="LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lSQUpOMk11Vmx0alpMWmVyRk50YklZend3RFFZSktvWklodmNOQVFFTEJRQXcKR0RFV01CUUdBMVVFQXhNTlkyOXVhblZ5TFc5emN5MWpZVEFlRncweU1UQXpNakF4TlRRNU1UTmFGdzB5TWpBegpNakF4TlRRNU1UTmFNQmd4RmpBVUJnTlZCQU1URFdOdmJtcDFjaTF2YzNNdFkyRXdnZ0VpTUEwR0NTcUdTSWIzCkRRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRQ3Z6cWVMTmZSRUM1OEdwcEZYNmtlbWUzYUNSdDlJRlRPOGhZR0IKVU5xQVJTb3hrNlJobC9nQ1ZZSVdRMHF3bEFzR0lOR2x3Wmw1ZS9YSlRGU2lQRUZqd05wZStDTHdCUThuWi9CRwpscVVvYnozb1ZiUkdaTEV0L3ZlYkVJTVNYTklhSGRyWThWY0pnR2VoazBGczhaQ1RodC9UcGc5My96MHkydnJqCnpXR2hLek9lK3NrRFFISU5IbGk2YWo2MUdQa1VIVFljYlVDcnZua2JnYXRON0w2VjJrbVFaejMzOFp5aUVsSHgKU3o0VkdmdnhBYXJkY2U0eTF0a1FzRThDNERFMjNVSFEyNVVtU0dnWCtjL0grNkludklvZzZoY25hOWFzRytOUQorL1NRenRDUFRidEx4YjFzd3ZjYnN0WnV2VXlwNUlha3hKZnpSV25YTkJYUk9WdlJBZ01CQUFHalFqQkFNQTRHCkExVWREd0VCL3dRRUF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFHRGFaRHpkaVZCMi82Unluc2NRUQpsanRkQmJwV1BFYlNwT1dNWGRndmVUSHhzU0pLQk5yR3YzQnpPZjViSkxVdVp1eGJ2ZjFJZjJvam91c2JIR3VJCkJHdTBZc2lCcGYrNUx4Vjd4dTJ3NWdiSXpWZnJZUUtDU3lKU052d0NwKzBHNXFocTlqRlFFY2xsd05yK1lrUkkKY212WUN6b2lNRFlZNkNzblM3SHc4OGZSOTZhaWFndnRRVXB5YXNMdWVscnpUc05VTlU1b2I3SktMeE1oMExwego1WnRyZWw1M0kxQzFXeEtIZTN0UlRBU2UxVEdzZW9aazhHS1A3OC96L0JwS05SUllGVmJkVkJldk5uYlJjZFlICncxYzFvdEN4UEF6ZXNrRitYR0JCem9yNWdkVyt3KzB4SG9aejVVSTJpQ1B4aGp6d1BjQXJWQ1F3V0xLd3NDK04KZ3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==" \
     --set authnK8s.authenticatorID="my-authenticator-id"
-

--- a/helm/kubernetes-cluster-prep/test-schema
+++ b/helm/kubernetes-cluster-prep/test-schema
@@ -58,7 +58,7 @@ function clusterrole_name_test() {
 }
 
 function main() {
-
+    banner $BOLD "Running Helm schema tests for chart \"kubernetes-cluster-prep\""
     check_helm_version
 
     announce "Appliance URL that begins with 'https://' is accepted"
@@ -142,6 +142,9 @@ function main() {
     update_results "$?" "$EXPECT_FAILURE"
 
     display_final_results
+    if [ "$num_failed" -ne 0 ]; then
+        exit 1
+    fi
 }
 
 main "$@"

--- a/helm/kubernetes-cluster-prep/test-unit
+++ b/helm/kubernetes-cluster-prep/test-unit
@@ -5,4 +5,5 @@
 
 source ../common/utils.sh
 
-run_helm-unittest
+banner $BOLD "Running Helm unit tests for chart \"kubernetes-cluster-prep\""
+run_helm_unittest


### PR DESCRIPTION
### What does this PR do?
Runs `helm lint` on kubernetes-cluster-prep, application-namespace-prep, and the sample-app helm charts as part of Jenkins pipeline. Done in a container because naturally the `helm` binary is needed. Also invokes the schema and unit tests for the kubernetes-cluster-prep and application-namespace-prep charts

### What ticket does this PR close?
Resolves #240 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
