### PR TITLE
Upgrade Alpine to v3.14 to resolve CVE-2021-36159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- Upgrades Alpine to v3.14 to resolve CVE-2021-36159.
+  [cyberark/conjur-authn-k8s-client#374](https://github.com/cyberark/conjur-authn-k8s-client/issues/374)
 
 ## [0.21.0] - 2021-06-25
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN sh -c "go tool nm authenticator | grep '_Cfunc__goboringcrypto_' 1> /dev/nul
 FROM busybox
 
 # =================== MAIN CONTAINER ===================
-FROM alpine:latest as authenticator-client
+FROM alpine:3.14 as authenticator-client
 MAINTAINER CyberArk Software Ltd.
 
 # copy a few commands from busybox
@@ -124,7 +124,7 @@ LABEL description="The authentication client required to expose secrets from a C
 
 # =================== CONTAINER FOR HELM TEST ===================
 
-FROM alpine:3.12 as k8s-cluster-test
+FROM alpine:3.14 as k8s-cluster-test
 
 # Install packages for testing
 RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl

--- a/Dockerfile.helm-unit-test
+++ b/Dockerfile.helm-unit-test
@@ -1,6 +1,6 @@
 # =================== CONTAINER FOR HELM UNIT TEST ===================
 
-FROM alpine:3.12 as conjur-k8s-helm-unit-test
+FROM alpine:3.14 as conjur-k8s-helm-unit-test
 
 # Install packages for installing Helm and Helm unittest plugin
 RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl


### PR DESCRIPTION
### What does this PR do?

Upgrades the base Alpine image used for Helm test functionality for various Helm charts from `alpine:3.12` to `alpine:3.14` in order to resolve CVE-2021-36159.

Also included is a change of other Alpine base images from `alpine:latest` to `alpine:3.14` (the current `latest`), effectively pinning these images to the current latest, so that Alpine images used are consistent and not a moving target.

### What ticket does this PR close?
Resolves #374

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
