### PR TITLE
Update rh base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-authn-k8s-client#134](https://github.com/cyberark/conjur-authn-k8s-client/issues/134)
 - Errors in the certificate injection process on login are now printed to the client logs.
   [cyberark/conjur-authn-k8s-client#/170](https://github.com/cyberark/conjur-authn-k8s-client/issues/170)
+- Support for OpenShift 4.7 has been certified as of this release.
 
 ### Changed
 - Detailed logs moved from Info to Debug log level to decrease verbosity of log messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `CAKC048` log message now shows the release version for release builds
   and no longer includes the git commit hash in the log output.
   [cyberark/conjur-authn-k8s-client#196](https://github.com/cyberark/conjur-authn-k8s-client/issues/196)
+- RH base image is now `ubi8/ubi` instead of `rhel7/rhel`.
 
 ## [0.19.1] - 2021-02-08
 ### Changed
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Support for OpenShift 4.6 was certified as of this release.
+- Support for OpenShift 4.7 was certified as of this release.
 
 ## [0.19.0] - 2020-10-08
 ### Added
@@ -43,7 +45,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-authn-k8s-client#134](https://github.com/cyberark/conjur-authn-k8s-client/issues/134)
 - Errors in the certificate injection process on login are now printed to the client logs.
   [cyberark/conjur-authn-k8s-client#/170](https://github.com/cyberark/conjur-authn-k8s-client/issues/170)
-- Support for OpenShift 4.7 has been certified as of this release.
 
 ### Changed
 - Detailed logs moved from Info to Debug log level to decrease verbosity of log messages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ COPY --from=authenticator-client-builder /opt/conjur-authn-k8s-client/authentica
 ENTRYPOINT [ "/usr/local/bin/authenticator" ]
 
 # =================== MAIN CONTAINER (REDHAT) ===================
-FROM registry.access.redhat.com/rhel as authenticator-client-redhat
+FROM registry.access.redhat.com/ubi8/ubi as authenticator-client-redhat
 MAINTAINER CyberArk Software Ltd.
 
     # Add Limited user


### PR DESCRIPTION
### What does this PR do?
- Adds note to CHANGELOG about OCP 4.7 support
- Changes base image to `ubi8/ubi`

The `rhel7/rhel` base image we've been using has a [CVE](https://access.redhat.com/security/cve/cve-2021-27219) and no updated image in sight. 

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
