### PR TITLE
Add `secrets-provider-init` sample app Helm chart

### DIFF
--- a/bin/test-workflow/7_app_deploy_backend.sh
+++ b/bin/test-workflow/7_app_deploy_backend.sh
@@ -11,11 +11,11 @@ source utils.sh
 check_env_var TEST_APP_NAMESPACE_NAME
 check_env_var SAMPLE_APP_BACKEND_DB_PASSWORD
 
-announce "Deploying summon-sidecar test app postgres backend for $TEST_APP_NAMESPACE_NAME."
+announce "Deploying test app postgres backend for $TEST_APP_NAMESPACE_NAME."
 
 set_namespace $TEST_APP_NAMESPACE_NAME
 
-app_name="app-summon-sidecar-backend-pg"
+app_name="app-backend-pg"
 
 # Uninstall backend if it exists so any PVCs can be deleted
 if [ "$(helm list -q -n $TEST_APP_NAMESPACE_NAME | grep "^$app_name$")" = "$app_name" ]; then
@@ -43,7 +43,7 @@ helm install $app_name bitnami/postgresql -n $TEST_APP_NAMESPACE_NAME --debug --
     --set image.tag="9.6" \
     --set postgresqlDataDir="/data/pgdata" \
     --set persistence.mountPath="/data/" \
-    --set fullnameOverride="test-summon-sidecar-app-backend" \
+    --set fullnameOverride="test-app-backend" \
     --set tls.enabled=true \
     --set volumePermissions.enabled=true \
     --set tls.certificatesSecret="test-app-backend-certs" \

--- a/bin/test-workflow/policy/app-access.yml
+++ b/bin/test-workflow/policy/app-access.yml
@@ -50,3 +50,20 @@
       role: !layer /test-app
       privileges: [ read, execute ]
       resources: *secretless-variables
+
+- !policy
+  id: test-secrets-provider-init-app-db
+  owner: !group developer
+  annotations:
+    description: This policy contains the creds to access the secrets provider app DB
+
+  body:
+    - &secrets-provider-init-variables
+      - !variable password
+      - !variable url
+      - !variable username
+
+    - !permit
+      role: !layer /test-app
+      privileges: [ read, execute ]
+      resources: *secrets-provider-init-variables

--- a/bin/test-workflow/policy/load_policies.sh
+++ b/bin/test-workflow/policy/load_policies.sh
@@ -33,6 +33,7 @@ readonly APPS=(
   "test-summon-init-app"
   "test-summon-sidecar-app"
   "test-secretless-app"
+  "test-secrets-provider-init-app"
 )
 
 for app_name in "${APPS[@]}"; do
@@ -54,7 +55,7 @@ for app_name in "${APPS[@]}"; do
     exit 1
     ;;
   esac
-  db_host="$app_name-backend.$TEST_APP_NAMESPACE_NAME.svc.cluster.local"
+  db_host="test-app-backend.$TEST_APP_NAMESPACE_NAME.svc.cluster.local"
   db_address="$db_host:$PORT"
 
   if [[ "$app_name" = "test-secretless-app" ]]; then

--- a/bin/test-workflow/policy/templates/project-authn-def.template.yml
+++ b/bin/test-workflow/policy/templates/project-authn-def.template.yml
@@ -36,6 +36,14 @@
         authn-k8s/deployment: test-app-secretless
         authn-k8s/authentication-container-name: secretless
         kubernetes: "{{ IS_KUBERNETES }}"
+    - !host
+      id: test-app-secrets-provider-init
+      annotations:
+        authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+        authn-k8s/service-account: test-app-secrets-provider-init
+        authn-k8s/deployment: test-app-secrets-provider-init
+        authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
+        kubernetes: "{{ IS_KUBERNETES }}"
 
     - !host
       id: oc-test-app-summon-sidecar

--- a/helm/conjur-app-deploy/Chart.yaml
+++ b/helm/conjur-app-deploy/Chart.yaml
@@ -20,3 +20,7 @@ dependencies:
       repository: "file://charts/app-summon-sidecar"
       version: ">= 0.0.1"
       condition: app-summon-sidecar.enabled
+    - name: app-secrets-provider-init
+      repository: "file://charts/app-secrets-provider-init"
+      version: ">= 0.0.1"
+      condition: app-secrets-provider-init.enabled

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/Chart.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: app-secrets-provider-init
+home: https://www.conjur.org
+version: 0.1.0
+description: A Helm chart deploying an application with a Secrets Provider init container
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
+keywords:
+  - security
+  - "secrets management"
+sources:
+  - https://github.com/cyberark/conjur-authn-k8s-client
+  - https://github.com/cyberark/secrets-provider-for-k8s
+  - https://github.com/cyberark/conjur-oss-helm-chart
+  - https://github.com/cyberark/conjur
+maintainers:
+  - name: Conjur Maintainers
+    email: conj_maintainers@cyberark.com

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/README.md
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/README.md
@@ -1,0 +1,2 @@
+# Helm Chart to Deploy an Application that uses a Secrets Provider for K8S init container
+

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/NOTES.txt
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/NOTES.txt
@@ -1,0 +1,8 @@
+The Application deployment is complete.
+The following have been deployed:
+{{ if .Values.conjur.authnConfigMap.create }}
+- A Conjur authentication configmap
+{{ end }}
+- A sample application with a Secrets Provider init container
+
+Application is now available at test-app-secrets-provider-init.{{ .Release.Namespace }}.svc.cluster.local

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/conjur_authn_configmap.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/conjur_authn_configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.conjur.authnConfigMap.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: {{ .Values.conjur.authnConfigMap.name }}
+    labels:
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      app.kubernetes.io/name: "conjur-authn-configmap"
+      app.kubernetes.io/component: "conjur-authn-config"
+      app.kubernetes.io/instance: "conjur-{{ .Chart.Name }}-configmap"
+      app.kubernetes.io/part-of: "conjur-app-config"
+      conjur.org/name: "conjur-authn-configmap"
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+data:
+    # authn-k8s Configuration 
+    conjurAuthnLogin: {{ required "A valid conjur.authnLogin is required!" .Values.conjur.authnLogin }}
+{{- end }}

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/rbac.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-app-secrets-provider-init-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-app-secrets-provider-init-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: test-app-secrets-provider-init
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: test-app-secrets-provider-init-role
+  apiGroup: ""

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/secret.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-app-secrets-provider-init-secret
+type: Opaque
+stringData:
+  conjur-map: |-
+    DB_URL: test-secrets-provider-init-app-db/url
+    DB_USERNAME: test-secrets-provider-init-app-db/username
+    DB_PASSWORD: test-secrets-provider-init-app-db/password

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-secrets-provider-init
+  labels:
+    app: test-app-secrets-provider-init
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: test-app-secrets-provider-init
+  type: {{ .Values.global.appServiceType }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-app-secrets-provider-init
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app-secrets-provider-init
+  name: test-app-secrets-provider-init
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-secrets-provider-init
+  template:
+    metadata:
+      labels:
+        app: test-app-secrets-provider-init
+    spec:
+      serviceAccountName: test-app-secrets-provider-init
+      containers:
+      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
+        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+        name: test-app
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /pets
+            port: http
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        env:
+          - name: DB_URL
+            valueFrom:
+              secretKeyRef:
+                name: test-app-secrets-provider-init-secret
+                key: DB_URL
+          - name: DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: test-app-secrets-provider-init-secret
+                key: DB_USERNAME
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-app-secrets-provider-init-secret
+                key: DB_PASSWORD
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+      initContainers:
+      - image: {{ printf "%s:%s" .Values.secretsProvider.image.repository .Values.secretsProvider.image.tag }}
+        imagePullPolicy: {{ .Values.secretsProvider.image.pullPolicy }}
+        name: cyberark-secrets-provider-for-k8s
+        env:
+          - name: CONTAINER_MODE
+            value: init
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: K8S_SECRETS
+            value: test-app-secrets-provider-init-secret
+          - name: SECRETS_DESTINATION
+            value: k8s_secrets
+          - name: DEBUG
+            value: "true"
+          - name: CONJUR_AUTHN_LOGIN
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Values.conjur.authnConfigMap.name }}
+                key: conjurAuthnLogin
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+      imagePullSecrets:
+        - name: dockerpullsecret

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/values.yaml
@@ -1,0 +1,23 @@
+# Default values for the Application Namespace Prep Helm chart
+# This is a YAML-formatted file.
+
+app:
+  image:
+    repository: "cyberark/demo-app"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+ 
+secretsProvider:
+  image:
+    repository: "cyberark/secrets-provider-for-k8s"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+
+conjur:
+  authnConfigMap:
+    create: true
+    name: "conjur-authn-configmap"
+  # host/conjur/authn-k8s/<authenticator-ID>/<conjur-policy-layer-or-group>/<app-host-id>
+  authnLogin:

--- a/helm/conjur-app-deploy/values.yaml
+++ b/helm/conjur-app-deploy/values.yaml
@@ -11,16 +11,18 @@ global:
 # Authenticator types to deploy and test. Multiple authenticator types
 # can be selected. All enabled authenticator types (along with their
 # associated sample application container) will be deployed to the
-# same application Namespace. The default (app-summon-sidecar) is to enable only an authn-k8s
-# sidecar container. Enable authenticator types as desired.
-app-summon-sidecar:
-  enabled: true
-
+# same application Namespace. Enable authenticator types as desired.
 app-summon-init:
+  enabled: false
+
+app-summon-sidecar:
   enabled: false
 
 app-secretless-broker:
   enabled: false
 
-app-secrets-provider:
+app-secrets-provider-init:
+  enabled: false
+
+app-secrets-provider-standalone:
   enabled: false


### PR DESCRIPTION
### What does this PR do?

A Helm subchart is added to the app deployment Helm chart for deploying an application + Secrets Provider init container.
* Helm values.yaml created for app subchart
* Helm manifest templates created for application + Secrets Provider sidecar
    - ConfigMap (containing `conjur.authnLogin`),
    - ServiceAccount
    - Secret (updated by Secrets Provider)
    - Role (get + update Secret)
    - RoleBinding (bind ServiceAccount to Role)
* Helm chart successfully deploys (application + Secrets Provider init container)
* Helm chart includes a templates/NOTES.txt that announces app/authenticator has been deployed
* E2E workflow test scripts modified to:
    - load Secrets Provider specific policies
    - use a single test app backend for each authenticator type

Test steps:
* Run E2E workflow by executing `bin/test-workflow/start` (installs and verifies `summon-sidecar` sample app)
* Change directory to `helm/conjur-app-deploy` and run the following command to install the `secrets-provider-init` sample app:
```
helm upgrade --install app-summon-sidecar . -n app-test --debug --wait \
    --set global.conjur.conjurConnConfigMap="conjur-connect" \
    --set app-secrets-provider-init.enabled=true \
    --set app-secrets-provider-init.conjur.authnLogin="host/conjur/authn-k8s/my-authenticator-id/apps/test-app-secrets-provider-init"
```

### What ticket does this PR close?
Resolves #272

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
