### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The client is configured entirely through environment variables. These are liste
 ### Using conjur-authn-k8s-client with Conjur Open Source 
 
 Are you using this project with [Conjur Open Source](https://github.com/cyberark/conjur)? Then we 
-**strongly** recommend choosing the version of this project to use from the latest [Conjur Open Source 
+**strongly** recommend choosing the version of this project to use from the latest [Conjur OSS 
 suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html). 
 Conjur maintainers perform additional testing on the suite release versions to ensure 
 compatibility. When possible, upgrade your Conjur version to match the 

--- a/bin/test-workflow/QUICKSTART.md
+++ b/bin/test-workflow/QUICKSTART.md
@@ -13,7 +13,7 @@ This guide will improve with updates to the end-to-end workflow scripts:
 
 At the end of this quickstart, you will have:
 
-* Deployed Conjur OSS to a KinD cluster
+* Deployed Conjur Open Source to a KinD cluster
 * Prepared the cluster with Conjur Config Cluster Prep Helm chart
 * Prepared and enabled the Kubernetes authenticator in Conjur
 * Prepared PetStore app namespace with Conjur NameSpace Prep Helm chart
@@ -28,23 +28,23 @@ At the end of this quickstart, you will have:
 
 # Steps
 
-### Prepare a Cluster and Deploy Conjur OSS
+### Prepare a Cluster and Deploy Conjur Open Source
 
 Preparing for the rest of the workflow requires:
 
 * Starting a KinD cluster with local Docker registry
 * Creating a new namespace for Conjur, `conjur-oss`
-* Deploying Conjur OSS with Helm
+* Deploying Conjur Open Source with Helm
 * Enable the Kubernetes Authenticator in Conjur
 
-The Conjur OSS Helm Chart is published on
+The Conjur Open Source Helm Chart is published on
 [GitHub](https://github.com/cyberark/conjur-oss-helm-chart).
 
-The Conjur OSS Helm Chart repository contains an [example]
+The Conjur Open Source Helm Chart repository contains an [example]
 (https://github.com/cyberark/conjur-oss-helm-chart/tree/main/examples/kubernetes-in-docker)
-folder with scripts and instructions for deploying the Conjur OSS Helm Chart on
+folder with scripts and instructions for deploying the Conjur Open Source Helm Chart on
 KinD. The scripts from the example folder are used to accomplish this step by
-git cloning the Conjur OSS Helm Chart repository and using them to carry out the
+git cloning the Conjur Open Source Helm Chart repository and using them to carry out the
 tasks mentioned above.
 
 To perform these steps, run:
@@ -99,7 +99,7 @@ Certificate authority initialized.
 ### Cluster Preparation
 
 In this step, the KinD cluster is prepared to enable applications to
-authenticate with Conjur OSS using:
+authenticate with Conjur Open Source using:
 
 * a "Golden" ConfigMap
 * an authenticator ClusterRole
@@ -130,7 +130,7 @@ directory.
 ### App Namespace Preparation
 
 In this step, a new namespace is created in the KinD cluster for the PetStore
-test app deployment, and it is prepared to authenticate with Conjur OSS using:
+test app deployment, and it is prepared to authenticate with Conjur Open Source using:
 
 * a Conjur connection ConfigMap
 * an authenticator RoleBinding
@@ -158,11 +158,11 @@ directory.
 
 At this point in the workflow:
 
-* Conjur OSS has been deployed to its own namespace
+* Conjur Open Source has been deployed to its own namespace
 * the `conjur-oss` namespace has been configured for Conjur Kubernetes
   authentication
 * an application namespace has been created and prepared for connecting to and
-  authenticating with Conjur OSS
+  authenticating with Conjur Open Source
 
 The following steps cover deploying the PetStore test app and the Conjur
 Kubernetes sidecar authenticator, and are performed by the Kubernetes Admin.

--- a/design/authenticator-client-for-container-platforms.md
+++ b/design/authenticator-client-for-container-platforms.md
@@ -92,7 +92,7 @@ by the Authenticator) it uses the certificate to authenticate, thereby obtaining
 **Note:** in the original design, we also proposed apply IP restrictions to the short-lived access token. This is not
 yet implemented. We also originally planned to have the Authenticator encrypt the access token using the client's
 private key (and have it implemented this way for Conjur Enterprise v4), but since the `authenticate` request is sent
-using mTLS for DAP v10+ and Conjur OSS v1+, we do not encrypt the access token for these versions.
+using mTLS for Conjur Enterprise (formerly DAP) v10+ and Conjur Open Source v1+, we do not encrypt the access token for these versions.
 
 ## Description
 
@@ -145,7 +145,7 @@ access token and sends the access token back to the client.
   have a short lifespan (minutes to hours); the default duration is 8 minutes.
 - In the original design (and in the Conjur Enterprise v4 implementation) the Conjur Authenticator encrypts the
   access token using the client certificate before returning it, and the client decrypts the access token upon
-  receipt. In the DAP v10+ and Conjur OSS v1+ implementations, the access token is returned over the encrypted
+  receipt. In the Conjur Enterprise (formerly DAP) v10+ and Conjur Open Source v1+ implementations, the access token is returned over the encrypted
   connection using the same process as the default authenticator.
 
 #### Authenticate flow

--- a/design/simple-client-configuration.md
+++ b/design/simple-client-configuration.md
@@ -38,7 +38,7 @@
 <td><a href="https://cyberark365.sharepoint.com/:w:/s/Conjur/EQnlgrc_aYZAhaZdR3oPSr0BsBoAtMnvyJuNDHGkOzokgw?e=sgrgBx">link</a> (private)</td>
 </tr>
 <tr class="odd">
-<td>Examples of Using Kubernetes with DAP</td>
+<td>Examples of Using Kubernetes with Conjur Enterprise</td>
 <td><a href="https://github.com/cyberark/dap-wiki/tree/master/how-to-guides/kubernetes">link</a> (private)</td>
 </tr>
 <tr class="even">
@@ -1019,7 +1019,7 @@ GKE 1.18.16</td>
 -   Conjur instance is available. Testing should support the following
     three configurations:
 
-    -   Conjur OSS in the Kubernetes cluster
+    -   Conjur Open Source in the Kubernetes cluster
 
     -   Conjur Enterprise master outside of Kubernetes cluster,
         followers inside the Kubernetes cluster
@@ -1329,7 +1329,7 @@ The overall workflow for this automated testing is:
 -   Create a Kubernetes cluster for testing. (This can be done using
     Kubernetes-in-Docker, a.k.a. KinD, in a GitHub action).
 
--   Create a Conjur instance. (This can be done using Conjur OSS Helm
+-   Create a Conjur instance. (This can be done using Conjur Open Source Helm
     chart).
 
 -   Generate and load Conjur policy for the authn-k8s authenticator.
@@ -1507,7 +1507,7 @@ The overall workflow for this testing is:
 <tr class="odd">
 <td>1</td>
 <td>Kubernetes</td>
-<td>Conjur OSS</td>
+<td>Conjur Open Source</td>
 <td>Application with Secrets Provider several types of authenticator containers can authenticate and retrieve secrets from Conjur.</td>
 <td></td>
 <td><ul>
@@ -1861,12 +1861,12 @@ conjur-authn-k8s-client</td>
 </tr>
 <tr class="even">
 <td>11</td>
-<td>Integration / E2E CI for Conjur OSS</td>
+<td>Integration / E2E CI for Conjur Open Source</td>
 <td>cyberark/<br />
 conjur-authn-k8s-client</td>
 <td><ul>
 <li><p>Can be either Jenkins+GKE or Github Actions + KinD</p></li>
-<li><p>Create script to Helm install Conjur OSS</p></li>
+<li><p>Create script to Helm install Conjur Open Source</p></li>
 <li><p>Run scripts from Task #5 above</p></li>
 </ul></td>
 <td></td>

--- a/design/templates/solution_design.md
+++ b/design/templates/solution_design.md
@@ -35,7 +35,7 @@
 [//]: # (Elaborate on whether your solution will affect the product's performance, and how)
 
 ### Affected Components
-[//]: # (Address the components that will be affected by your solution [Conjur, DAP, clients, integrations, etc.])
+[//]: # (Address the components that will be affected by your solution [Conjur, Conjur Enterprise, clients, integrations, etc.])
 
 ## Security
 [//]: # (Are there any security issues with your solution and how do you plan to mitigate them? Even if you mentioned them somewhere in the doc it may be convenient for the security architect review to have them centralized here)
@@ -62,7 +62,7 @@
 [//]: # (Does this solution require additional audit messages?)
 
 ## Documentation
-[//]: # (Add notes on what should be documented in this solution. Elaborate on where this should be documented. If the change is in open-source projects, we may need to update the docs in github too. If it's in Conjur and/or DAP mention which products are affected by it)
+[//]: # (Add notes on what should be documented in this solution. Elaborate on where this should be documented. If the change is in open-source projects, we may need to update the docs in github too. If it's in Conjur and/or Conjur Enterprise mention which products are affected by it)
 
 ## Open questions
 [//]: # (Add any question that is still open. It makes it easier for the reader to have the open questions accumulated here istead of them being acattered along the doc)

--- a/helm/conjur-config-cluster-prep/README.md
+++ b/helm/conjur-config-cluster-prep/README.md
@@ -67,7 +67,7 @@ The steps are as follows:
 
    - Conjur appliance URL:\
      The URL of the Conjur Enterprise Follower
-     or Conjur OSS server that will be used to authenticate your applications.
+     or Conjur Open Source server that will be used to authenticate your applications.
      The Conjur appliance URL could be an address that is either internal
      or external with respect to the Kubernetes cluster. Examples include:
      - https://conjur.example.com       (external address)
@@ -84,7 +84,7 @@ The steps are as follows:
    - __(OPTIONAL)__ Existing ServiceAccount to reuse for Conjur authentication:\
      If a Conjur-related ServiceAccount already exists in the Namespace
      to which you intend to deploy this Helm chart (for example, if
-     you're using the same Namespace to which Conjur OSS has been deployed,
+     you're using the same Namespace to which Conjur Open Source has been deployed,
      and you'd like to reuse the existing Conjur ServiceAccount), then you
      have the option of simply reusing that ServiceAccount.
 
@@ -387,7 +387,7 @@ can be found [here](assets/example-Conjur-policy-with-validator.md).
 
 ## Configuration
 
-The following table lists the configurable parameters of the Conjur OSS chart and their default values.
+The following table lists the configurable parameters of the Conjur Open Source chart and their default values.
 
 |Parameter|Description|Default|Mandatory|
 |---------|-----------|-------|---------|


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
