### PR TITLE
Add unittest and schema validation tests to Secretless app subchart

### DIFF
--- a/bin/test-helm-unit
+++ b/bin/test-helm-unit
@@ -28,6 +28,11 @@ pushd helm
     pushd conjur-app-deploy
         ./test-lint
 
+        pushd charts/app-secretless-broker
+            ./test-schema
+            ./test-unit
+        popd
+
         pushd charts/app-secrets-provider-init
             ./test-schema
             ./test-unit

--- a/helm/conjur-app-deploy/charts/app-secretless-broker/README.md
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker/README.md
@@ -1,0 +1,2 @@
+# Helm Chart to Deploy an Application that uses a Secretless Broker sidecar
+

--- a/helm/conjur-app-deploy/charts/app-secretless-broker/test-schema
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker/test-schema
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# This script tests the restrictions on chart values
+# as defined in the 'values.schema.json' file.
+#
+# Requirements:
+#   - Helm v3.5.3 or later
+
+# Run this script from the directory in which this script resides
+# regardless of where it is invoked.
+cd "$(dirname "$0")"
+chart_dir="$(pwd)"
+
+source ../../../common/utils.sh
+
+# Default required settings
+readonly DEFAULT_AUTHN_LOGIN="conjur.authnLogin=host/conjur/authn-k8s/my-id/my-group/my-app"
+
+# Global test state
+num_passed=0
+num_failed=0
+test_failed=false
+
+function global_conjur_conn_configmap_name_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "global.conjur.conjurConnConfigMap=$1"
+}
+
+function global_app_service_type_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "global.appServiceType=$1"
+}
+
+function app_image_repository_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "app.image.repository=$1"
+}
+
+function app_image_pull_policy_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "app.image.pullPolicy=$1"
+}
+
+function conjur_authn_configmap_name_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "conjur.authnConfigMap.name=$1"
+}
+
+function main() {
+    banner $BOLD "Running Helm schema tests for chart \"$chart_dir\""
+    check_helm_version
+
+    announce "Conjur Connect ConfigMap name with dashes is accepted"
+    global_conjur_conn_configmap_name_test "name-with-dashes"
+    update_results "$?"
+
+    announce "Conjur Connect ConfigMap name with dotted name is accepted"
+    global_conjur_conn_configmap_name_test "dotted.serviceaccount.name"
+    update_results "$?"
+
+    announce "Valid app image Docker repository accepted"
+    app_image_repository_test "my-org/abc_123"
+    update_results "$?"
+
+    announce "App image Docker repository with '%' is rejected"
+    app_image_repository_test "my-org/abc%123"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "App image pullPolicy of 'Always' is accepted"
+    app_image_pull_policy_test "Always"
+    update_results "$?"
+
+    announce "App image pullPolicy of 'Never' is accepted"
+    app_image_pull_policy_test "Never"
+    update_results "$?"
+
+    announce "App image pullPolicy of 'IfNotPresent' is accepted"
+    app_image_pull_policy_test "Never"
+    update_results "$?"
+
+    announce "App image pullPolicy of lower case 'always' is rejected"
+    app_image_pull_policy_test "always"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Conjur Authn ConfigMap name with underscores is rejected"
+    conjur_authn_configmap_name_test "name_with_underscores"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Conjur Authn ConfigMap name with upper case characters is rejected"
+    conjur_authn_configmap_name_test "NameWithUpperCase"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "Conjur Authn ConfigMap name with less than 253 characters is accepted"
+    conjur_authn_configmap_name_test "name-with-253-chars----------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130-------140-------150-------160-------170-------180-------190-------200-------210-------220-------230-------240-------250"
+    update_results "$?"
+
+    announce "ServiceAccount name with 253 characters is rejected"
+    conjur_authn_configmap_name_test "name-with-more-than-253-chars----------40--------50--------60--------70--------80--------90--------100-------110-------120--------130-------140-------150-------160-------170-------180-------190-------200-------210-------220-------230-------240-------2503"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    display_final_results
+    if [ "$num_failed" -ne 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/helm/conjur-app-deploy/charts/app-secretless-broker/test-unit
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker/test-unit
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Runs a Helm unit test using the 'helm-unittest' Helm plugin.
+# Reference: https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md
+
+# Run this script from the directory in which this script resides
+# regardless of where it is invoked.
+cd "$(dirname "$0")"
+chart_dir="$(pwd)"
+
+source ../../../common/utils.sh
+
+banner $BOLD "Running Helm unit tests for chart \"$chart_dir\""
+run_helm_unittest

--- a/helm/conjur-app-deploy/charts/app-secretless-broker/tests/conjur_authn_configmap_test.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker/tests/conjur_authn_configmap_test.yaml
@@ -1,0 +1,50 @@
+suite: test conjur_authn_configmap
+
+templates:
+  - conjur_authn_configmap.yaml
+
+defaults: &defaultRequired
+  conjur.authnLogin: "host/conjur/authn-k8s/my-authn-id/my-conjur-policy/my-host-id"
+
+tests:
+  #=======================================================================
+  - it: should not create a authnConfigMap if ConfigMap creation is disabled
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+      conjur.authnConfigMap.create: false
+    asserts:
+      - hasDocuments:
+          count: 0 
+
+  #=======================================================================
+  - it: should use default values when those values are not set explicitly
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+      
+    asserts:
+      # Confirm that a ConfigMap has been created
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+
+      # Confirm that default values have been used
+      - equal:
+          path: data.CONJUR_AUTHN_LOGIN
+          value: "host/conjur/authn-k8s/my-authn-id/my-conjur-policy/my-host-id"
+
+      - equal:
+          path: metadata.name
+          value: "conjur-authn-configmap"
+
+  #=======================================================================
+  - it: should fail if conjur.authnLogin is not set
+  #=======================================================================
+    set:
+    asserts:
+      - failedTemplate:
+          errorMessage: "A valid conjur.authnLogin is required!"

--- a/helm/conjur-app-deploy/charts/app-secretless-broker/tests/test_app_secretless_broker_test.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker/tests/test_app_secretless_broker_test.yaml
@@ -1,0 +1,68 @@
+suite: test test_app_secretless_broker
+
+templates:
+  - test_app_secretless_broker.yaml
+
+tests:
+  #=======================================================================
+  - it: should use default values for Service 
+  #=======================================================================    
+    set:
+
+    documentIndex: 0
+
+    asserts:
+     - isKind:
+         of: Service
+
+     - equal:
+          path: spec.type
+          value: NodePort
+     - equal:
+          path: metadata.name
+          value:  test-app-secretless-broker
+     - equal:
+          path: metadata.labels.app
+          value: test-app-secretless-broker
+
+  #=======================================================================
+  - it: should use default values for ServiceAccount
+  #=======================================================================    
+    set:
+
+    documentIndex: 1
+
+    asserts:
+     - hasDocuments:
+          count: 3
+     - isKind:
+         of: ServiceAccount
+
+  #=======================================================================
+  - it: should use default values for Deployment 
+  #=======================================================================    
+    set:
+
+    documentIndex: 2
+
+    asserts:
+     - isKind:
+          of: Deployment
+     - equal:
+          path: spec.template.spec.containers[0].image
+          value: "cyberark/demo-app:latest"
+     - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"
+     - equal:
+          path: spec.template.spec.containers[1].image
+          value: "cyberark/secretless-broker:latest"
+     - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: "Always"
+     - equal:
+          path: spec.template.spec.containers[1].envFrom[0].configMapRef.name
+          value: "conjur-authn-configmap"
+     - equal:
+          path: spec.template.spec.containers[1].envFrom[1].configMapRef.name
+          value: "conjur-connect"

--- a/helm/conjur-app-deploy/charts/app-secretless-broker/values.schema.json
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker/values.schema.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "properties": {
+      "app": {
+        "properties": {
+          "image": {
+            "properties": {
+              "repository": {
+                "type": "string",
+                "pattern": "^[a-z0-9:./_-]+$"
+              },
+              "tag": {
+                "type": "string"
+              },
+              "pullPolicy": {
+                "type": "string",
+                "pattern": "^(Always|Never|IfNotPresent)$"
+              }
+            }
+          }
+        }
+      },
+      "conjur": {
+        "properties": {
+          "authnConfigMap": {
+            "properties": {
+              "create": {
+                "type": "boolean"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "authnLogin": {
+            "type": "string"
+          }
+        }
+      },
+      "secretless": {
+        "properties": {
+          "image": {
+            "properties": {
+              "repository": {
+                "type": "string"
+              },
+              "tag": {
+                "type": "string"
+              },
+              "pullPolicy": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+}

--- a/helm/conjur-app-deploy/charts/app-secretless-broker/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker/values.yaml
@@ -5,7 +5,7 @@ global:
   conjur:
     # name of the ConfigMap created by the conjur-config-namespace-prep chart
     conjurConnConfigMap: "conjur-connect"
-  appServiceTpe: "NodePort"
+  appServiceType: "NodePort"
 
 app:
   image:


### PR DESCRIPTION
### What does this PR do?
Adds Helm unittest and schema validation tests to the recently added test app + Secretless Broker subchart.

### What ticket does this PR close?
Resolves #376

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
