### PR TITLE
Bump version to 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.21.0] - 2021-06-25
+### Added
+- Introduces the `conjur-config-cluster-prep` and `conjur-config-namespace-prep` Helm charts.
+  Together these charts simplify the deployment of Conjur-authenticated applications as part of
+  the [Simplified Client Configuration](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/design/simple-client-configuration.md) feature.
+  [cyberark/conjur-authn-k8s-client#232](https://github.com/cyberark/conjur-authn-k8s-client/issues/232)
+  [cyberark/conjur-authn-k8s-client#249](https://github.com/cyberark/conjur-authn-k8s-client/issues/249)
+
 ## [0.20.0] - 2021-06-16
 ### Fixed
 - Fixes bug in error handling within the `VerifyFileExists` method that resulted in a
@@ -157,7 +165,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix an issue where sidecar fails when not run as root user.
 
-[Unreleased]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.18.1...v0.19.0

--- a/pkg/authenticator/version.go
+++ b/pkg/authenticator/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the authn-k8s-client
-var Version = "0.20.0"
+var Version = "0.21.0"
 
 // TagSuffix field denotes the specific build type for the client. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### What does this PR do?
This PR bumps the version to `0.21.0` for release.

### What ticket does this PR close?
Resolves #261
Resolves #319
### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [x] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
