### PR TITLE
Fixes broken E2E workflow scripts

### DIFF
--- a/bin/test-workflow/0_prep_conjur_in_kind.sh
+++ b/bin/test-workflow/0_prep_conjur_in_kind.sh
@@ -9,11 +9,11 @@ pushd temp > /dev/null
     rm -rf conjur-oss-helm-chart
     git clone https://github.com/cyberark/conjur-oss-helm-chart.git
 
-    pushd conjur-oss-helm-chart/examples/kubernetes-in-docker > /dev/null
-        source utils.sh
+    pushd conjur-oss-helm-chart/examples/common > /dev/null
+        source ./utils.sh
 
         announce "Setting demo environment variable defaults"
-        source ./0_export_env_vars.sh
+        source ../kubernetes-in-docker/0_export_env_vars.sh
 
         announce "Creating a Kubernetes-in-Docker cluster if necessary"
         ./1_create_kind_cluster.sh


### PR DESCRIPTION
### What does this PR do?

After a recent change ([PR # 154](https://github.com/cyberark/conjur-oss-helm-chart/pull/154)) to the Kubernetes-in-Docker example in the cyberark/conjur-oss-helm-chart repo, the GitHub actions tests that use the E2E workflow scripts started failing in CI.

The root cause is that the example scripts in the conjur-oss-helm-chart were reorganized to accommodate both a KinD example and an OpenShift example. So now the E2E workflow scripts are being modified to use the new script paths.

### What ticket does this PR close?
Resolves #356

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
