### PR TITLE
Add Helm subchart for test app w/ Secrets Provider in standalone mode

### DIFF
--- a/bin/test-helm-unit
+++ b/bin/test-helm-unit
@@ -13,35 +13,29 @@ function popd() {
 }
 
 pushd helm
-    pushd conjur-config-cluster-prep
-        ./test-lint
-        ./test-schema
-        ./test-unit
-    popd
-
-    pushd conjur-config-namespace-prep
-        ./test-lint
-        ./test-schema
-        ./test-unit
-    popd
+    declare -a prep_charts=("conjur-config-cluster-prep"
+                            "conjur-config-namespace-prep")
+    for chart in "${prep_charts[@]}"; do
+        pushd "$chart"
+            ./test-lint
+            ./test-schema
+            ./test-unit
+        popd
+    done
 
     pushd conjur-app-deploy
         ./test-lint
 
-        pushd charts/app-secretless-broker
-            ./test-schema
-            ./test-unit
-        popd
-
-        pushd charts/app-secrets-provider-init
-            ./test-schema
-            ./test-unit
-        popd
-
-        pushd charts/app-summon-sidecar
-            ./test-schema
-            ./test-unit
-        popd
+        declare -a subcharts=("app-summon-sidecar"
+                              "app-secretless-broker"
+                              "app-secrets-provider-init"
+                              "app-secrets-provider-standalone")
+        for subchart in "${subcharts[@]}"; do
+            pushd charts/"$subchart"
+                ./test-schema
+                ./test-unit
+            popd
+        done
 
     popd
 popd

--- a/helm/conjur-app-deploy/Chart.yaml
+++ b/helm/conjur-app-deploy/Chart.yaml
@@ -28,3 +28,7 @@ dependencies:
       repository: "file://charts/app-secretless-broker"
       version: ">= 0.0.1"
       condition: app-secretless-broker.enabled
+    - name: app-secrets-provider-standalone
+      repository: "file://charts/app-secrets-provider-standalone"
+      version: ">= 0.0.1"
+      condition: app-secrets-provider-standalone.enabled

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/test-schema
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/test-schema
@@ -71,17 +71,12 @@ function main() {
     app_image_repository_test "my-org/abc#123"
     update_results "$?" "$EXPECT_FAILURE"
 
-    announce "App image pullPolicy of 'Always' is accepted"
-    app_image_pull_policy_test "Always"
-    update_results "$?"
-
-    announce "App image pullPolicy of 'Never' is accepted"
-    app_image_pull_policy_test "Never"
-    update_results "$?"
-
-    announce "App image pullPolicy of 'IfNotPresent' is accepted"
-    app_image_pull_policy_test "Never"
-    update_results "$?"
+    declare -a pull_policy_types=("Always" "Never" "IfNotPresent")
+    for policy in "${pull_policy_types[@]}"; do
+        announce "App image pullPolicy of $policy is accepted"
+        app_image_pull_policy_test "$policy"
+        update_results "$?"
+    done
 
     announce "App image pullPolicy of lower case 'always' is rejected"
     app_image_pull_policy_test "always"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/Chart.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: app-secrets-provider-standalone
+home: https://www.conjur.org
+version: 0.1.0
+description: A Helm chart deploying an application that uses the Cyberark
+             Secrets Provider running as a standalone Kubernetes Job to
+             provide the application with Kubernetes Secrets containing
+             credentials retrieved from Conjur
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
+keywords:
+  - security
+  - "secrets management"
+sources:
+  - https://github.com/cyberark/conjur-authn-k8s-client
+  - https://github.com/cyberark/secrets-provider-for-k8s
+  - https://github.com/cyberark/conjur-oss-helm-chart
+  - https://github.com/cyberark/conjur
+maintainers:
+  - name: Conjur Maintainers
+    email: conj_maintainers@cyberark.com
+
+dependencies:
+  - name: secrets-provider
+    repository: "https://cyberark.github.io/helm-charts"
+    version: "1.1.5"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/README.md
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/README.md
@@ -1,0 +1,2 @@
+# Helm Chart to Deploy an Application that uses a Secrets Provider as a Standalone K8S Job
+

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/NOTES.txt
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/NOTES.txt
@@ -1,0 +1,9 @@
+The Application deployment is complete.
+The following have been deployed:
+- A sample "Pet Store" application that uses a Kubernetes Secret to configure
+  its backend database credentials.
+- A CyberArk Secrets Provider Job that, upon startup, updates the Kubernetes
+  Secret that is used by the "Pet Store" application with backend database
+  credentials that the Secrets Provider has retrieved from Conjur.
+
+Application is now available at test-app-secrets-provider-standalone.{{ .Release.Namespace }}.svc.cluster.local

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/secret.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-app-secrets-provider-standalone-secret
+type: Opaque
+stringData:
+  conjur-map: |-
+    DB_URL: test-secrets-provider-standalone-app-db/url
+    DB_USERNAME: test-secrets-provider-standalone-app-db/username
+    DB_PASSWORD: test-secrets-provider-standalone-app-db/password

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/test_app_secrets_provider_standalone.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/test_app_secrets_provider_standalone.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-secrets-provider-standalone
+  labels:
+    app: test-app-secrets-provider-standalone
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: test-app-secrets-provider-standalone
+  type: {{ .Values.global.appServiceType }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-app-secrets-provider-standalone
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app-secrets-provider-standalone
+  name: test-app-secrets-provider-standalone
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-secrets-provider-standalone
+  template:
+    metadata:
+      labels:
+        app: test-app-secrets-provider-standalone
+    spec:
+      serviceAccountName: test-app-secrets-provider-standalone
+      containers:
+      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
+        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+        name: test-app
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /pets
+            port: http
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        envFrom:
+        - secretRef:
+            name: test-app-secrets-provider-standalone-secret
+      {{- if eq .Values.app.platform "kubernetes" }}
+      imagePullSecrets:
+        - name: dockerpullsecret
+      {{- end }}

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/test-schema
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/test-schema
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# This script tests the restrictions on chart values
+# as defined in the 'values.schema.json' file.
+#
+# Requirements:
+#   - Helm v3.5.3 or later
+
+# Run this script from the directory in which this script resides
+# regardless of where it is invoked.
+cd "$(dirname "$0")"
+chart_dir="$(pwd)"
+
+source ../../../common/utils.sh
+
+# Default required settings
+declare -a DEFAULT_SETTINGS="--set secrets-provider.environment.conjur.authnLogin=host/conjur/authn-k8s/my-id/my-group/my-app \
+    --set secrets-provider.environment.conjur.conjurConnConfigMap=conjur-connect"
+
+# Global test state
+num_passed=0
+num_failed=0
+test_failed=false
+
+function global_app_service_type_test() {
+    helm lint . --strict $DEFAULT_SETTINGS --set "global.appServiceType=$1"
+}
+
+function app_image_repository_test() {
+    helm lint . --strict $DEFAULT_SETTINGS --set "app.image.repository=$1"
+}
+
+function app_image_pull_policy_test() {
+    helm lint . --strict $DEFAULT_SETTINGS --set "app.image.pullPolicy=$1"
+}
+
+function main() {
+    banner $BOLD "Running Helm schema tests for chart\n" \
+        "\"$chart_dir\""
+    check_helm_version
+
+    announce "Updating Helm dependencies to ensure that Secrets Provider\n" \
+        "Helm chart has been downloaded"
+    helm dependency update .
+
+    declare -a svc_types=("ClusterIP" "NodePort" "LoadBalancer" "ExternalName")
+    for type in "${svc_types[@]}"; do
+        announce "Application ServiceType of $type is accepted"
+        global_app_service_type_test "$type"
+        update_results "$?"
+    done
+
+    announce "Application ServiceType of nodePort (begins w/ lower case) is rejected"
+    global_app_service_type_test "nodePort"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Valid app image Docker repository accepted"
+    app_image_repository_test "my-org/abc_123"
+    update_results "$?"
+
+    announce "App image Docker repository with '#' is rejected"
+    app_image_repository_test "my-org/abc#123"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    declare -a pull_policy_types=("Always" "Never" "IfNotPresent")
+    for policy in "${pull_policy_types[@]}"; do
+        announce "App image pullPolicy of $policy is accepted"
+        app_image_pull_policy_test "$policy"
+        update_results "$?"
+    done
+
+    announce "App image pullPolicy of lower case 'always' is rejected"
+    app_image_pull_policy_test "always"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    display_final_results
+    if [ "$num_failed" -ne 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/test-unit
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/test-unit
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Runs a Helm unit test using the 'helm-unittest' Helm plugin.
+# Reference: https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md
+
+# Run this script from the directory in which this script resides
+# regardless of where it is invoked.
+cd "$(dirname "$0")"
+chart_dir="$(pwd)"
+
+source ../../../common/utils.sh
+
+banner $BOLD "Running Helm unit tests for chart \"$chart_dir\""
+run_helm_unittest

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/tests/test_app_secrets_provider_standalone_test.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/tests/test_app_secrets_provider_standalone_test.yaml
@@ -1,0 +1,67 @@
+suite: test test_app_secrets_provider_standalone
+
+templates:
+  - test_app_secrets_provider_standalone.yaml
+
+defaults: &defaultRequired
+  secrets-provider.environment.conjur.authnLogin: "host/conjur/authn-k8s/my-id/my-group/my-app"
+  secrets-provider.environment.conjur.conjurConnConfigMap: "conjur-connect"
+  secrets-provider.environment.k8sSecrets: ["my-app-secret"]
+
+tests:
+  #=======================================================================
+  - it: should use default values for Service 
+  #=======================================================================    
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+    documentIndex: 0
+
+    asserts:
+     - isKind:
+         of: Service
+
+     - equal:
+          path: spec.type
+          value: NodePort
+     - equal:
+          path: metadata.name
+          value:  test-app-secrets-provider-standalone          
+     - equal:
+          path: metadata.labels.app
+          value:  test-app-secrets-provider-standalone
+
+  #=======================================================================
+  - it: should create a ServiceAccount
+  #=======================================================================    
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+    documentIndex: 1
+
+    asserts:
+     - hasDocuments:
+          count: 3
+     - isKind:
+         of: ServiceAccount
+
+  #=======================================================================
+  - it: should use default values for Deployment 
+  #=======================================================================    
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+    documentIndex: 2
+
+    asserts:
+     - isKind:
+          of: Deployment
+     - equal:
+          path: spec.template.spec.containers[0].image
+          value: cyberark/demo-app:latest
+     - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/values.schema.json
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/values.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "properties": {
+    "app": {
+      "properties": {
+        "image": {
+          "properties": {
+            "repository": {
+              "type": "string",
+              "pattern": "^[a-z0-9:./_-]+$"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "pattern": "^(Always|Never|IfNotPresent)$"
+            }
+          }
+        }
+      }
+    },
+    "global": {
+      "properties": {
+        "appServiceType": {
+           "type": "string",
+           "pattern": "^(ClusterIP|NodePort|LoadBalancer|ExternalName)$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/values.yaml
@@ -1,0 +1,30 @@
+# Default values for the Application Namespace Prep Helm chart
+# This is a YAML-formatted file.
+
+global:
+  # Supported values: "ClusterIP", "NodePort", "LoadBalancer", "ExternalName"
+  appServiceType: "NodePort"
+  
+app:
+  image:
+    repository: "cyberark/demo-app"
+    tag: "latest"
+    # Supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+  platform: "kubernetes"
+
+secrets-provider:
+  environment:
+    conjur:
+      # conjurConnConfigMap must match the following parent chart's Global setting:
+      #      'global.conjur.conjurConnConfigMap'
+      conjurConnConfigMap: "conjur-connect"
+
+      # Set 'authnLogin' to the authentication host ID for this test app,
+      # as defined in Conjur security policy. For example:
+      #   authnLogin: "host/conjur/authn-k8s/my-authenticator-id/apps/test-app-secrets-provider-standalone"
+      # This is a required value.
+      #
+      # authnLogin:
+
+    k8sSecrets: ["test-app-secrets-provider-standalone-secret"]


### PR DESCRIPTION
### What does this PR do?

This change adds a Helm subchart to the `conjur-app-deploy` main Helm chart that can be used to deploy:
- A sample "Pet Store" application that uses a Kubernetes Secret to configure its backend database credentials
- A "standalone" Secrets Provider Job that, upon startup, updates the Kubernetes Secret that is used by the "Pet Store" application with backend database credentials that the Secrets Provider has retrieved from Conjur.

The deployment of the "standalone" Secrets Provider is done by using the Secrets Provider Helm chart as a [Helm chart dependency](https://helm.sh/docs/helm/helm_dependency/) of the `app-secrets-provider-standalone` subchart.

This change also includes Helm unittest test cases and Helm schema validation tests for the new subchart.

NOTE: Adding this Helm subchart to the E2E workflow scripts will be done with PR #380.

### What ticket does this PR close?
Resolves #273

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
