### PR TITLE
Fix calls to functions that use 'eval' in E2E test scripts

### DIFF
--- a/bin/test-workflow/utils.sh
+++ b/bin/test-workflow/utils.sh
@@ -30,8 +30,8 @@ announce() {
 }
 
 platform_image_for_pull() {
-  local image=$1
-  local namespace=$2
+  local image="$1"
+  local namespace="$2"
   if [[ ${PLATFORM} = "openshift" ]]; then
     echo "${PULL_DOCKER_REGISTRY_PATH}/$namespace/$1:$namespace"
   elif [[ "$USE_DOCKER_LOCAL_REGISTRY" = "true" ]]; then
@@ -42,8 +42,8 @@ platform_image_for_pull() {
 }
 
 platform_image_for_push() {
-  local image=$1
-  local namespace=$2
+  local image="$1"
+  local namespace="$2"
   if [[ ${PLATFORM} = "openshift" ]]; then
     echo "${DOCKER_REGISTRY_PATH}/$namespace/$1:$namespace"
   elif [[ "$USE_DOCKER_LOCAL_REGISTRY" = "true" ]]; then
@@ -54,7 +54,7 @@ platform_image_for_push() {
 }
 
 has_namespace() {
-  if $cli get namespace  "$1" &>/dev/null; then
+  if "$cli" get namespace  "$1" &>/dev/null; then
     true
   else
     false
@@ -62,8 +62,8 @@ has_namespace() {
 }
 
 has_resource() {
-  local selector=$1
-  local num_matching_resources=$($cli get pods -n "$CONJUR_NAMESPACE_NAME" --selector $selector --no-headers 2>/dev/null | wc -l)
+  local selector="$1"
+  local num_matching_resources=$("$cli" get pods -n "$CONJUR_NAMESPACE_NAME" --selector "$selector" --no-headers 2>/dev/null | wc -l)
   if [ $num_matching_resources -gt 0 ]; then
     return 0
   else
@@ -72,15 +72,15 @@ has_resource() {
 }
 
 get_pod_name() {
-  local pod_identifier=$1
+  local pod_identifier="$1"
 
   # Query to get the pod name, ignoring temp "deploy" pods
-  pod_name=$($cli get pods | grep "$pod_identifier" | grep -v "deploy" | awk '{ print $1 }')
+  pod_name=$("$cli" get pods | grep "$pod_identifier" | grep -v "deploy" | awk '{ print $1 }')
   echo "$pod_name"
 }
 
 get_pods() {
-  $cli get pods --selector "$1" --no-headers | awk '{ print $1 }'
+  "$cli" get pods --selector "$1" --no-headers | awk '{ print $1 }'
 }
 
 get_master_pod_name() {
@@ -93,12 +93,12 @@ get_master_pod_name() {
 }
 
 get_conjur_cli_pod_name() {
-  pod_list=$($cli get pods -n "$CONJUR_NAMESPACE_NAME" --selector app=conjur-cli --no-headers | awk '{ print $1 }')
-  echo $pod_list | awk '{print $1}'
+  pod_list="$($cli get pods -n $CONJUR_NAMESPACE_NAME --selector app=conjur-cli --no-headers | awk '{ print $1 }')"
+  echo "$pod_list" | awk '{print $1}'
 }
 
 run_conjur_cmd_as_admin() {
-  local command=$(cat $@)
+  local command="$(cat $@)"
 
   conjur authn logout > /dev/null
   conjur authn login -u admin -p "$CONJUR_ADMIN_PASSWORD" > /dev/null
@@ -119,11 +119,11 @@ conjur_service_account() {
 
 set_namespace() {
   if [[ $# != 1 ]]; then
-    printf "Error in %s/%s - expecting 1 arg.\n" $(pwd) $0
+    printf "Error in %s/%s - expecting 1 arg.\n" "$(pwd)" "$0"
     exit -1
   fi
 
-  $cli config set-context $($cli config current-context) --namespace="$1" > /dev/null
+  "$cli" config set-context "$($cli config current-context)" --namespace="$1" > /dev/null
 }
 
 load_policy() {
@@ -138,7 +138,7 @@ rotate_host_api_key() {
   local host=$1
 
   run_conjur_cmd_as_admin <<CMD
-conjur host rotate_api_key -h $host
+conjur host rotate_api_key -h "$host"
 CMD
 }
 
@@ -171,7 +171,7 @@ function wait_for_it() {
 }
 
 function external_ip() {
-  local service=$1
+  local service="$1"
 
   echo "$($cli get svc $service -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
 }
@@ -184,9 +184,9 @@ function deployment_status() {
 }
 
 function pods_ready() {
-  local app_label=$1
+  local app_label="$1"
 
-  $cli describe pod --selector "app=$app_label" | awk '/Ready/{if ($2 != "True") exit 1}'
+  "$cli" describe pod --selector "app=$app_label" | awk '/Ready/{if ($2 != "True") exit 1}'
 }
 
 function urlencode() {
@@ -209,34 +209,34 @@ function urlencode() {
 
 function dump_kubernetes_resources() {
   echo "Status of pods in namespace $TEST_APP_NAMESPACE_NAME:"
-  $cli get -n $TEST_APP_NAMESPACE_NAME pods
+  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" pods
   echo "Display pods in namespace $TEST_APP_NAMESPACE_NAME:"
-  $cli get -n $TEST_APP_NAMESPACE_NAME pods -o yaml
+  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" pods -o yaml
   echo "Describe pods in namespace $TEST_APP_NAMESPACE_NAME:"
-  $cli describe -n $TEST_APP_NAMESPACE_NAME pods
+  "$cli" describe -n "$TEST_APP_NAMESPACE_NAME" pods
   echo "Services:in namespace $TEST_APP_NAMESPACE_NAME:"
-  $cli get -n $TEST_APP_NAMESPACE_NAME svc
+  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" svc
   echo "ServiceAccounts:in namespace $TEST_APP_NAMESPACE_NAME:"
-  $cli get -n $TEST_APP_NAMESPACE_NAME serviceaccounts
+  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" serviceaccounts
   echo "Deployments in namespace $TEST_APP_NAMESPACE_NAME:"
-  $cli get -n $TEST_APP_NAMESPACE_NAME deployments
+  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" deployments
   if [[ "$PLATFORM" == "openshift" ]]; then
     echo "DeploymentConfigs in namespace $TEST_APP_NAMESPACE_NAME:"
-    $cli get -n $TEST_APP_NAMESPACE_NAME deploymentconfigs
+    "$cli" get -n "$TEST_APP_NAMESPACE_NAME" deploymentconfigs
   fi
   echo "Roles in namespace $TEST_APP_NAMESPACE_NAME:"
-  $cli get -n $TEST_APP_NAMESPACE_NAME roles
+  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" roles
   echo "RoleBindings in namespace $TEST_APP_NAMESPACE_NAME:"
-  $cli get -n $TEST_APP_NAMESPACE_NAME rolebindings
+  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" rolebindings
   echo "ClusterRoles in the cluster:"
-  $cli get clusterroles
+  "$cli" get clusterroles
   echo "ClusterRoleBindings in the cluster:"
-  $cli get clusterrolebindings
+  "$cli" get clusterrolebindings
 }
 
 function dump_authentication_policy {
   announce "Authentication policy:"
-  cat policy/generated/$TEST_APP_NAMESPACE_NAME.project-authn.yml
+  cat "policy/generated/$TEST_APP_NAMESPACE_NAME.project-authn.yml"
 }
 
 function get_admin_password {


### PR DESCRIPTION
### What does this PR do?

There are a couple of functions in 'utils.sh' file for the E2E workflow test scripts that use the Bash 'eval' command:

- run_conjur_cmd_as_admin()
- wait_for_it()

The calls made to these two functions pass in a command string, and these functions in turn execute the command strings using 'eval'.

In some cases, the callers to these functions include environment variable values in the command strings that they dynamically generate. Here is one example of a call to 'wait_for_it':

```
  wait_for_it 300 "$cli exec $conjur_cli_pod -- \
     bash -c \"
       conjur_appliance_url=${CONJUR_APPLIANCE_URL} \
       CONJUR_ACCOUNT=${CONJUR_ACCOUNT} \
       CONJUR_ADMIN_PASSWORD=${CONJUR_ADMIN_PASSWORD} \
       DB_PASSWORD=${SAMPLE_APP_BACKEND_DB_PASSWORD} \
       TEST_APP_NAMESPACE_NAME=${TEST_APP_NAMESPACE_NAME} \
       TEST_APP_DATABASE=${TEST_APP_DATABASE} \
       /policy/load_policies.sh
     \"
   "
```

The environment variable expressions in these statements should be encapsulated in quotes (single or double) to prevent potential code injection that might occur when these variables are expanded and executed as part of the `bash -c ...` command, if these environment variables (which are retrieved from Conjur) happen to contain executable code.

This change also adds quotes around some bash variables that are interpreted as strings, to adhere to Bash style guides:

https://github.com/cyberark/community/blob/main/Conjur/conventions/bash-style-guide.md#style-baseline

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
