### PR TITLE
Adds app that uses Secrets Provider in standalone mode to E2E scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ test
 temp
 
 helm/conjur-config-cluster-prep/files/conjur-cert.pem
+helm/conjur-app-deploy/charts/app-secrets-provider-standalone/Chart.lock
+helm/conjur-app-deploy/charts/app-secrets-provider-standalone/charts/secrets-provider-*.tgz
 
 bin/test-workflow/policy/generated/*
 tmp.*

--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -29,15 +29,27 @@ pushd ../../helm/conjur-app-deploy > /dev/null
     --set app-secretless-broker.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secretless-broker \
     --set app-secretless-broker.conjur.authnConfigMap.name=conjur-authn-configmap-secretless \
     --set app-secretless-broker.app.platform=$PLATFORM"
+  secrets_provider_standalone_options="--set app-secrets-provider-standalone.enabled=true \
+    --set app-secrets-provider-standalone.secrets-provider.environment.conjur.authnLogin="$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-standalone" \
+    --set app-secrets-provider-standalone.app.image.tag="$TEST_APP_TAG" \
+    --set app-secrets-provider-standalone.app.image.repository="$TEST_APP_REPO" \
+    --set app-secrets-provider-standalone.app.platform=$PLATFORM"
 
   declare -A app_options
   app_options[summon-sidecar]="$summon_sidecar_options"
   app_options[secretless-broker]="$secretless_broker_options"
+  app_options[secrets-provider-standalone]="$secrets_provider_standalone_options"
 
   # restore array of apps to install
   declare -a install_apps=($(split_on_comma_delimiter $INSTALL_APPS))
   options_string=""
   for app in "${install_apps[@]}"; do
+    # If application that uses Secrets Provider in standalone mode is enabled,
+    # make sure that the Secrets Provider Helm chart has been downloaded as a
+    # dependency for that application's subchart.
+    if [ "$app" = "secrets-provider-standalone" ]; then
+      helm dependency update charts/app-secrets-provider-standalone
+    fi
     options_string+="${app_options[$app]} "
   done
 
@@ -49,4 +61,4 @@ pushd ../../helm/conjur-app-deploy > /dev/null
 
 popd > /dev/null
 
-echo "Test app/sidecar deployed."
+echo "Test apps deployed."

--- a/bin/test-workflow/8_app_verify_authentication.sh
+++ b/bin/test-workflow/8_app_verify_authentication.sh
@@ -26,6 +26,7 @@ function finish {
     "INIT_PORT_FORWARD_PID"
     "INIT_WITH_HOST_OUTSIDE_APPS_PORT_FORWARD_PID"
     "SECRETLESS_PORT_FORWARD_PID"
+    "SECRETS_PROVIDER_STANDALONE_PID"
   )
 
   # Upon error, dump some kubernetes resources and Conjur authentication policy
@@ -44,7 +45,7 @@ function finish {
     fi
   done
 
-if [ $exit_code -eq 0 ]; then
+  if [ $exit_code -eq 0 ]; then
     announce "Test PASSED!!!!"
   else
     announce "Test FAILED!!!!"
@@ -81,6 +82,7 @@ if [[ "$PLATFORM" == "openshift" ]]; then
   init_pod=$(get_pod_name test-app-summon-init)
   init_pod_with_host_outside_apps=$(get_pod_name test-app-with-host-outside-apps-branch-summon-init)
   secretless_pod=$(get_pod_name test-app-secretless)
+  secrets_provider_standalone_pod=$(get_pod_name test-app-secrets-provider-standalone)
 
   # Routes are defined, but we need to do port-mapping to access them
   oc port-forward "$sidecar_pod" 8081:8080 > /dev/null 2>&1 &
@@ -89,14 +91,17 @@ if [[ "$PLATFORM" == "openshift" ]]; then
   INIT_PORT_FORWARD_PID=$!
   oc port-forward "$secretless_pod" 8083:8080 > /dev/null 2>&1 &
   SECRETLESS_PORT_FORWARD_PID=$!
-  oc port-forward "$init_pod_with_host_outside_apps" 8084:8080 > /dev/null 2>&1 &
+  oc port-forward "$secrets_provider_standalone_pod" 8084:8080 > /dev/null 2>&1 &
+  SECRETS_PROVIDER_STANDALONE_PID=$!
+  oc port-forward "$init_pod_with_host_outside_apps" 8085:8080 > /dev/null 2>&1 &
   INIT_WITH_HOST_OUTSIDE_APPS_PORT_FORWARD_PID=$!
 
   curl_cmd=curl
   sidecar_url="localhost:8081"
   init_url="localhost:8082"
   secretless_url="localhost:8083"
-  init_url_with_host_outside_apps="localhost:8084"
+  secrets_provider_standalone_url="localhost:8084"
+  init_url_with_host_outside_apps="localhost:8085"
 else
   # Test by curling from a pod that is inside the KinD cluster.
   curl_cmd=pod_curl
@@ -104,6 +109,7 @@ else
   init_url_with_host_outside_apps="test-app-with-host-outside-apps-branch-summon-init.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   sidecar_url="test-app-summon-sidecar.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   secretless_url="test-app-secretless-broker.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
+  secrets_provider_standalone_url="test-app-secrets-provider-standalone.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
 fi
 
 echo "Waiting for urls to be ready"
@@ -119,10 +125,12 @@ declare -a install_apps=($(split_on_comma_delimiter $INSTALL_APPS))
 declare -A app_urls
 app_urls[summon-sidecar]="$sidecar_url"
 app_urls[secretless-broker]="$secretless_url"
+app_urls[secrets-provider-standalone]="$secrets_provider_standalone_url"
 
 declare -A app_pets
 app_pets[summon-sidecar]="Mr. Sidecar"
 app_pets[secretless-broker]="Mr. Secretless"
+app_pets[secrets-provider-standalone]="Mr. Standalone"
 
 # check connection to each installed test app
 for app in "${install_apps[@]}"; do

--- a/bin/test-workflow/policy/app-access.yml
+++ b/bin/test-workflow/policy/app-access.yml
@@ -67,3 +67,20 @@
       role: !layer /test-app
       privileges: [ read, execute ]
       resources: *secrets-provider-init-variables
+
+- !policy
+  id: test-secrets-provider-standalone-app-db
+  owner: !group developer
+  annotations:
+    description: This policy contains the creds to access the secrets provider app DB
+
+  body:
+    - &secrets-provider-standalone-variables
+      - !variable password
+      - !variable url
+      - !variable username
+
+    - !permit
+      role: !layer /test-app
+      privileges: [ read, execute ]
+      resources: *secrets-provider-standalone-variables

--- a/bin/test-workflow/policy/load_policies.sh
+++ b/bin/test-workflow/policy/load_policies.sh
@@ -34,6 +34,7 @@ readonly APPS=(
   "test-summon-sidecar-app"
   "test-secretless-app"
   "test-secrets-provider-init-app"
+  "test-secrets-provider-standalone-app"
 )
 
 for app_name in "${APPS[@]}"; do

--- a/bin/test-workflow/policy/templates/project-authn-def.template.yml
+++ b/bin/test-workflow/policy/templates/project-authn-def.template.yml
@@ -44,6 +44,13 @@
         authn-k8s/deployment: test-app-secrets-provider-init
         authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
         kubernetes: "{{ IS_KUBERNETES }}"
+    - !host
+      id: test-app-secrets-provider-standalone
+      annotations:
+        authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+        authn-k8s/service-account: secrets-provider-service-account
+        authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
+        kubernetes: "{{ IS_KUBERNETES }}"
 
     - !host
       id: oc-test-app-summon-sidecar
@@ -66,6 +73,20 @@
         authn-k8s/service-account: oc-test-app-secretless
         authn-k8s/authentication-container-name: secretless
         openshift: "{{ IS_OPENSHIFT }}"
+    - !host
+      id: oc-test-app-secrets-provider-init
+      annotations:
+        authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+        authn-k8s/service-account: oc-test-app-secrets-provider-init
+        authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
+        kubernetes: "{{ IS_OPENSHIFT }}"
+    - !host
+      id: oc-test-app-secrets-provider-standalone
+      annotations:
+        authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+        authn-k8s/service-account: oc-secrets-provider-service-account
+        authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
+        kubernetes: "{{ IS_OPENSHIFT }}"
 
   - !grant
     role: !layer

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -27,6 +27,7 @@ Usage: ./start [options]:
                               Currently supports:
                                 - summon-sidecar
                                 - secretless-broker
+                                - secrets-provider-standalone
                               All other selections are rejected
     -h, --help                Show the help message
 EOF
@@ -38,8 +39,9 @@ function cleanup {
   ./stop
 }
 
-declare -a supported_apps=("summon-sidecar" "secretless-broker")
-declare -a install_apps=()
+declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" )
+# Default: Test all applications
+declare -a install_apps=("${supported_apps[@]}")
 
 while true; do
   case "$1" in
@@ -82,9 +84,6 @@ while true; do
   esac
 done
 
-if [ ${#install_apps[@]} -eq 0 ]; then
-  install_apps=("${supported_apps[@]}")
-fi
 # Bash arrays cannot be exported to the environment for use between scripts.
 # Here, export a version that complies with the bash environment,
 # and can be reassembled when it's needed


### PR DESCRIPTION
### What does this PR do?

This change adds the deployment of an application that uses the Secrets
Provider in standalone mode to the E2E application deployment scripts.

### What ticket does this PR close?
Resolves #292
### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
