### PR TITLE
Adding checks for Conjur account and authenticatorID

### DIFF
--- a/helm/kubernetes-cluster-prep/templates/tests/_helm_test.bats.txt
+++ b/helm/kubernetes-cluster-prep/templates/tests/_helm_test.bats.txt
@@ -16,6 +16,7 @@ source "/bats/bats-file/load.bash"
 
 readonly ACCESS_TOKEN_FILE="/run/conjur/access-token"
 readonly AUTHN_LOG_FILE="/run/conjur/authn-logs.txt"
+readonly TEMP_INFO_FILE="/info.txt"
 readonly AUTHN_TIMEOUT_SECS=5
 
 # Baseline BATS test result color
@@ -74,4 +75,43 @@ text_color "$MAGENTA"
   assert_failure
 }
 {{- end }}
+
+@test "Conjur Account is valid" {
+  display_info "Validating account from the info endpoint for enterprise"
+
+  cmd=( curl -k --connect-timeout 5 "$conjurApplianceUrl"/info -o "$TEMP_INFO_FILE")
+  display_info "Running ${cmd[@]}"
+  "${cmd[@]}"
+  run grep account.*"$conjurAccount" "$TEMP_INFO_FILE"
+
+  if [ "$status" -ne 0 ]; then
+    if (grep account "$TEMP_INFO_FILE"); then
+        display_error "Please check the configured Conjur Account.\n" \
+                      "It does not match with values from the info endpoint."
+    else
+        skip "test due to the info endpoint is not available for OSS"
+    fi
+  fi
+  assert_success
+}
+
+@test "Conjur Authenticator is valid" {
+  display_info "Validating authenticator ID from the info endpoint for enterprise"
+
+  cmd=( curl -k --connect-timeout 5 "$conjurApplianceUrl"/info -o "$TEMP_INFO_FILE")
+  display_info "Running ${cmd[@]}"
+  run "${cmd[@]}"
+  run grep name.*"$authnK8sAuthenticatorID" "$TEMP_INFO_FILE"
+
+  if [ "$status" -ne 0 ]; then
+    if (grep name "$TEMP_INFO_FILE"); then
+        display_error "Please check configured authenticator ID\n" \
+                      "It does not match with values from the info endpoint."
+    else
+        skip "test due to the info endpoint is not available for OSS"
+    fi
+  fi
+  assert_success
+}
+
 {{- end }}


### PR DESCRIPTION
Adding checks for Conjur account and authenticatorID in the Helm tests.

### What does this PR do?
This adds two Helm tests to validate the Conjur account and authenticatorID
that is retrieved from the /info endpoint.
The /info endpoint only works on the enterprise edition to extra checks were made
for the failing case if it wasn't enterprise.

Opted not to add new item to values.yaml
Instead of a setting of enterprise or oss, the test will parse the info endpoint.
If the data matches, it passes no matter what edition.
If the first test fails, then we do another check of the information gathered
from the curl of the endpoint. If it was oss, the results will not have lines
like account and name, it will just have "Authorization missing".

So for OSS, the tests will be skipped, as below.
```
ok 1 Conjur Appliance URL is a reachable address

ok 2 Conjur Account is valid # skip test due to the info endpoint is not available for OSS

ok 3 Conjur Authenticator is valid # skip test due to the info endpoint is not available for OSS

```
### What ticket does this PR close?
Resolves #230 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
