### PR TITLE
Add fingerprint check in get-conjur-cert

### DIFF
--- a/helm/conjur-config-cluster-prep/README.md
+++ b/helm/conjur-config-cluster-prep/README.md
@@ -123,6 +123,8 @@ The steps are as follows:
       -h                             Show help
       -i                             Conjur appliance URL is a Kubernetes
                                      cluster internal address.
+      -s                             Display the fingerprint but skip prompting
+                                     the user to acknowledge it is trusted
       -u <Conjur appliance URL>      Conjur appliance URL (required)
       -v                             Verify the certificate
 
@@ -178,6 +180,27 @@ The steps are as follows:
    9gi8KwcJAxv0+CXPjL0gAH9dWrUmKXAQGzA2dnNCgIfVqgfPZwMqpxEwZt+GEEu8
    zA==
    -----END CERTIFICATE-----
+   ```
+
+   The script will display the fingerprint for the certificate and ask if
+   you trust the certificate.
+
+   For Conjur Enterprise, the fingerprint can be verified by running
+   the following command on the Conjur instance (either leader or follower,
+   depending upon the Conjur appliance URL):
+   ```
+   openssl x509 -fingerprint -noout -in <certificate file path>
+   ```
+   The certificate is located at ~conjur/etc/ssl/conjur.pem
+
+   In a Kubernetes cluster, the certificate is located at
+   /opt/conjur/etc/ssl/cert/tls.crt in the nginx container in the conjur server pod.
+   OpenSSL may need to be installed in the container.
+
+   For example:
+
+   ```
+   kubectl exec -it conjur-oss-7ddbb984c9-j96nb  -- bash -c "apt-get update;apt-get install openssl;openssl x509 -fingerprint -noout -in /opt/conjur/etc/ssl/cert/tls.crt"
    ```
 
 1. Create a Namespace for the authn-k8s authenticator.


### PR DESCRIPTION

### What does this PR do?
This add a fingerprint check to the get-conjur-cert script and asks
the user if they trust the cert. The user is asked to validate the fingerprint
by logging into the conjur server and getting the fingerprint there also.

The process for getting the fingerprint is longer in a Kubernetes
cluster, so in that case the script refers back to the README.

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]
Works towards #297 


### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
