### PR TITLE
Add Helm authentication validation test

### DIFF
--- a/helm/kubernetes-cluster-prep/assets/example-conjur-policy-with-validator.yaml
+++ b/helm/kubernetes-cluster-prep/assets/example-conjur-policy-with-validator.yaml
@@ -1,0 +1,43 @@
+---
+# This policy defines an authn-k8s endpoint, CA creds and a layer for whitelisted identities permitted to authenticate to it
+- !policy
+  id: conjur/authn-k8s/my-authenticator-id
+  owner: !group cluster_admin
+  annotations:
+    description: Namespace defs for the Conjur cluster in dev
+  body:
+  - !webservice
+    annotations:
+      description: authn service for cluster
+
+  - !host
+    id: validator
+    annotations:
+      description: Validation host used when configuring a cluster
+      authn-k8s/namespace: conjur-oss
+
+  - !policy
+    id: ca 
+    body:
+    - !variable
+      id: cert
+      annotations:
+        description: CA cert for Kubernetes Pods.
+    - !variable
+      id: key
+      annotations:
+        description: CA key for Kubernetes Pods.
+
+  # define layer of whitelisted authn ids permitted to call authn service
+  - !layer users
+
+  - !permit
+    resource: !webservice
+    privilege: [ read, authenticate ]
+    role: !layer users
+
+- !grant
+  role: !layer conjur/authn-k8s/my-authenticator-id/users
+  members:
+    - !layer conjur/authn-k8s/my-authenticator-id/apps
+    - !host conjur/authn-k8s/my-authenticator-id/validator

--- a/helm/kubernetes-cluster-prep/templates/tests/_authn_container.yaml.txt
+++ b/helm/kubernetes-cluster-prep/templates/tests/_authn_container.yaml.txt
@@ -1,0 +1,47 @@
+{{- define "kube-cluster-prep.authn-container.yaml" }}
+- name: authenticator
+  image: cyberark/conjur-authn-k8s-client
+  imagePullPolicy: Always
+  command: ["sh", "-c", "/usr/local/bin/authenticator | tee /run/conjur/authn-logs.txt"]
+  env:
+  - name: CONTAINER_MODE
+    value: sidecar
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
+  - name: MY_POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.namespace
+  - name: MY_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  {{- if eq .Values.test.authentication.debug true }}
+  - name: DEBUG
+    value: "true"
+  {{- end }}
+  - name: CONJUR_AUTHN_URL
+    value: {{ .Values.conjur.applianceUrl }}/authn-k8s/{{ .Values.authnK8s.authenticatorID }}
+  - name: CONJUR_ACCOUNT
+    valueFrom:
+      configMapKeyRef:
+        name: {{ .Values.authnK8s.configMap.name }}
+        key: conjurAccount
+  - name: CONJUR_AUTHN_LOGIN
+    value: host/conjur/authn-k8s/{{ .Values.authnK8s.authenticatorID }}/{{ .Values.test.authentication.validatorID }}
+  - name: CONJUR_SSL_CERTIFICATE
+    valueFrom:
+      configMapKeyRef:
+        name: {{ .Values.authnK8s.configMap.name }}
+        key: conjurSslCertificate
+  - name: CONJUR_TOKEN_TIMEOUT
+    value: 10s
+  volumeMounts:
+  - mountPath: /run/conjur
+    name: conjur-access-token
+{{- end }}

--- a/helm/kubernetes-cluster-prep/templates/tests/_helm_test.bats.txt
+++ b/helm/kubernetes-cluster-prep/templates/tests/_helm_test.bats.txt
@@ -14,6 +14,10 @@ source "/bats/bats-support/load.bash"
 source "/bats/bats-assert/load.bash"
 source "/bats/bats-file/load.bash"
 
+readonly ACCESS_TOKEN_FILE="/run/conjur/access-token"
+readonly AUTHN_LOG_FILE="/run/conjur/authn-logs.txt"
+readonly AUTHN_TIMEOUT_SECS=5
+
 # Baseline BATS test result color
 text_color "$MAGENTA"
 
@@ -28,4 +32,46 @@ text_color "$MAGENTA"
   assert_success
 }
 
+{{- if .Values.test.authentication.enable }}
+
+@test "Conjur authenticator sidecar has successfully retrieved an API token" {
+  display_info "Checking for existence of access token at '$ACCESS_TOKEN_FILE'"
+  secs=0
+  until [ "$secs" -ge "$AUTHN_TIMEOUT_SECS" ]
+  status=0
+  do
+    echo "Checking for existence of authn token at $ACCESS_TOKEN_FILE"
+    test -f "$ACCESS_TOKEN_FILE" || status="$?"
+    if [ "$status" -eq 0 ]; then
+      break
+    fi
+    secs=$((secs+1))
+    echo "$n"
+    sleep 1
+  done
+  if [ "$status" -ne 0 ]; then
+    display_error "The authenticator sidecar was not able to authenticate\n" \
+                  "with Conjur. Check that your Conjur policy contains the\n" \
+                  "required validator host ID with the command:\n" \
+                  "  conjur list -k host -s conjur/authn-k8s/{{ .Values.authnK8s.authenticatorID }}/{{ .Values.test.authentication.validatorID }}\n"
+  fi
+  assert_success
+}
+
+@test "CAKC028 error code does not appear in authenticator logs" {
+  error_code="CAKC028"
+  display_info "Checking for existence of error code $error_code in authenticator logs"
+  run grep "$error_code" "$AUTHN_LOG_FILE"
+  if [ "$status" -eq 0 ]; then
+    display_error "The authenticator returns the following error:\n" \
+      "$output\n" \
+      "This means that Subject names in the Conjur's SSL certificate\n" \
+      "does not include the domain name in the configured Conjur Appliance\n" \
+      "URL: $conjurApplianceUrl\n" \
+      "Please check that the configured Conjur Appliance URL is correct."
+  fi
+  # Failure of the grep command is success in this case 
+  assert_failure
+}
+{{- end }}
 {{- end }}

--- a/helm/kubernetes-cluster-prep/templates/tests/test-cluster-prep.yaml
+++ b/helm/kubernetes-cluster-prep/templates/tests/test-cluster-prep.yaml
@@ -3,11 +3,15 @@ kind: Pod
 metadata:
   name: {{ .Release.Name }}-cluster-prep-test
   labels:
+    "app": "cluster-prep-test"
   annotations:
     "helm.sh/hook": test-success
 spec:
   containers:
-  - name: {{ .Release.Name }}-test
+  {{- if .Values.test.authentication.enable }}
+    {{- include "kube-cluster-prep.authn-container.yaml" . | indent 2 }}
+  {{- end }}
+  - name: tester
     image: cyberark/conjur-k8s-cluster-test:edge
     command: ["/usr/local/bin/bats", "-t", "/tests/helm-test.bats"]
     envFrom: 
@@ -17,6 +21,8 @@ spec:
     - mountPath: /tests
       name: tests
       readOnly: true
+    - mountPath: /run/conjur
+      name: conjur-access-token
   serviceAccount: {{ .Values.authnK8s.serviceAccount.name }}
   volumes:
   - name: conjur-access-token

--- a/helm/kubernetes-cluster-prep/test-helm
+++ b/helm/kubernetes-cluster-prep/test-helm
@@ -1,10 +1,15 @@
 #!/bin/bash
 #
-# Usage:
-#     ./test-helm [<Helm test release>]
+# Run a Kubernetes cluster prep Helm chart Helm test to validate
+# an installed chart release.
 #
-# Example:
-#     ./test-helm my-test-release
+# Example: Run test without authentication with a Conjur instance:
+#     ./test-helm -r my-test-release
+#
+# Example: Run test including authentication with a Conjur instance:
+#     ./test-helm -r my-test-release -a -v "validator"
+
+source ../common/utils.sh
 
 print_usage() {
   echo "Usage:"
@@ -13,59 +18,53 @@ print_usage() {
   echo "Syntax:"
   echo "    $0 [Options]"
   echo "    Options:"
-  echo "    -h           Show help"
-  echo "    -i           Install the Helm release"
-  echo "    -u           Uninstall the Helm release"
-  echo "    -r           Specify the Helm release"
-  echo "    -None at this time"
+  echo "    -a            Test authentication with Conjur instance"
+  echo "    -h            Show help"
+  echo "    -r <release>  Specify the Helm release"
+  echo "                  (defaults to 'authn-k8s')"
+  echo "    -v <host-ID>  Specify validator host ID to use for testing"
+  echo "                  authentication (defaults to 'validator')"
 }
 
-helm_release="helm-test-release"
-install=false
-uninstall=false
-conjur_account="${CONJUR_ACCOUNT:-myConjurAccount}"
-conjur_appliance_url="${CONJUR_APPLIANCE_URL:-https://conjur-oss.conjur-oss.svc.cluster.local}"
-conjur_certificate_file_path="${CONJUR_CERT_FILE_PATH:-files/conjur-cert.pem}"
-authenticator_id="${AUTHENTICATOR_ID:-my-authenticator-id}"
+helm_release="authn-k8s"
+test_authentication=false
+validator_id="validator"
+test_timeout="10s"
 
 function main() {
   # Process command line options
   local OPTIND
-  while getopts ':h:ir:u' flag; do
+  while getopts ':ahr:v:' flag; do
     case "${flag}" in
-      #a) conjur_account=${OPTARG} ;;
+      a) test_authentication=true ;;
       h) print_usage; exit 0 ;;
-      i) install=true ;;
       r) helm_release=${OPTARG} ;;
-      u) uninstall=true ;;
+      v) validator_id=${OPTARG} ;;
       *) echo "Invalid argument -${OPTARG}" >&2; echo; print_usage ; exit 1;;
     esac
   done
   shift $((OPTIND-1))
 
-  if [ "$uninstall" = true ] ; then
-    echo "Cleaning up previous release, if necessary"
-    helm status "$helm_release" &> /dev/null 
-    status="$?"
-    echo "status=" "$status"
+  kubectl delete pod -l "app=cluster-prep-test" --ignore-not-found
+  helm upgrade "$helm_release" . \
+      --reuse-values \
+      --set test.authentication.enable="$test_authentication" \
+      --set test.authentication.validatorID="$validator_id" \
+      --set test.authentication.debug=true
 
-    if [ "$status" = 0 ] ; then
-      echo "Deleting"
-      helm delete "$helm_release"
-    fi
-    echo "Done cleaning up previous release"
-    sleep 6
+  announce "Running Helm test"
+  if "$test_authentication"; then
+    # Run with a timeout, since authenticator sidecar will run indefinitely.
+    # Also, the Helm test '--logs' option does not work if there are
+    # multiple containers in the test Pod.
+    helm test "$helm_release" --timeout "$test_timeout"
+    announce "Retrieving Conjur authenticator container logs"
+    kubectl logs "$helm_release"-cluster-prep-test authenticator
+    announce "Retrieving BATS tester logs"
+    kubectl logs "$helm_release"-cluster-prep-test tester
+  else
+    helm test "$helm_release" --logs
   fi
-  if [ "$install" = true ] ; then
-    echo "Helm installing a new release" "$conjur_account"
-    helm install "$helm_release" . \
-         --set conjur.account="$conjur_account" \
-         --set conjur.applianceUrl="$conjur_appliance_url" \
-         --set conjur.certificateFilePath="$conjur_certificate_file_path" \
-         --set authnK8s.authenticatorID="$authenticator_id"
-  fi
-  echo "Running Helm test"
-  helm test "$helm_release" --logs
 }
 
 main "$@"

--- a/helm/kubernetes-cluster-prep/values.yaml
+++ b/helm/kubernetes-cluster-prep/values.yaml
@@ -46,7 +46,20 @@ authnK8s:
     # name: authn-k8s-serviceaccount
     # name:
 
-displaySamplePolicy: false
-
 test:
+  # 'colorize' determines if test output should include color escape sequences
   colorize: true
+  authentication:
+    # 'enable' indicates whether validation tests should include an attempt
+    # to authenticate with a Conjur instance using the Golden ConfigMap
+    # contents and a special "authentication-only" (no secrets access)
+    # validator Conjur host ID.
+    enable: false
+    # 'validatorID' indicates the Conjur host ID that should be used
+    # to test authentication with a Conjur instance. This host ID must be
+    # pre-configured for basic authentication in Conjur security policy.
+    # The authn-k8s sidecar will use a CONJUR_AUTHN_LOGIN value of:
+    #    host/conjur/authn-k8s/{{authenticatorID}}/{{validatorID}}
+    validatorID: "validator"
+    # 'debug' enables authenticator sidecar debug logs during testing
+    debug: true


### PR DESCRIPTION
### What does this PR do?

This change adds an optional Helm chart test that can validate that a deployed Helm chart
release is actually capable of authenticating with the configured Conjur
instance. This Conjur authentication validation testing requires the
configuration of a special "validator" host ID in Conjur security policy
that supports Conjur Kubernetes authentication. This "validator" host ID
does not require access to Conjur secrets for the purposes of this
authentication test.

An example Conjur security policy that includes an "authenticate-only"
validator host ID for testing authentication can be found in
`assets/example-conjur-policy-with-validator.yaml`.

When the Conjur authentication validation test is enabled, the Helm test
Pod that is deployed for the `helm test ...` command will include an
authn-k8s client sidecar container that uses values from the Golden
ConfigMap to attempt to authenticate with the Conjur instance. Logs from the
authn-k8s client sidecar container are copied to a volume that is shared
with the Helm test's main test container, so that the test container can
scan the logs for some common error codes.

This change also updates the `test-helm` script so that it uses
`helm upgrade ...` to update test-specific chart values, rather than
relying on the user to select the `-u` (uninstall) and `-i` (install)
options for this purpose. 

### What ticket does this PR close?
Resolves #231 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
