### PR TITLE
Add GitHub Action which generates manifests from Helm charts

### DIFF
--- a/.github/workflows/helm-template-generate-k8s-manifests.yaml
+++ b/.github/workflows/helm-template-generate-k8s-manifests.yaml
@@ -1,0 +1,61 @@
+name: Generate K8S Manifests from Helm Charts
+
+on:
+  # Run this when PR operations are done
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
+
+jobs:
+  generate-k8s-manifests:
+    name: Generate K8S manifests via `helm template` command
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kube-tag:
+          - v1.21.3
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v1
+        with:
+          version: v1.21.3
+        id: install
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.6.2
+      
+      - name: Install Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Install yq
+        run: brew install yq
+
+      - name: Generate manifest for cluster-prep
+        run: bin/helm-generate-raw-manifest-cluster-prep.sh
+
+      - name: Generate manifest for namespace-prep
+        run: bin/helm-generate-raw-manifest-namespace-prep.sh
+
+      - name: Commit generated manifests
+        id: commit-generated-manifests
+        run: |
+          git add helm/conjur-config-cluster-prep/generated
+          git add helm/conjur-config-namespace-prep/generated
+          git commit -m "Auto-commit of K8S manifests generated from Helm charts"
+        continue-on-error: true
+
+      - name: Push files
+        if: steps.commit-generated-manifests.outcome == 'success'
+        run: |
+          git push --force "https://${{ github.actor }}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git" "HEAD:$GITHUB_HEAD_REF"

--- a/.github/workflows/release-upload-raw-k8s-manifests.yaml
+++ b/.github/workflows/release-upload-raw-k8s-manifests.yaml
@@ -1,0 +1,22 @@
+name: Upload Raw K8S Manifests as Release Artifacts
+
+on:
+  # Run this on tagged releases
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            helm/conjur-config-cluster-prep/generated/*.yaml
+            helm/conjur-config-namespace-prep/generated/*.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/helm-generate-raw-manifest-cluster-prep.sh
+++ b/bin/helm-generate-raw-manifest-cluster-prep.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+pushd helm/conjur-config-cluster-prep > /dev/null
+    mkdir -p generated
+
+    helm template cluster-prep . \
+        -f sample-values.yaml \
+        --render-subchart-notes \
+        --skip-tests > generated/conjur-config-cluster-prep.yaml
+
+    yq eval -i \
+        'del(.data.conjurSslCertificateBase64)' \
+        generated/conjur-config-cluster-prep.yaml
+
+popd > /dev/null

--- a/bin/helm-generate-raw-manifest-namespace-prep.sh
+++ b/bin/helm-generate-raw-manifest-namespace-prep.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+pushd helm/conjur-config-namespace-prep > /dev/null
+    mkdir -p generated
+
+    helm template namespace-prep . \
+        -f sample-values.yaml \
+        --render-subchart-notes \
+        --skip-tests | tee generated/conjur-config-namespace-prep.yaml
+popd > /dev/null

--- a/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
+++ b/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
@@ -1,0 +1,74 @@
+---
+# Source: conjur-config-cluster-prep/templates/serviceaccount.yaml
+# This ServiceAccount provides the Kubernetes RBAC identity for the Conjur Kubernetes authenticator
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: conjur-serviceaccount
+  labels:
+    release: cluster-prep
+    heritage: Helm
+    app.kubernetes.io/name: "conjur-serviceaccount"
+    app.kubernetes.io/component: "conjur-kubernetes-identity"
+    app.kubernetes.io/instance: "conjur-serviceaccount"
+    app.kubernetes.io/part-of: "conjur-config"
+    conjur.org/name: "conjur-serviceaccount"
+    helm.sh/chart: conjur-config-cluster-prep-0.1.0
+---
+# Source: conjur-config-cluster-prep/templates/golden_configmap.yaml
+# The Golden ConfigMap keeps a reference copy of Conjur configuration information
+# that will be used for subsequent operations such as preparing application Namespaces
+# for using Conjur Kubernetes authentication.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: conjur-configmap
+  labels:
+    release: cluster-prep
+    heritage: Helm
+    app.kubernetes.io/name: "conjur-golden-configmap"
+    app.kubernetes.io/component: "conjur-reference-config"
+    app.kubernetes.io/instance: "conjur-golden-configmap"
+    app.kubernetes.io/part-of: "conjur-config"
+    conjur.org/name: "conjur-golden-configmap"
+    helm.sh/chart: conjur-config-cluster-prep-0.1.0
+data:
+  # authn-k8s Configuration 
+  authnK8sAuthenticatorID: <Insert-Authenticator-ID-Here>
+  authnK8sClusterRole: conjur-clusterrole
+  authnK8sNamespace: default
+  authnK8sServiceAccount: conjur-serviceaccount
+  # Conjur Configuration 
+  conjurAccount: <Insert-Conjur-Account-Here>
+  conjurApplianceUrl: https://insert.conjur.appliance.url.here
+  conjurSslCertificate: "<Insert-Conjur-SSL-Certificate-Here>"
+---
+# Source: conjur-config-cluster-prep/templates/clusterrole.yaml
+# This ClusterRole defines the Kubernetes API access permissions that the Conjur
+# authenticator will require in order to validate application identities.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: conjur-clusterrole
+  labels:
+    release: cluster-prep
+    heritage: Helm
+    app.kubernetes.io/name: "conjur-clusterrole"
+    app.kubernetes.io/component: "conjur-permissions"
+    app.kubernetes.io/instance: "conjur-clusterrole"
+    app.kubernetes.io/part-of: "conjur-config"
+    conjur.org/name: "conjur-clusterrole"
+    helm.sh/chart: conjur-config-cluster-prep-0.1.0
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["pods", "serviceaccounts"]
+    verbs: ["get", "list"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "replicasets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]

--- a/helm/conjur-config-cluster-prep/sample-values.yaml
+++ b/helm/conjur-config-cluster-prep/sample-values.yaml
@@ -1,0 +1,11 @@
+# User-supplied values for the conjur-config-cluster-prep Helm chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+conjur:
+  account: "<Insert-Conjur-Account-Here>"
+  applianceUrl: "https://insert.conjur.appliance.url.here"
+  certificateBase64: "PEluc2VydC1Db25qdXItU1NMLUNlcnRpZmljYXRlLUhlcmU+"
+
+authnK8s:
+  authenticatorID: "<Insert-Authenticator-ID-Here>"

--- a/helm/conjur-config-cluster-prep/templates/tests/test-cluster-prep-configmap.yaml
+++ b/helm/conjur-config-cluster-prep/templates/tests/test-cluster-prep-configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-tests-configmap
+  annotations:
+    "helm.sh/hook": test
 
 data:
   helm-test.bats: |-

--- a/helm/conjur-config-cluster-prep/templates/tests/test-cluster-prep.yaml
+++ b/helm/conjur-config-cluster-prep/templates/tests/test-cluster-prep.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     "app": "cluster-prep-test"
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
   containers:
   {{- if .Values.test.authentication.enable }}

--- a/helm/conjur-config-namespace-prep/generated/conjur-config-namespace-prep.yaml
+++ b/helm/conjur-config-namespace-prep/generated/conjur-config-namespace-prep.yaml
@@ -1,0 +1,44 @@
+---
+# Source: conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
+# The Conjur Connection Configmap contains references to Conjur credentials,
+# taken from the "Golden Configmap". These can be used to enable Conjur
+# authentication for applications to retrieve secrets securely.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: conjur-connect
+  labels:
+    app.kubernetes.io/name: "conjur-connect-configmap"
+    app.kubernetes.io/instance: "conjur-default-configmap"
+    app.kubernetes.io/part-of: "conjur-config"
+    conjur.org/name: "conjur-connect-configmap"
+data:
+  CONJUR_ACCOUNT: <Insert-Conjur-Account-Here>
+  CONJUR_APPLIANCE_URL: https://insert.conjur.appliance.url.here
+  CONJUR_AUTHN_URL: https://insert.conjur.appliance.url.here/authn-k8s/<Insert-Authenticator-ID-Here>
+  CONJUR_SSL_CERTIFICATE: |- 
+    <Insert-Conjur-SSL-Certificate-Here>
+  CONJUR_AUTHENTICATOR_ID: <Insert-Authenticator-ID-Here>
+---
+# Source: conjur-config-namespace-prep/templates/authenticator_rolebinding.yaml
+# The Authenticator RoleBinding grants permissions to the Conjur Authenticator ServiceAccount
+# for the authenticator ClusterRole, which provides a list of Kubernetes API access permissions.
+# This is required to validate application identities.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conjur-rolebinding
+  labels: 
+    app.kubernetes.io/name: "conjur-rolebinding"
+    app.kubernetes.io/component: "conjur-namespace-access"
+    app.kubernetes.io/instance: "conjur-default-rolebinding"
+    app.kubernetes.io/part-of: "conjur-config"
+    conjur.org/name: "conjur-rolebinding"
+subjects:
+- kind: ServiceAccount
+  name: conjur-serviceaccount
+  namespace: conjur-oss
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: conjur-clusterrole

--- a/helm/conjur-config-namespace-prep/sample-values.yaml
+++ b/helm/conjur-config-namespace-prep/sample-values.yaml
@@ -1,0 +1,16 @@
+# User-supplied values for the conjur-config-namespace-prep Helm chart:
+# This is a YAML-formatted file:
+# Declare variables to be passed into your templates:
+
+authnK8s:
+  goldenConfigMap: "conjur-configmap"
+  namespace: "conjur-oss"
+test:
+  mock:
+    enable: true
+    conjurAccount: "<Insert-Conjur-Account-Here>"
+    conjurApplianceUrl: "https://insert.conjur.appliance.url.here"
+    conjurSslCertificate: "<Insert-Conjur-SSL-Certificate-Here>"
+    authnK8sAuthenticatorID: "<Insert-Authenticator-ID-Here>"
+    authnK8sClusterRole: "conjur-clusterrole"
+    authnK8sServiceAccount: "conjur-serviceaccount"

--- a/helm/conjur-config-namespace-prep/templates/authenticator_rolebinding.yaml
+++ b/helm/conjur-config-namespace-prep/templates/authenticator_rolebinding.yaml
@@ -2,7 +2,6 @@
 # The Authenticator RoleBinding grants permissions to the Conjur Authenticator ServiceAccount
 # for the authenticator ClusterRole, which provides a list of Kubernetes API access permissions.
 # This is required to validate application identities.
----
 {{ $config := required "Both authnK8s.namespace and authnK8s.configMap are required" .Values.authnK8s -}}
 
 {{ $g := .Values.test.mock -}}

--- a/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
+++ b/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
@@ -2,7 +2,6 @@
 # The Conjur Connection Configmap contains references to Conjur credentials,
 # taken from the "Golden Configmap". These can be used to enable Conjur
 # authentication for applications to retrieve secrets securely.
----
 {{ $config := required "Both authnK8s.namespace and authnK8s.configMap are required" .Values.authnK8s -}}
 
 {{ $g := .Values.test.mock -}}

--- a/helm/conjur-config-namespace-prep/templates/tests/test-namespace-prep-configmap.yaml
+++ b/helm/conjur-config-namespace-prep/templates/tests/test-namespace-prep-configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-tests-configmap
+  annotations:
+    "helm.sh/hook": test
 
 data:
   helm-test.bats: |-

--- a/helm/conjur-config-namespace-prep/templates/tests/test-namespace-prep.yaml
+++ b/helm/conjur-config-namespace-prep/templates/tests/test-namespace-prep.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-namespace-prep
+  annotations:
+    "helm.sh/hook": test
 ---
 apiVersion: v1
 kind: Pod
@@ -11,7 +13,7 @@ metadata:
   labels:
     "app": "namespace-prep-test"
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
   containers:
   {{- if .Values.test.authentication.enable }}


### PR DESCRIPTION
### What does this PR do?

Two new Github Actions added:
1) Auto-commit raw k8s manifests generated via `helm template` from `cluster-prep` and `namespace-prep` Helm charts
2) Upload raw manifests to tagged releases

### What ticket does this PR close?
Resolves #351 and #352

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
