### PR TITLE
Fixes missing publish to DockerHub for new release tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,14 +91,10 @@ pipeline {
             }
         }
         stage('On a new tag') {
-          when {
-            allOf {
-              branch 'master'
-              tag "v*"
-            }
-          }
+          when { tag "v*" }
+
           steps {
-            sh 'summon ./bin/publish'
+            sh 'summon ./bin/publish --latest'
           }
         }
       }


### PR DESCRIPTION
### What does this PR do?

Currently, a conjur-authn-k8s-client image is not getting published
(pushed) to DockerHub when new Git tags have been added.
Example build log (for new tag v0.20.0):
https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur-authn-k8s-client/detail/v0.20.0/1/pipeline/156

The issue is that the Jenkinsfile is looking for not only a new tag (which is
correct), but also checking that the branch is `main` (which is incorrect...
the branch will be the version tag in this case, e.g. `v0.20.0`).

Also had to add a `--latest` argument in call to `bin/publish` because
this script is looking for `$1` positional parameter, and the
`bin/build_utils` script that it includes is setting the `-u` flag with `set -euo pipefail`.

### What ticket does this PR close?
Resolves #336

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
