### PR TITLE
Update Helm chart READMEs

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,22 @@
+# Conjur Kubernetes Authentication Helm Charts
+
+## Overview
+
+The Helm charts contained within this repository together aim to simplify the deployment of applications that use the Conjur Kubernetes authenticator. They do so primarily by leveraging Helm to create several Kubernetes resources allowing the following benefits to be realized:
+
+* The amount of copy/pasting of boilerplate configuration is drastically reduced; in particular, much of what is currently required to be added to CyberArk container definitions in Kubernetes manifests can be replaced by a reference to a common configuration `ConfigMap`.
+
+* The persona that is deploying each Conjur-enabled application does not need to know Conjur connection details.
+
+* Setting up the cluster for Conjur integration fails fast, so any potential misconfigurations are caught and highlighted early. Helm's input validation contributes to this.
+
+## Getting Started
+
+The Helm charts in this repository can be used with either the Enterprise or OSS versions of Conjur, and should be installed in the following order:
+
+1) `conjur-config-cluster-prep` ([README](conjur-config-cluster-prep/README.md))
+2) `conjur-config-namespace-prep` ([README](conjur-config-namespace-prep/README.md))
+
+To deploy a sample application:
+
+3) `conjur-app-deploy` ([README](conjur-app-deploy/README.md))

--- a/helm/README.md
+++ b/helm/README.md
@@ -4,9 +4,9 @@
 
 The Helm charts contained within this repository together aim to simplify the deployment of applications that use the Conjur Kubernetes authenticator. They do so primarily by leveraging Helm to create several Kubernetes resources allowing the following benefits to be realized:
 
-* The amount of copy/pasting of boilerplate configuration is drastically reduced; in particular, much of what is currently required to be added to CyberArk container definitions in Kubernetes manifests can be replaced by a reference to a common configuration `ConfigMap`.
+* The amount of copy/paste boilerplate for configuration is drastically reduced; in particular, much of what is currently required to be added to CyberArk container definitions in Kubernetes manifests can be replaced by a reference to a common configuration `ConfigMap`.
 
-* The persona that is deploying each Conjur-enabled application does not need to know Conjur connection details.
+* The Application or DevOps engineer who deploys each Conjur-enabled application does not need to know Conjur connection details.
 
 * Setting up the cluster for Conjur integration fails fast, so any potential misconfigurations are caught and highlighted early. Helm's input validation contributes to this.
 
@@ -17,6 +17,6 @@ The Helm charts in this repository can be used with either the Enterprise or OSS
 1) `conjur-config-cluster-prep` ([README](conjur-config-cluster-prep/README.md))
 2) `conjur-config-namespace-prep` ([README](conjur-config-namespace-prep/README.md))
 
-To deploy a sample application:
+Optionally, use the following to deploy a sample application:
 
 3) `conjur-app-deploy` ([README](conjur-app-deploy/README.md))

--- a/helm/conjur-config-cluster-prep/README.md
+++ b/helm/conjur-config-cluster-prep/README.md
@@ -8,7 +8,7 @@
 * [Preparing the Kubernetes Cluster for Conjur Authentication](#preparing-the-kubernetes-cluster-for-conjur-authentication)
 * [Examples: Running Helm Install](#examples-running-helm-install)
   + [Optional: Creating a Local Copy of This Helm Chart](#optional-creating-a-local-copy-of-this-helm-chart)
-  + [Optional: Deploying the Kubernetes resources specified by this chart without Helm](#optional-deploying-the-kubernetes-resources-specified-by-this-chart-without-helm)
+  + [Alternative: Creating K8s Resources with `kubectl` instead of Helm](#alternative-creating-k8s-resources-with-kubectl-instead-of-helm)
 * [Configuration](#configuration)
 
 ## Overview
@@ -296,9 +296,9 @@ command is run using a local copy of the Helm chart. You can use
   helm install my-conjur-release . -f my-custom-values.yaml 
   ```
 
-### Optional: Deploying the Kubernetes resources specified by this chart without Helm
+### Alternative: Creating K8s Resources with `kubectl` instead of Helm
 
-If Helm can not be used to deploy Kubernetes resources, the raw Kubernetes manifests can be generated ahead of time with the `helm template` command. Then the generated manifests can be applied with `kubectl`.
+If Helm can not be used to deploy Kubernetes resources, the raw Kubernetes manifests can instead be generated ahead of time with the `helm template` command. The generated manifests can then be applied with `kubectl`.
 
 ```
 helm template my-conjur-release . \

--- a/helm/conjur-config-cluster-prep/README.md
+++ b/helm/conjur-config-cluster-prep/README.md
@@ -4,9 +4,11 @@
 
 * [Overview](#overview)
   + [Objects Created](#objects-created)
+  + [Conjur Enterprise Documentation Reference](#conjur-enterprise-documentation-reference)
 * [Preparing the Kubernetes Cluster for Conjur Authentication](#preparing-the-kubernetes-cluster-for-conjur-authentication)
 * [Examples: Running Helm Install](#examples-running-helm-install)
   + [Optional: Creating a Local Copy of This Helm Chart](#optional-creating-a-local-copy-of-this-helm-chart)
+  + [Optional: Deploying the Kubernetes resources specified by this chart without Helm](#optional-deploying-the-kubernetes-resources-specified-by-this-chart-without-helm)
 * [Configuration](#configuration)
 
 ## Overview
@@ -52,6 +54,10 @@ include:
   This ClusterRole is used to provide a list of Kubernetes API access
   permissions that the Conjur authenticator will require in order to
   validate application identities.
+
+### Conjur Enterprise Documentation Reference
+
+Installation of this Helm chart replaces the manual creation of the Kubernetes resources outlined in [Step 5 of the Conjur Enterprise Kubernetes Authenticator Documentation](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Integrations/k8s-ocp/k8s-k8s-authn.htm). The `Namespace` for the authn-k8s authenticator is created as part of Step 3 of the [next section](#preparing-the-kubernetes-cluster-for-conjur-authentication).
 
 ## Preparing the Kubernetes Cluster for Conjur Authentication
 
@@ -289,6 +295,19 @@ command is run using a local copy of the Helm chart. You can use
 
   helm install my-conjur-release . -f my-custom-values.yaml 
   ```
+
+### Optional: Deploying the Kubernetes resources specified by this chart without Helm
+
+If Helm can not be used to deploy Kubernetes resources, the raw Kubernetes manifests can be generated ahead of time with the `helm template` command. Then the generated manifests can be applied with `kubectl`.
+
+```
+helm template my-conjur-release . \
+       --set conjur.applianceUrl="https://conjur.example.com" \
+       --set conjur.certificateFilePath="files/conjur-cert.pem" \
+       --set authnK8s.authenticatorID="my-authenticator-id" > conjur-config-cluster-prep.yaml
+
+kubectl apply -f conjur-config-cluster-prep.yaml
+```
 
 ## Running Helm Chart Tests
 

--- a/helm/conjur-config-namespace-prep/README.md
+++ b/helm/conjur-config-namespace-prep/README.md
@@ -30,6 +30,8 @@ ConfigMap and RoleBinding of its own. These objects will expose the credentials 
 environment variables and prepare for communication for any Kubernetes authenticators 
 in the given Conjur NameSpace. 
 
+<img alt="Prepare Namespace" src="https://user-images.githubusercontent.com/26872683/111843074-eae22480-88d6-11eb-9cc3-60b1ece9139b.png">
+
 ### Prerequisites
 
 - A running Conjur instance inside or outside of a Kubernetes cluster

--- a/helm/conjur-config-namespace-prep/README.md
+++ b/helm/conjur-config-namespace-prep/README.md
@@ -9,6 +9,7 @@
   * [Examples](#examples)
     + [Fresh Installation](#fresh-installation)
     + [Upgrading](#upgrading)
+    + [Alternative: Creating K8s Resources with `kubectl` instead of Helm](#alternative-creating-k8s-resources-with-kubectl-instead-of-helm)
   * [Issues with Helm "lookup"](#issues-with-helm-"lookup")
   * [Using the Conjur Connection ConfigMap in your application deployment manifest](#using-the-conjur-connection-configmap-in-your-application-deployment-manifest)
 
@@ -111,9 +112,9 @@ helm upgrade NameSpace-prep . -n "my-NameSpace" \
   --set authnK8s.NameSpace="new-NameSpace"
 ```
 
-### Optional: Deploying the Kubernetes resources specified by this chart without Helm
+### Alternative: Creating K8s Resources with `kubectl` instead of Helm
 
-If Helm can not be used to deploy Kubernetes resources, the raw Kubernetes manifests can be generated ahead of time with the `helm template` command. Then the generated manifests can be applied with `kubectl`.
+If Helm can not be used to deploy Kubernetes resources, the raw Kubernetes manifests can instead be generated ahead of time with the `helm template` command. The generated manifests can then be applied with `kubectl`.
 
 ```shell-session
 helm template NameSpace-prep . -n "my-NameSpace" \
@@ -133,7 +134,7 @@ supported by `--dry-run` or `lint`.
 
 ## Using the Conjur Connection ConfigMap in your application deployment manifest
 
-Edit the relevant `container` and/or `image` subsections of your application deployment manifest to include the Conjur Connection ConfigMap values as environment variables as in the example for the Kubernetes Authenticator Client below:
+In order to leverage the standardized `ConfigMap` containing Conjur connection details, it needs to be exposed as environment variables to the Kubernetes Authenticator Client. Edit the relevant `container` and/or `image` subsections of your application manifest to include the `ConfigMap` in the container environment, as seen in the example below:
 
 ```
 containers:
@@ -147,4 +148,4 @@ containers:
         name: conjur-connect
 ```
 
-Applications using Secrets Provider or Secretless can be modified similarly to make use of the `ConfigMap` values.
+Applications using [Secrets Provider](https://github.com/cyberark/secrets-provider-for-k8s) or [Secretless Broker](https://github.com/cyberark/secretless-broker) can be modified similarly to make use of the `ConfigMap` values.

--- a/helm/conjur-config-namespace-prep/README.md
+++ b/helm/conjur-config-namespace-prep/README.md
@@ -4,11 +4,13 @@
   * [Overview](#overview)
     + [Prerequisites](#prerequisites)
     + [Objects Created](#objects-created)
+    + [Conjur Enterprise Documentation Reference](#conjur-enterprise-documentation-reference)
   * [Configuration](#configuration)
   * [Examples](#examples)
     + [Fresh Installation](#fresh-installation)
     + [Upgrading](#upgrading)
   * [Issues with Helm "lookup"](#issues-with-helm-"lookup")
+  * [Using the Conjur Connection ConfigMap in your application deployment manifest](#using-the-conjur-connection-configmap-in-your-application-deployment-manifest)
 
 <!--
   Table of contents generated with markdown-toc
@@ -47,6 +49,10 @@ The per-Kubernetes-NameSpace resources created by this Helm chart include:
 
     The [Authenticator RoleBinding](templates/authenticator-RoleBinding.yml) 
     grants permissions to the Conjur Authenticator ServiceAccount for the Authn-Kubernetes ClusterRole, which provides a list of Kubernetes API access permissions. This is required to validate application identities.
+
+### Conjur Enterprise Documentation Reference
+
+Installation of this Helm chart replaces the manual creation of the Kubernetes resources outlined in [Steps 4 and 5 of the Conjur Enterprise Kubernetes Authenticator Documentation](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Integrations/k8s-ocp/cjr-k8s-authn-client.htm?tocpath=Integrations%7COpenShift%252FKubernetes%7CSet%20Up%20Applications%7C_____1#Setuptheapplicationtoretrievesecrets).
 
 ## Configuration
 
@@ -105,10 +111,40 @@ helm upgrade NameSpace-prep . -n "my-NameSpace" \
   --set authnK8s.NameSpace="new-NameSpace"
 ```
 
+### Optional: Deploying the Kubernetes resources specified by this chart without Helm
+
+If Helm can not be used to deploy Kubernetes resources, the raw Kubernetes manifests can be generated ahead of time with the `helm template` command. Then the generated manifests can be applied with `kubectl`.
+
+```shell-session
+helm template NameSpace-prep . -n "my-NameSpace" \
+  --set authnK8s.goldenConfigMap="conjur-configmap" \
+  --set authnK8s.NameSpace="default" > conjur-config-namespace-prep.yaml
+
+kubectl apply -f conjur-config-namespace-prep.yaml
+```
+
 ## Issues with Helm "lookup"
 
-When using `helm install -dry-run` or `helm lint`, you may notice that the
+When using `helm install --dry-run` or `helm lint`, you may notice that the
 outputted ConfigMap and RoleBinding do not contain the actual credentials
 that would be retrieved from your "Golden Configmap". This is due to the
 Helm `lookup` function, which retrieves Kubernetes objects and data, not being
 supported by `--dry-run` or `lint`.
+
+## Using the Conjur Connection ConfigMap in your application deployment manifest
+
+Edit the relevant `container` and/or `image` subsections of your application deployment manifest to include the Conjur Connection ConfigMap values as environment variables as in the example for the Kubernetes Authenticator Client below:
+
+```
+containers:
+- name: test-app
+  envFrom:
+    - configMapRef:
+        name: conjur-connect
+- image: cyberark/conjur-authn-k8s-client
+  envFrom:
+    - configMapRef:
+        name: conjur-connect
+```
+
+Applications using Secrets Provider or Secretless can be modified similarly to make use of the `ConfigMap` values.


### PR DESCRIPTION
### What does this PR do?
- Added base README to `helm/` directory root with an overview of motivation and links to chart-specific READMEs
- Added sections highlighting which parts of Conjur Enterprise docs these charts are meant to supersede
- Added instructions for pregenerating k8s manifests with `helm template` to be applied with later with `kubectl`
- Added a section to the namespace Helm chart README that explains how to include the Conjur Connection ConfigMap values as environment variables in Pods deployed by application deployment manifests

### What ticket does this PR close?
Resolves #332 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

