### PR TITLE
Use 'secrets-provider' as Job name for standalone Secrets Provider

### DIFF
--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/values.yaml
@@ -14,6 +14,8 @@ app:
   platform: "kubernetes"
 
 secrets-provider:
+  secretsProvider:
+    jobName: "secrets-provider"
   environment:
     conjur:
       # conjurConnConfigMap must match the following parent chart's Global setting:


### PR DESCRIPTION
### What ticket does this PR close?

Currently, the E2E workflow for an application that uses the Secrets Provider in standalone ("app") mode uses the default Job name for the Secrets Provider as defined by the Secrets Provider Helm chart. The Secrets Provider Helm chart uses the charts Release name as a default:
https://github.com/cyberark/secrets-provider-for-k8s/blob/main/helm/secrets-provider/values.yaml#L19-L20

Normally, using the Helm chart release name makes sense when the Secrets Provider Helm chart is installed directly. However, for `conjur-authn-k8s-client` E2E workflow test app deployment, this Helm chart is installed as a dependency (i.e. downloaded subchart), so that the Helm release name is the Release name for the parent chart, which in
this case is typicall "test-app". Using this "test-app" as the name of the standalone Secrets Provider Job is a bit confusing.

This change sets the Job name for the standalone Secrets Provider to "secrets-provider".

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
