### PR TITLE
Allow custom names for Namespace prep entities

### DIFF
--- a/helm/conjur-config-namespace-prep/templates/authenticator_rolebinding.yaml
+++ b/helm/conjur-config-namespace-prep/templates/authenticator_rolebinding.yaml
@@ -12,8 +12,8 @@
 apiVersion: {{ include "conjur-prep.rbac-api" . }}
 kind: RoleBinding
 metadata:
-  name: conjur-rolebinding
-  labels: 
+  name: {{ .Values.authnRoleBinding.name }}
+  labels:
     app.kubernetes.io/name: "conjur-rolebinding"
     app.kubernetes.io/component: "conjur-namespace-access"
     app.kubernetes.io/instance: "conjur-{{ .Release.Namespace }}-rolebinding"

--- a/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
+++ b/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
@@ -12,7 +12,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: conjur-connect
+  name: {{ .Values.conjurConfigMap.name }}
   labels:
     app.kubernetes.io/name: "conjur-connect-configmap"
     app.kubernetes.io/instance: "conjur-{{ .Release.Namespace }}-configmap"

--- a/helm/conjur-config-namespace-prep/tests/authenticator_rolebinding_test.yaml
+++ b/helm/conjur-config-namespace-prep/tests/authenticator_rolebinding_test.yaml
@@ -58,3 +58,17 @@ tests:
       - failedTemplate:
           errorMessage: "Both authnK8s.namespace and authnK8s.configMap are required"
 
+  #=======================================================================
+  - it: should allow RoleBinding name to be set explicitly
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Set explicit RoleBinding name
+      authnRoleBinding.name: "my-awesome-rolebinding"
+
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "my-awesome-rolebinding"

--- a/helm/conjur-config-namespace-prep/tests/conjur_connect_configmap_test.yaml
+++ b/helm/conjur-config-namespace-prep/tests/conjur_connect_configmap_test.yaml
@@ -69,3 +69,17 @@ tests:
       - failedTemplate:
           errorMessage: "Both authnK8s.namespace and authnK8s.configMap are required"
 
+  #=======================================================================
+  - it: should allow ConfigMap name to be set explicitly
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Set explicit ConfigMap name
+      conjurConfigMap.name: "my-awesome-configmap"
+
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "my-awesome-configmap"


### PR DESCRIPTION
### What does this PR do?
Allows for custom names of ConfigMap and RoleBinding entities created by the Namespace prep Helm chart.
Includes Helm unit tests to confirm this behavior.

### What ticket does this PR close?
Resolves #383

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
