### PR TITLE
Runs test apps in E2E workflow as non-root user

### DIFF
--- a/helm/conjur-app-deploy/charts/app-secretless-broker/templates/test_app_secretless_broker.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker/templates/test_app_secretless_broker.yaml
@@ -80,11 +80,25 @@ spec:
           mountPath: /etc/secretless
           name: config
           readOnly: true
+        - name: conjur-access-token
+          mountPath: /run/conjur
+        - name: conjur-certs
+          mountPath: /etc/conjur/ssl
       {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret
       {{- end }}
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
       volumes:
       - name: config
         configMap:
           name: secretless-config-configmap
+      - name: conjur-access-token
+        emptyDir:
+          medium: Memory
+      - name: conjur-certs
+        emptyDir:
+          medium: Memory

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
@@ -93,7 +93,23 @@ spec:
             name: {{ .Values.conjur.authnConfigMap.name }}
         - configMapRef:
             name: {{ .Values.global.conjur.conjurConnConfigMap }}
+        volumeMounts:
+        - name: conjur-access-token
+          mountPath: /run/conjur
+        - name: conjur-certs
+          mountPath: /etc/conjur/ssl
       {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret
       {{- end }}
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
+      volumes:
+      - name: conjur-access-token
+        emptyDir:
+          medium: Memory
+      - name: conjur-certs
+        emptyDir:
+          medium: Memory

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/test_app_secrets_provider_standalone.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/test_app_secrets_provider_standalone.yaml
@@ -55,3 +55,7 @@ spec:
       imagePullSecrets:
         - name: dockerpullsecret
       {{- end }}
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534

--- a/helm/conjur-app-deploy/charts/app-summon-sidecar/templates/test-app-summon-sidecar.yaml
+++ b/helm/conjur-app-deploy/charts/app-summon-sidecar/templates/test-app-summon-sidecar.yaml
@@ -88,12 +88,21 @@ spec:
         volumeMounts:
           - mountPath: /run/conjur
             name: conjur-access-token
+          - mountPath: /etc/conjur/ssl
+            name: conjur-certs
       {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret
       {{- end }}
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
       volumes:
         - name: conjur-access-token
+          emptyDir:
+            medium: Memory
+        - name: conjur-certs
           emptyDir:
             medium: Memory
         - name: secrets-config


### PR DESCRIPTION
### What does this PR do?

This change modifies the deployment manifests for applications in the E2E workflow so that the test application runs as a non-root user. Running containers using non-root user/group is considered best practice for Kubernetes workloads.

This is accomplished by setting the associated 'PodSecurityContext' for each deployment so that every container (i.e. the application container as well as the authentication container, if present) are run using:

- The 'nobody' non-root user (UserID 66634)
- The 'nobody' non-root group (GroupID 65534)
- fsGroup of 65534 (i.e. directories and files for all shared volumes
                    are created using a Group ID of 65534).

In some cases, this also requires creating `volumeMounts` for containers and `emptyDir` Volumes for the Pods for directories to which the authenticator client containers write, or from which application containers will read. This is required so that these directories and their contents will be created with the `65534` GroupID, as is needed since the containers will now be running as User:group of `65534:65534`. Without these `emptyDir` additions, the authenticator containers will lack permission to write files to these directories, and the application container will lack permission to read from these directories.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
