### PR TITLE
Include Secrets Provider init app in E2E workflow

### DIFF
--- a/bin/test-workflow/0_prep_env.sh
+++ b/bin/test-workflow/0_prep_env.sh
@@ -47,7 +47,7 @@ export TEST_APP_NAMESPACE_NAME="${TEST_APP_NAMESPACE_NAME:-app-test}"
 export TEST_APP_DATABASE="${TEST_APP_DATABASE:-postgres}"
 export TEST_APP_REPO="${TEST_APP_REPO:-cyberark/demo-app}"
 export TEST_APP_TAG="${TEST_APP_TAG:-latest}"
-export INSTALL_APPS="${INSTALL_APPS:-summon-sidecar,secretless-broker}"
+export INSTALL_APPS="${INSTALL_APPS:-summon-sidecar,secretless-broker,secrets-provider-init}"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   conjur_service="conjur-oss"

--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -34,11 +34,16 @@ pushd ../../helm/conjur-app-deploy > /dev/null
     --set app-secrets-provider-standalone.app.image.tag="$TEST_APP_TAG" \
     --set app-secrets-provider-standalone.app.image.repository="$TEST_APP_REPO" \
     --set app-secrets-provider-standalone.app.platform=$PLATFORM"
+  secrets_provider_init_options="--set app-secrets-provider-init.enabled=true \
+    --set app-secrets-provider-init.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-init \
+    --set app-secrets-provider-init.conjur.authnConfigMap.name=conjur-authn-configmap-secrets-provider-init \
+    --set app-secrets-provider-init.app.platform=$PLATFORM"
 
   declare -A app_options
   app_options[summon-sidecar]="$summon_sidecar_options"
   app_options[secretless-broker]="$secretless_broker_options"
   app_options[secrets-provider-standalone]="$secrets_provider_standalone_options"
+  app_options[secrets-provider-init]="$secrets_provider_init_options"
 
   # restore array of apps to install
   declare -a install_apps=($(split_on_comma_delimiter $INSTALL_APPS))

--- a/bin/test-workflow/8_app_verify_authentication.sh
+++ b/bin/test-workflow/8_app_verify_authentication.sh
@@ -27,6 +27,7 @@ function finish {
     "INIT_WITH_HOST_OUTSIDE_APPS_PORT_FORWARD_PID"
     "SECRETLESS_PORT_FORWARD_PID"
     "SECRETS_PROVIDER_STANDALONE_PID"
+    "SECRETS_PROVIDER_INIT_PORT_FORWARD_PID"
   )
 
   # Upon error, dump some kubernetes resources and Conjur authentication policy
@@ -83,6 +84,7 @@ if [[ "$PLATFORM" == "openshift" ]]; then
   init_pod_with_host_outside_apps=$(get_pod_name test-app-with-host-outside-apps-branch-summon-init)
   secretless_pod=$(get_pod_name test-app-secretless)
   secrets_provider_standalone_pod=$(get_pod_name test-app-secrets-provider-standalone)
+  secrets_provider_init_pod=$(get_pod_name test-app-secrets-provider-init)
 
   # Routes are defined, but we need to do port-mapping to access them
   oc port-forward "$sidecar_pod" 8081:8080 > /dev/null 2>&1 &
@@ -95,6 +97,8 @@ if [[ "$PLATFORM" == "openshift" ]]; then
   SECRETS_PROVIDER_STANDALONE_PID=$!
   oc port-forward "$init_pod_with_host_outside_apps" 8085:8080 > /dev/null 2>&1 &
   INIT_WITH_HOST_OUTSIDE_APPS_PORT_FORWARD_PID=$!
+  oc port-forward "$secrets_provider_init_pod" 8086:8080 > /dev/null 2>&1 &
+  SECRETS_PROVIDER_INIT_PORT_FORWARD_PID=$!
 
   curl_cmd=curl
   sidecar_url="localhost:8081"
@@ -102,6 +106,7 @@ if [[ "$PLATFORM" == "openshift" ]]; then
   secretless_url="localhost:8083"
   secrets_provider_standalone_url="localhost:8084"
   init_url_with_host_outside_apps="localhost:8085"
+  secrets_provider_init_url="localhost:8086"
 else
   # Test by curling from a pod that is inside the KinD cluster.
   curl_cmd=pod_curl
@@ -110,6 +115,7 @@ else
   sidecar_url="test-app-summon-sidecar.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   secretless_url="test-app-secretless-broker.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   secrets_provider_standalone_url="test-app-secrets-provider-standalone.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
+  secrets_provider_init_url="test-app-secrets-provider-init.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
 fi
 
 echo "Waiting for urls to be ready"
@@ -126,11 +132,13 @@ declare -A app_urls
 app_urls[summon-sidecar]="$sidecar_url"
 app_urls[secretless-broker]="$secretless_url"
 app_urls[secrets-provider-standalone]="$secrets_provider_standalone_url"
+app_urls[secrets-provider-init]="$secrets_provider_init_url"
 
 declare -A app_pets
 app_pets[summon-sidecar]="Mr. Sidecar"
 app_pets[secretless-broker]="Mr. Secretless"
 app_pets[secrets-provider-standalone]="Mr. Standalone"
+app_pets[secrets-provider-init]="Mr. Provider"
 
 # check connection to each installed test app
 for app in "${install_apps[@]}"; do

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -39,7 +39,7 @@ function cleanup {
   ./stop
 }
 
-declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" )
+declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
 # Default: Test all applications
 declare -a install_apps=("${supported_apps[@]}")
 
@@ -53,6 +53,7 @@ while true; do
           echo "Supported test apps include:"
           echo "  - summon-sidecar"
           echo "  - secretless-broker"
+          echo "  - secrets-provider-init"
           exit 1
         fi
       done

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
@@ -93,5 +93,7 @@ spec:
             name: {{ .Values.conjur.authnConfigMap.name }}
         - configMapRef:
             name: {{ .Values.global.conjur.conjurConnConfigMap }}
+      {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret
+      {{- end }}

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/values.yaml
@@ -6,14 +6,15 @@ global:
     # name of the ConfigMap created by the conjur-config-namespace-prep chart
     conjurConnConfigMap: "conjur-connect"
   appServiceType: "NodePort"
-  
+
 app:
   image:
     repository: "cyberark/demo-app"
     tag: "latest"
     # supported values: "Always", "IfNotPresent", "Never"
     pullPolicy: "Always"
- 
+  platform: "kubernetes"
+
 secretsProvider:
   image:
     repository: "cyberark/secrets-provider-for-k8s"

--- a/helm/conjur-config-namespace-prep/generated/conjur-config-namespace-prep.yaml
+++ b/helm/conjur-config-namespace-prep/generated/conjur-config-namespace-prep.yaml
@@ -28,7 +28,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: conjur-rolebinding
-  labels: 
+  labels:
     app.kubernetes.io/name: "conjur-rolebinding"
     app.kubernetes.io/component: "conjur-namespace-access"
     app.kubernetes.io/instance: "conjur-default-rolebinding"


### PR DESCRIPTION
### What does this PR do?
In #272, the app deploy Helm Chart was updated to support deployment of the app + Secrets Provider init container.
Here, the E2E workflow scripts are updated to deploy and test against this application.
Also, updates the app + Secrets Provider init container subchart for Openshift deployment, similar to changes to the `app-summon-sidecar` and `app-secretless-broker` subcharts made in PR #346.

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
