### PR TITLE
Downgrade pet store app to fix broken E2E workflow tests

### DIFF
--- a/bin/test-workflow/test_app_summon/Dockerfile
+++ b/bin/test-workflow/test_app_summon/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH="/usr/local/lib/summon:${PATH}"
 
 # ============= MAIN CONTAINER ============== #
 
-FROM cyberark/demo-app
+FROM cyberark/demo-app:1.1.0
 ARG namespace
 MAINTAINER CyberArk
 

--- a/bin/test-workflow/test_app_summon/Dockerfile.oc
+++ b/bin/test-workflow/test_app_summon/Dockerfile.oc
@@ -1,4 +1,4 @@
-FROM cyberark/demo-app
+FROM cyberark/demo-app:1.1.0
 ARG namespace
 MAINTAINER CyberArk
 

--- a/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
+++ b/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
@@ -43,6 +43,191 @@ data:
   conjurApplianceUrl: https://insert.conjur.appliance.url.here
   conjurSslCertificate: "<Insert-Conjur-SSL-Certificate-Here>"
 ---
+# Source: conjur-config-cluster-prep/templates/tests/test-cluster-prep-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-prep-tests-configmap
+data:
+  helm-test.bats: |-
+    #!/usr/bin/env bats
+
+    # Run out of same directory in which this script resides
+    cd "/tests"
+    source "./utils.sh"
+
+    source "/bats/bats-support/load.bash"
+    source "/bats/bats-assert/load.bash"
+    source "/bats/bats-file/load.bash"
+
+    readonly ACCESS_TOKEN_FILE="/run/conjur/access-token"
+    readonly AUTHN_LOG_FILE="/run/conjur/authn-logs.txt"
+    readonly TEMP_INFO_FILE="/info.txt"
+    readonly AUTHN_TIMEOUT_SECS=5
+
+    # Baseline BATS test result color
+    text_color "$MAGENTA"
+
+
+    ###################################################
+    #               Helper Functions                  #
+    ###################################################
+
+    function conjur_is_reachable() {
+      curl -s -k --connect-timeout 5 "$conjurApplianceUrl":443 >&2
+    }
+
+    function get_conjur_info() {
+      curl -s -k --connect-timeout 5 "$conjurApplianceUrl"/info
+    }
+
+    function has_authorization_error() {
+      echo $1 | grep -s -q "Authorization missing"
+    }
+
+    function conjur_access_token_exists() {
+      test -f "$ACCESS_TOKEN_FILE"
+    }
+
+    ###################################################
+    #  Validation Tests Not Requiring Authentication  #
+    ###################################################
+
+    @test "Conjur Appliance URL is a reachable address" {
+      display_info "Attempting to reach Conjur URL with 'curl -k ...'"
+      run conjur_is_reachable
+      if [ "$status" -ne 0 ]; then
+        display_error "The 'conjur.applianceUrl' chart value is set to\n" \
+                      "$conjurApplianceUrl. This is not reachable via 'curl -k'"
+      fi
+      assert_success
+    }
+
+    # If the Conjur instance supports an /info endpoint, then validate that one
+    # part of the Conjur config (e.g. Conjur account or authenticator ID) matches
+    # the corresponding field in the /info response.
+    #
+    # Syntax:
+    #   validate_info_endpoint_field <YAML path> <exp value> <desc> <chart value>
+    #
+    # Where arguments are:
+    #   <YAML path>:   YAML path to field in /info response,
+    #                  e.g. '.configuration.conjur.account'
+    #   <exp value>:   Value expected in /info response
+    #   <desc>:        Description of field
+    #   <chart value>: Corresponding Helm chart value, e.g. 'conjur.account'
+    #
+    function validate_info_endpoint_field() {
+      yaml_path=$1
+      expected_value=$2
+      description=$3
+      chart_value=$4
+
+      # First make sure that the Conjur URL is a reachable address
+      display_info "Checking whether Conjur URL is a reachable address."
+      run conjur_is_reachable
+      if [ "$status" -ne 0 ]; then
+        skip "test due to Conjur URL being unreachable."
+      fi
+
+      display_info "Conjur URL is reachable. Checking whether /info REST\n" \
+                   "endpoint is available at that address."
+      run get_conjur_info
+      if [ "$status" -ne 0 ] || (has_authorization_error "$output"); then
+        skip "test due to the /info REST endpoint being unavailable for Conjur OSS."
+      fi
+      conjur_info="$output"
+
+      display_info "The /info endpoint is available. Validating $description\n" \
+                   "($expected_value) based on /info content."
+      run yq eval "$yaml_path" <(echo "$conjur_info")
+      if [ "$output" != "$expected_value" ]; then
+        display_error "The '$chart_value' chart value is set to $expected_value.\n" \
+                      "This does not match the actual $description."
+      fi
+      assert_output "$expected_value"
+    }
+
+    @test "Conjur Account is valid" {
+      yaml_path=".configuration.conjur.account"
+      exp_value="$conjurAccount"
+      description="Conjur account"
+      chart_value="conjur.account"
+      validate_info_endpoint_field "$yaml_path" "$exp_value" "$description" "$chart_value"
+    }
+
+    @test "Conjur Authenticator ID is valid" {
+      yaml_path=".services.authn-k8s.name"
+      exp_value="$authnK8sAuthenticatorID"
+      description="Authenticator ID"
+      chart_value="authnK8s.authenticatorID"
+      validate_info_endpoint_field "$yaml_path" "$exp_value" "$description" "$chart_value"
+    }
+
+
+    ###################################################
+    #    Validation Tests Requiring Authentication    #
+    ###################################################
+  utils.sh: |-
+    #!/bin/bash
+
+    # Color codes for ANSI color escape squences
+    RESET_COLOR=0
+    RED=31
+    GREEN=32
+    NO_COLOR=33
+    BLUE=34
+    MAGENTA=35
+    CYAN=36
+
+    ANNOUNCE_COLOR="$BLUE"
+    ERROR_COLOR="$RED"
+    INFO_COLOR="$GREEN"
+    CODEBLOCK_COLOR="$BLUE"
+
+    function text_color() {
+      #
+      color_code="$1"
+      echo -e '\033[0;'"$color_code"'m'
+      #
+    }
+
+    function banner() {
+      text_color "$1"
+      shift
+      echo =====================================================================
+      echo -e "${@}"
+      echo =====================================================================
+      text_color "$RESET_COLOR"
+    }
+
+    function indented_banner() {
+      text_color "$1"
+      shift
+      echo "      --------------------------------------------------------------"
+      echo -e "      ${@}"
+      echo "      --------------------------------------------------------------"
+      text_color "$RESET_COLOR"
+    }
+
+    function announce() {
+      banner "$BLUE" "$@"
+    }
+
+    function display_error() {
+      banner "$RED" "$@"
+    }
+
+    function display_info() {
+      text_color "$INFO_COLOR"
+      echo -e "$@"
+      text_color "$RESET_COLOR"
+    }
+
+    function codeblock() {
+      indented_banner "$CODEBLOCK_COLOR" "$@"
+    }
+---
 # Source: conjur-config-cluster-prep/templates/clusterrole.yaml
 # This ClusterRole defines the Kubernetes API access permissions that the Conjur
 # authenticator will require in order to validate application identities.

--- a/helm/conjur-config-cluster-prep/templates/tests/test-cluster-prep-configmap.yaml
+++ b/helm/conjur-config-cluster-prep/templates/tests/test-cluster-prep-configmap.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-tests-configmap
-  annotations:
-    "helm.sh/hook": test
 
 data:
   helm-test.bats: |-

--- a/helm/conjur-config-namespace-prep/generated/conjur-config-namespace-prep.yaml
+++ b/helm/conjur-config-namespace-prep/generated/conjur-config-namespace-prep.yaml
@@ -1,4 +1,10 @@
 ---
+# Source: conjur-config-namespace-prep/templates/tests/test-namespace-prep.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-namespace-prep
+---
 # Source: conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
 # The Conjur Connection Configmap contains references to Conjur credentials,
 # taken from the "Golden Configmap". These can be used to enable Conjur
@@ -19,6 +25,193 @@ data:
   CONJUR_SSL_CERTIFICATE: |- 
     <Insert-Conjur-SSL-Certificate-Here>
   CONJUR_AUTHENTICATOR_ID: <Insert-Authenticator-ID-Here>
+---
+# Source: conjur-config-namespace-prep/templates/tests/test-namespace-prep-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: namespace-prep-tests-configmap
+
+data:
+  helm-test.bats: |-    
+    #!/usr/bin/env bats
+    
+    # Run out of same directory in which this script resides
+    cd "/tests"
+    source "./utils.sh"
+    
+    source "/bats/bats-support/load.bash"
+    source "/bats/bats-assert/load.bash"
+    source "/bats/bats-file/load.bash"
+    
+    readonly ACCESS_TOKEN_FILE="/run/conjur/access-token"
+    readonly AUTHN_LOG_FILE="/run/conjur/authn-logs.txt"
+    readonly TEMP_INFO_FILE="/info.txt"
+    readonly AUTHN_TIMEOUT_SECS=5
+    
+    # Baseline BATS test result color
+    text_color "$MAGENTA"
+    
+    
+    ###################################################
+    #               Helper Functions                  #
+    ###################################################
+    
+    function conjur_is_reachable() {
+      curl -s -k --connect-timeout 5 "$CONJUR_APPLIANCE_URL":443 >&2
+    }
+    
+    function get_conjur_info() {
+      curl -s -k --connect-timeout 5 "$CONJUR_APPLIANCE_URL"/info
+    }
+    
+    function has_authorization_error() {
+      echo "$1" | grep -s -q "Authorization missing"
+    }
+    
+    function conjur_access_token_exists() {
+      test -f "$ACCESS_TOKEN_FILE"
+    }
+    
+    ###################################################
+    #  Validation Tests Not Requiring Authentication  #
+    ###################################################
+    
+    @test "Conjur Appliance URL is a reachable address" {
+      display_info "Attempting to reach Conjur URL with 'curl -k ...'"
+      run conjur_is_reachable
+      if [ "$status" -ne 0 ]; then
+        display_error "The 'conjur.applianceUrl' chart value is set to\n" \
+                      "$CONJUR_APPLIANCE_URL. This is not reachable via 'curl -k'"
+      fi
+      assert_success
+    }
+    
+    # If the Conjur instance supports an /info endpoint, then validate that one
+    # part of the Conjur config (e.g. Conjur account or authenticator ID) matches
+    # the corresponding field in the /info response.
+    #
+    # Syntax:
+    #   validate_info_endpoint_field <YAML path> <exp value> <desc> <chart value>
+    #
+    # Where arguments are:
+    #   <YAML path>:   YAML path to field in /info response,
+    #                  e.g. '.configuration.conjur.account'
+    #   <exp value>:   Value expected in /info response
+    #   <desc>:        Description of field
+    #   <chart value>: Corresponding Helm chart value, e.g. 'conjur.account'
+    #
+    function validate_info_endpoint_field() {
+      yaml_path="$1"
+      expected_value="$2"
+      description="$3"
+      chart_value="$4"
+    
+      # First make sure that the Conjur URL is a reachable address
+      display_info "Checking whether Conjur URL is a reachable address."
+      run conjur_is_reachable
+      if [ "$status" -ne 0 ]; then
+        skip "test due to Conjur URL being unreachable."
+      fi
+    
+      display_info "Conjur URL is reachable. Checking whether /info REST\n" \
+                   "endpoint is available at that address."
+      run get_conjur_info
+      if [ "$status" -ne 0 ] || (has_authorization_error "$output"); then
+        skip "test due to the /info REST endpoint being unavailable for Conjur OSS."
+      fi
+      conjur_info="$output"
+    
+      display_info "The /info endpoint is available. Validating $description\n" \
+                   "($expected_value) based on /info content."
+      run yq eval "$yaml_path" <(echo "$conjur_info")
+      if [ "$output" != "$expected_value" ]; then
+        display_error "The '$chart_value' chart value is set to $expected_value.\n" \
+                      "This does not match the actual $description."
+      fi
+      assert_output "$expected_value"
+    }
+    
+    @test "Conjur Account is valid" {
+      yaml_path=".configuration.conjur.account"
+      exp_value="$CONJUR_ACCOUNT"
+      description="Conjur account"
+      chart_value="conjur.account"
+      validate_info_endpoint_field "$yaml_path" "$exp_value" "$description" "$chart_value"
+    }
+    
+    @test "Conjur Authenticator ID is valid" {
+      yaml_path=".services.authn-k8s.name"
+      exp_value="$CONJUR_AUTHENTICATOR_ID"
+      description="Authenticator ID"
+      chart_value="authnK8s.authenticatorID"
+      validate_info_endpoint_field "$yaml_path" "$exp_value" "$description" "$chart_value"
+    }
+    
+    
+    ###################################################
+    #    Validation Tests Requiring Authentication    #
+    ###################################################
+
+  utils.sh: |-    
+    #!/bin/bash
+    
+    # Color codes for ANSI color escape squences
+    RESET_COLOR=0
+    RED=31
+    GREEN=32
+    NO_COLOR=33
+    BLUE=34
+    MAGENTA=35
+    CYAN=36
+    
+    ANNOUNCE_COLOR="$BLUE"
+    ERROR_COLOR="$RED"
+    INFO_COLOR="$GREEN"
+    CODEBLOCK_COLOR="$BLUE"
+    
+    function text_color() {
+      #
+      color_code="$1"
+      echo -e '\033[0;'"$color_code"'m'
+      #
+    }
+    
+    function banner() {
+      text_color "$1"
+      shift
+      echo =====================================================================
+      echo -e "${@}"
+      echo =====================================================================
+      text_color "$RESET_COLOR"
+    }
+    
+    function indented_banner() {
+      text_color "$1"
+      shift
+      echo "      --------------------------------------------------------------"
+      echo -e "      ${@}"
+      echo "      --------------------------------------------------------------"
+      text_color "$RESET_COLOR"
+    }
+    
+    function announce() {
+      banner "$BLUE" "$@"
+    }
+    
+    function display_error() {
+      banner "$RED" "$@"
+    }
+    
+    function display_info() {
+      text_color "$INFO_COLOR"
+      echo -e "$@"
+      text_color "$RESET_COLOR"
+    }
+    
+    function codeblock() {
+      indented_banner "$CODEBLOCK_COLOR" "$@"
+    }
 ---
 # Source: conjur-config-namespace-prep/templates/authenticator_rolebinding.yaml
 # The Authenticator RoleBinding grants permissions to the Conjur Authenticator ServiceAccount

--- a/helm/conjur-config-namespace-prep/templates/tests/test-namespace-prep-configmap.yaml
+++ b/helm/conjur-config-namespace-prep/templates/tests/test-namespace-prep-configmap.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-tests-configmap
-  annotations:
-    "helm.sh/hook": test
 
 data:
   helm-test.bats: |-

--- a/helm/conjur-config-namespace-prep/templates/tests/test-namespace-prep.yaml
+++ b/helm/conjur-config-namespace-prep/templates/tests/test-namespace-prep.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-namespace-prep
-  annotations:
-    "helm.sh/hook": test
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
### What does this PR do?

The E2E workflow tests on KinD are currently failing after a recent
new release of the Pet Store demo app that includes 'summon' and
'summon-conjur' in the demo Docker image. The new Pet Store image is causing a
problem when the E2E workflow attempts to build its own Docker image
by also adding 'summon' and 'summon-conjur' to this image, causing a
conflict.

This change also includes a temporary fix for failures in the Helm test
validation CI. This is failing because there are Helm test hooks applied
to the test ConfigMaps. For some reason, Helm doesn't create the Helm
test ConfigMaps for 'helm test ...' when these hooks are present, so
these hooks are being backed out for now.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
