### PR TITLE
Improve E2E test cleanup

### DIFF
--- a/bin/test-workflow/0_prep_env.sh
+++ b/bin/test-workflow/0_prep_env.sh
@@ -4,6 +4,7 @@ set -o pipefail
 
 ### PLATFORM DETAILS
 export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
+export UNIQUE_TEST_ID="$(uuidgen | tr "[:upper:]" "[:lower:]" | head -c 10)"
 
 # PLATFORM is used to differentiate between general Kubernetes platforms (K8s vs. oc), while
 # CLUSTER_TYPE is used to differentiate between sub-platforms (for vanilla K8s, KinD vs. GKE)
@@ -11,7 +12,6 @@ if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   CLUSTER_TYPE="${CLUSTER_TYPE:-kind}"
 else
   CLUSTER_TYPE="${CLUSTER_TYPE:-gke}"
-  export UNIQUE_TEST_ID="$(uuidgen | tr "[:upper:]" "[:lower:]" | head -c 10)"
 fi
 export CLUSTER_TYPE
 

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -23,7 +23,7 @@ pushd ../../helm/conjur-config-cluster-prep > /dev/null
   if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
     ./bin/get-conjur-cert.sh -v -i -s -u "$CONJUR_APPLIANCE_URL"
 
-    helm upgrade --install cluster-prep . -n "$CONJUR_NAMESPACE_NAME" --debug --wait --timeout "$TIMEOUT" \
+    helm upgrade --install "cluster-prep-$UNIQUE_TEST_ID" . -n "$CONJUR_NAMESPACE_NAME" --debug --wait --timeout "$TIMEOUT" \
         --set conjur.account="$CONJUR_ACCOUNT" \
         --set conjur.applianceUrl="$CONJUR_APPLIANCE_URL" \
         --set conjur.certificateFilePath="files/conjur-cert.pem" \
@@ -31,12 +31,13 @@ pushd ../../helm/conjur-config-cluster-prep > /dev/null
   else
     ./bin/get-conjur-cert.sh -v -i -s -u "$CONJUR_FOLLOWER_URL"
 
-    helm upgrade --install cluster-prep . -n "$CONJUR_NAMESPACE_NAME" --debug --wait --timeout "$TIMEOUT" \
+    helm upgrade --install "cluster-prep-$UNIQUE_TEST_ID" . -n "$CONJUR_NAMESPACE_NAME" --debug --wait --timeout "$TIMEOUT" \
         --set conjur.account="$CONJUR_ACCOUNT" \
         --set conjur.applianceUrl="$CONJUR_FOLLOWER_URL" \
         --set conjur.certificateFilePath="files/conjur-cert.pem" \
         --set authnK8s.authenticatorID="$AUTHENTICATOR_ID" \
         --set authnK8s.serviceAccount.create=false \
-        --set authnK8s.serviceAccount.name="conjur-cluster"
+        --set authnK8s.serviceAccount.name="conjur-cluster" \
+        --set authnK8s.clusterRole.name="conjur-clusterrole-$UNIQUE_TEST_ID"
   fi
 popd > /dev/null

--- a/bin/test-workflow/5_app_namespace_prep.sh
+++ b/bin/test-workflow/5_app_namespace_prep.sh
@@ -16,7 +16,7 @@ set_namespace default
 announce "Installing namespace prep chart"
 pushd ../../helm/conjur-config-namespace-prep > /dev/null
     # Namespace $TEST_APP_NAMESPACE_NAME will be created if it does not exist
-    helm upgrade --install namespace-prep . -n "$TEST_APP_NAMESPACE_NAME" --debug --wait --timeout "$TIMEOUT" \
+    helm upgrade --install "namespace-prep-$UNIQUE_TEST_ID" . -n "$TEST_APP_NAMESPACE_NAME" --debug --wait --timeout "$TIMEOUT" \
         --create-namespace \
         --set authnK8s.goldenConfigMap="conjur-configmap" \
         --set authnK8s.namespace="$CONJUR_NAMESPACE_NAME"

--- a/bin/test-workflow/cleanup_helm.sh
+++ b/bin/test-workflow/cleanup_helm.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+helm uninstall "cluster-prep-$UNIQUE_TEST_ID" -n "$CONJUR_NAMESPACE_NAME"
+helm uninstall "namespace-prep-$UNIQUE_TEST_ID" -n "$TEST_APP_NAMESPACE_NAME"
+helm uninstall app-backend-pg -n "$TEST_APP_NAMESPACE_NAME"

--- a/bin/test-workflow/cleanup_namespaces.sh
+++ b/bin/test-workflow/cleanup_namespaces.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source ./utils.sh
+
+$cli delete namespace "$CONJUR_NAMESPACE_NAME"
+$cli delete namespace "$TEST_APP_NAMESPACE_NAME"

--- a/bin/test-workflow/stop
+++ b/bin/test-workflow/stop
@@ -4,14 +4,13 @@ set -uo pipefail
 source utils.sh
 
 if [[ "${CONJUR_OSS_HELM_INSTALLED}" == "true" ]]; then
-  $cli delete namespace "$CONJUR_NAMESPACE_NAME"
-  $cli delete namespace "$TEST_APP_NAMESPACE_NAME"
+  ./cleanup_helm.sh
+  ./cleanup_namespaces.sh
 else
   run_command_with_platform "
-    cd temp/kubernetes-conjur-deploy-$UNIQUE_TEST_ID &&
-    ./stop &&
-    $cli delete namespace $TEST_APP_NAMESPACE_NAME &&
-    $cli delete clusterrole conjur-clusterrole
+    ./cleanup_helm.sh
+    pushd temp/kubernetes-conjur-deploy-$UNIQUE_TEST_ID && ./stop && popd
+    ./cleanup_namespaces.sh
   "
   rm -rf temp/kubernetes-conjur-deploy-"$UNIQUE_TEST_ID"
 fi

--- a/bin/test-workflow/utils.sh
+++ b/bin/test-workflow/utils.sh
@@ -253,6 +253,7 @@ function run_command_with_platform {
     -e CONJUR_OSS_HELM_INSTALLED \
     -e PLATFORM \
     -e CLUSTER_TYPE \
+    -e UNIQUE_TEST_ID \
     -e USE_DOCKER_LOCAL_REGISTRY \
     -e DOCKER_REGISTRY_URL \
     -e DOCKER_REGISTRY_PATH \


### PR DESCRIPTION
### What does this PR do?
- Adds unique IDs to cluster and namespace prep helm charts
- Adds unique ID to cluster prep clusterrole
- In `stop` script, uses `helm uninstall` on cluster and namespace prep charts, to ensure all installed entities are removed

### What ticket does this PR close?
Doesn't close a ticket, but should resolve failing builds due to poor test teardown.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
