### PR TITLE
Updating scripts for Jenkins on Openshift

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,11 @@ pipeline {
             sh './bin/helm-dependency-update-in-docker'
           }
         }
+        stage('Openshift E2E Workflow Tests') {
+          steps {
+            sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --platform oc'
+          }
+        }
         stage('Run E2E Tests') {
           parallel {
             stage('Enterprise and test app deployed to GKE') {

--- a/bin/test-workflow/2_admin_load_conjur_policies.sh
+++ b/bin/test-workflow/2_admin_load_conjur_policies.sh
@@ -61,6 +61,7 @@ ensure_conjur_cli_initialized() {
 
 pushd policy > /dev/null
   mkdir -p ./generated > /dev/null
+  chmod 777 ./generated || true
 
   # NOTE: generated files are prefixed with the test app namespace to allow for parallel CI
 

--- a/bin/test-workflow/6_app_deploy_backend.sh
+++ b/bin/test-workflow/6_app_deploy_backend.sh
@@ -66,5 +66,11 @@ if [[ "$PLATFORM" == "openshift" ]]; then
 fi
 
 echo "helm" "${args[@]}"
-helm "${args[@]}"
-
+ret_val=0
+helm "${args[@]}" || ret_val=$?
+if [[ "$ret_val" != 0 ]]; then
+  announce "checking stateful set test-app-backend"
+  $cli version
+  $cli get statefulset -n "$TEST_APP_NAMESPACE_NAME"
+  $cli describe statefulset test-app-backend -n "$TEST_APP_NAMESPACE_NAME"
+fi

--- a/bin/test-workflow/8_app_verify_authentication.sh
+++ b/bin/test-workflow/8_app_verify_authentication.sh
@@ -23,8 +23,6 @@ function finish {
 
   readonly PIDS=(
     "SIDECAR_PORT_FORWARD_PID"
-    "INIT_PORT_FORWARD_PID"
-    "INIT_WITH_HOST_OUTSIDE_APPS_PORT_FORWARD_PID"
     "SECRETLESS_PORT_FORWARD_PID"
     "SECRETS_PROVIDER_STANDALONE_PID"
     "SECRETS_PROVIDER_INIT_PORT_FORWARD_PID"
@@ -80,8 +78,6 @@ echo "Waiting for pods to become available"
 
 if [[ "$PLATFORM" == "openshift" ]]; then
   sidecar_pod=$(get_pod_name test-app-summon-sidecar)
-  init_pod=$(get_pod_name test-app-summon-init)
-  init_pod_with_host_outside_apps=$(get_pod_name test-app-with-host-outside-apps-branch-summon-init)
   secretless_pod=$(get_pod_name test-app-secretless)
   secrets_provider_standalone_pod=$(get_pod_name test-app-secrets-provider-standalone)
   secrets_provider_init_pod=$(get_pod_name test-app-secrets-provider-init)
@@ -89,29 +85,21 @@ if [[ "$PLATFORM" == "openshift" ]]; then
   # Routes are defined, but we need to do port-mapping to access them
   oc port-forward "$sidecar_pod" 8081:8080 > /dev/null 2>&1 &
   SIDECAR_PORT_FORWARD_PID=$!
-  oc port-forward "$init_pod" 8082:8080 > /dev/null 2>&1 &
-  INIT_PORT_FORWARD_PID=$!
   oc port-forward "$secretless_pod" 8083:8080 > /dev/null 2>&1 &
   SECRETLESS_PORT_FORWARD_PID=$!
   oc port-forward "$secrets_provider_standalone_pod" 8084:8080 > /dev/null 2>&1 &
   SECRETS_PROVIDER_STANDALONE_PID=$!
-  oc port-forward "$init_pod_with_host_outside_apps" 8085:8080 > /dev/null 2>&1 &
-  INIT_WITH_HOST_OUTSIDE_APPS_PORT_FORWARD_PID=$!
   oc port-forward "$secrets_provider_init_pod" 8086:8080 > /dev/null 2>&1 &
   SECRETS_PROVIDER_INIT_PORT_FORWARD_PID=$!
 
   curl_cmd=curl
   sidecar_url="localhost:8081"
-  init_url="localhost:8082"
   secretless_url="localhost:8083"
   secrets_provider_standalone_url="localhost:8084"
-  init_url_with_host_outside_apps="localhost:8085"
   secrets_provider_init_url="localhost:8086"
 else
   # Test by curling from a pod that is inside the KinD cluster.
   curl_cmd=pod_curl
-  init_url="test-app-summon-init.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
-  init_url_with_host_outside_apps="test-app-with-host-outside-apps-branch-summon-init.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   sidecar_url="test-app-summon-sidecar.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   secretless_url="test-app-secretless-broker.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   secrets_provider_standalone_url="test-app-secrets-provider-standalone.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"

--- a/bin/test-workflow/Dockerfile
+++ b/bin/test-workflow/Dockerfile
@@ -18,6 +18,13 @@ RUN curl -LO https://dl.k8s.io/release/v"${KUBECTL_VERSION:-1.21.3}"/bin/linux/a
     mv kubectl /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
+# Install OpenShift oc CLI
+ARG OPENSHIFT_CLI_URL
+RUN wget -O oc.tar.gz "${OPENSHIFT_CLI_URL:-https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz}" && \
+    tar xvf oc.tar.gz  && \
+    mv oc /usr/local/bin/oc && \
+    rm -rf oc.tar.gz
+
 # Install Helm CLI
 ARG HELM_CLI_VERSION
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3

--- a/bin/test-workflow/cleanup_helm.sh
+++ b/bin/test-workflow/cleanup_helm.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-helm uninstall "cluster-prep-$UNIQUE_TEST_ID" -n "$CONJUR_NAMESPACE_NAME"
-helm uninstall "namespace-prep-$UNIQUE_TEST_ID" -n "$TEST_APP_NAMESPACE_NAME"
-helm uninstall app-backend-pg -n "$TEST_APP_NAMESPACE_NAME"
-helm uninstall test-apps -n "$TEST_APP_NAMESPACE_NAME"
+source ./utils.sh
+
+uninstall_helm_release "cluster-prep-$UNIQUE_TEST_ID" "$CONJUR_NAMESPACE_NAME"
+uninstall_helm_release "namespace-prep-$UNIQUE_TEST_ID" "$TEST_APP_NAMESPACE_NAME"
+uninstall_helm_release app-backend-pg "$TEST_APP_NAMESPACE_NAME"
+uninstall_helm_release test-apps "$TEST_APP_NAMESPACE_NAME"
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
-  helm uninstall conjur-oss -n "$CONJUR_NAMESPACE_NAME"
+  uninstall_helm_release "$HELM_RELEASE" "$CONJUR_NAMESPACE_NAME"
 fi

--- a/bin/test-workflow/cleanup_namespaces.sh
+++ b/bin/test-workflow/cleanup_namespaces.sh
@@ -2,5 +2,5 @@
 
 source ./utils.sh
 
-$cli delete namespace "$CONJUR_NAMESPACE_NAME"
-$cli delete namespace "$TEST_APP_NAMESPACE_NAME"
+$cli delete namespace "$CONJUR_NAMESPACE_NAME" --ignore-not-found
+$cli delete namespace "$TEST_APP_NAMESPACE_NAME" --ignore-not-found

--- a/bin/test-workflow/dev-start.sh
+++ b/bin/test-workflow/dev-start.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# This script is intended for use by developers and not to be called by automation.
+
+set -euo pipefail
+IFS=$'\n\t'
+export GCLOUD_PROJECT_NAME="${GCLOUD_PROJECT_NAME:-gke}"
+export GCLOUD_ZONE="${GCLOUD_ZONE:-gke}"
+export GCLOUD_CLUSTER_NAME="${GCLOUD_CLUSTER_NAME:-gke}"
+export GCLOUD_SERVICE_KEY="${GCLOUD_SERVICE_KEY:-gke}"
+
+print_usage() {
+  echo "Usage:"
+  echo "    This script will run start for the various platforms"
+  echo ""
+  echo "Syntax:"
+  echo "    $0 [Options]"
+  echo "    Options:"
+  echo "    -c                         Run clients from a container"
+  echo "    -e <Summon environment>    The environment used in"
+  echo "                               secrets.yml. Defaults to dev"
+  echo "    -g                         GKE"
+  echo "    -h                         Show help"
+  echo "    -l                         Just Log in to the platform"
+  echo "    -o                         Openshift"
+  echo "    -n                         No cleanup"
+  echo "    -s <Step #>                Run one of the numbered scripts"
+  echo "    -v <Openshift version>     The Openshift version"
+  echo "                               defaults to current"
+}
+
+function main() {
+  # Process command line options
+  local OPTIND
+  openshift_version="current"
+  env="dev"
+  oc_selected=false
+  gke_selected=false
+  no_cleanup=false
+  local_container=false
+  cmd=("")
+  while getopts ':ce:ghlnos:v:' flag; do
+    case "${flag}" in
+      c) local_container=true ;;
+      e) env=${OPTARG} ;;
+      g) CONJUR_PLATFORM="gke" ; gke_selected=true ;;
+      h) print_usage; exit 0 ;;
+      l) cmd=("./platform_login.sh") ;;
+      n) no_cleanup=true ;;
+      o) oc_selected=true ;;
+      s) cmd="./"$(ls | grep ${OPTARG}_) ;; 
+      v) openshift_version=${OPTARG} ;;
+
+  *) echo "Invalid argument -${OPTARG}" >&2; echo; print_usage ; exit 1;;
+    esac
+  done
+  shift $((OPTIND-1))
+
+  if [[ "$oc_selected" = true && "$gke_selected" = true ]]; then
+    echo "Invalid arguments, cannot set -g and -o at the same time" >&2; print_usage ; exit 1;
+  fi
+  if [[ "$gke_selected" = true ]]; then
+    cmd=("./start -p gke")
+  elif [[ "$oc_selected" = true ]]; then
+    if [[ $cmd == "" ]]; then
+      cmd=("./start -p oc" )
+    fi
+    if [[ "$no_cleanup" = true ]]; then
+      cmd+=" -n"
+    fi
+    echo "Openshift"
+    echo "Running" "${cmd}"
+    # some scripts need these set
+    export CONJUR_PLATFORM="oc"
+    export APP_PLATFORM="oc"
+    export RUN_CLIENT_CONTAINER="$local_container"
+    summon -e openshift -D ENV=$env -D VER=$openshift_version \
+        sh -c "${cmd}"
+  else
+    echo "Unknown platform"
+  fi
+
+}
+
+main "$@"
+

--- a/bin/test-workflow/platform_login.sh
+++ b/bin/test-workflow/platform_login.sh
@@ -3,6 +3,24 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+source utils.sh
+
+if [[ "$CONJUR_PLATFORM" == "gke" || "$APP_PLATFORM" == "gke" ]]; then
+  check_env_var GCLOUD_SERVICE_KEY
+  check_env_var GCLOUD_CLUSTER_NAME
+  check_env_var GCLOUD_ZONE
+  check_env_var GCLOUD_PROJECT_NAME
+fi
+
+if [[ "$CONJUR_PLATFORM" == "oc" || "$APP_PLATFORM" == "oc" ]]; then
+  check_env_var CONJUR_PLATFORM
+  check_env_var APP_PLATFORM
+  check_env_var OPENSHIFT_URL
+  check_env_var OPENSHIFT_USERNAME
+  check_env_var OPENSHIFT_PASSWORD
+  check_env_var DOCKER_REGISTRY_PATH
+fi
+
 function main {
   if [[ "$CONJUR_PLATFORM" == "gke" || "$APP_PLATFORM" == "gke" ]]; then
     gcloud auth activate-service-account \

--- a/bin/test-workflow/secrets.yml
+++ b/bin/test-workflow/secrets.yml
@@ -19,3 +19,16 @@ gke:
   USE_DOCKER_LOCAL_REGISTRY: false
   DOCKER_REGISTRY_URL: us.gcr.io
   DOCKER_REGISTRY_PATH: us.gcr.io/conjur-gke-dev
+
+openshift:
+  PLATFORM: openshift
+# For the 3.x Openshift 
+# OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+  OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
+  OPENSHIFT_URL: !var $ENV/openshift/$VER/api-url
+  OPENSHIFT_USERNAME: !var $ENV/openshift/$VER/username
+  OPENSHIFT_PASSWORD: !var $ENV/openshift/$VER/password
+  DOCKER_REGISTRY_PATH: !var $ENV/openshift/$VER/registry-url
+  DOCKER_REGISTRY_URL: !var $ENV/openshift/$VER/registry-url
+  PULL_DOCKER_REGISTRY_PATH: !var $ENV/openshift/$VER/internal-registry-url
+  PULL_DOCKER_REGISTRY_URL: !var $ENV/openshift/$VER/internal-registry-url

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -4,6 +4,7 @@ set -eo pipefail
 cd "$(dirname "$0")" || ( echo "cannot cd into dir" && exit 1 )
 
 source ./utils.sh
+do_cleanup=true
 
 function print_help {
   cat << EOF
@@ -17,6 +18,7 @@ Usage: ./start [options]:
     -p, --platform <pform>    Platform on which to deploy Conjur
                               For Open Source workflow:
                                 - Defaults to 'kind'
+                                - Supports 'oc'
                               For Enterprise workflow:
                                 - Defaults to 'gke'
                                 - Supports 'jenkins'
@@ -28,6 +30,7 @@ Usage: ./start [options]:
                                 - summon-sidecar
                                 - secretless-broker
                                 - secrets-provider-standalone
+    -n, --nocleanup           Do not run the cleanup scripts, all resources are maintained.
                               All other selections are rejected
     -h, --help                Show the help message
 EOF
@@ -35,8 +38,10 @@ EOF
 }
 
 function cleanup {
-  announce "Removing test environment"
-  ./stop
+  if [ "$do_cleanup" = "true" ] ; then
+    announce "Removing test environment"
+    ./stop
+  fi
 }
 
 declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
@@ -70,6 +75,10 @@ while true; do
       shift
       shift
       ;;
+    -n|--nocleanup )
+      do_cleanup="false"
+      shift
+      ;;
     -h|--help )
       print_help
       shift
@@ -91,13 +100,14 @@ done
 export INSTALL_APPS=$(IFS=','; echo "${install_apps[*]}")
 
 export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
+export RUN_CLIENT_CONTAINER="${RUN_CLIENT_CONTAINER:-true}"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   if [[ -z "$CONJUR_PLATFORM" ]]; then
     CONJUR_PLATFORM="kind"
-  elif [[ "$CONJUR_PLATFORM" != "kind" ]]; then
+  elif [[ "$CONJUR_PLATFORM" != "kind" && "$CONJUR_PLATFORM" != "oc" ]]; then
     echo "Conjur Open Source workflow not compatible with platform \"$CONJUR_PLATFORM\""
-    echo "Workflow currently only compatible with \"kind\""
+    echo "Workflow currently only compatible with \"kind\" or \"oc\""
     exit
   fi
 else
@@ -122,13 +132,16 @@ export APP_PLATFORM
 
 trap cleanup EXIT
 
+conjur_init="
 source ./0_prep_env.sh
-./1_deploy_conjur.sh
+./1_deploy_conjur.sh"
 
 conjur_prep="
 ./2_admin_load_conjur_policies.sh &&
 ./3_admin_init_conjur_cert_authority.sh"
+
 cluster_prep="./4_admin_cluster_prep.sh"
+
 test_app_workflow="
 ./5_app_namespace_prep.sh &&
 ./6_app_deploy_backend.sh &&
@@ -136,14 +149,28 @@ test_app_workflow="
 ./8_app_verify_authentication.sh"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
-  eval "$conjur_prep"
-  eval "$cluster_prep"
-  eval "$test_app_workflow"
+  if [[ "$CONJUR_PLATFORM" == "oc" && "$RUN_CLIENT_CONTAINER" == "true" ]]; then
+    source "./0_prep_env.sh"
+    run_command_with_platform "./1_deploy_conjur.sh"
+    run_command_with_platform "$conjur_prep"
+    run_command_with_platform "$cluster_prep"
+    run_command_with_platform "$test_app_workflow"
+  else
+    if [[ "$CONJUR_PLATFORM" == "oc" ]]; then
+      ./platform_login.sh
+    fi
+    eval "$conjur_init"
+    eval "$conjur_prep"
+    eval "$cluster_prep"
+    eval "$test_app_workflow"
+  fi
 elif [[ "$CONJUR_PLATFORM" == "gke" ]]; then
+  eval "$conjur_init"
   run_command_with_platform "$conjur_prep"
   run_command_with_platform "$cluster_prep"
   run_command_with_platform "$test_app_workflow"
 elif [[ "$CONJUR_PLATFORM" == "jenkins" && "$APP_PLATFORM" == "gke" ]]; then
+  eval "$conjur_init"
   eval "$conjur_prep"
   run_command_with_platform "$cluster_prep"
   ./conjur_outside_k8s_vars.sh

--- a/bin/test-workflow/stop
+++ b/bin/test-workflow/stop
@@ -3,10 +3,19 @@ set -uo pipefail
 
 source utils.sh
 
-if [[ "${CONJUR_OSS_HELM_INSTALLED}" == "true" ]]; then
-  ./cleanup_helm.sh
-  ./cleanup_namespaces.sh
+check_env_var RUN_CLIENT_CONTAINER
 
+if [[ "${CONJUR_OSS_HELM_INSTALLED}" == "true" ]]; then
+  if [[ "$RUN_CLIENT_CONTAINER" == "true" ]]; then
+    run_command_with_platform "
+    ./cleanup_helm.sh
+    ./cleanup_namespaces.sh
+    rm -rf temp
+    "
+  else 
+    ./cleanup_helm.sh
+    ./cleanup_namespaces.sh
+  fi
 elif [[ "$CONJUR_PLATFORM" == "gke" ]]; then
   run_command_with_platform "
     ./cleanup_helm.sh

--- a/helm/conjur-app-deploy/charts/app-secretless-broker/templates/test_app_secretless_broker.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker/templates/test_app_secretless_broker.yaml
@@ -87,11 +87,11 @@ spec:
       {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret
-      {{- end }}
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534
         runAsUser: 65534
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
@@ -101,11 +101,11 @@ spec:
       {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret
-      {{- end }}
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534
         runAsUser: 65534
+      {{- end }}
       volumes:
       - name: conjur-access-token
         emptyDir:

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/test_app_secrets_provider_standalone.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-standalone/templates/test_app_secrets_provider_standalone.yaml
@@ -54,8 +54,8 @@ spec:
       {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret
-      {{- end }}
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534
         runAsUser: 65534
+      {{- end }}

--- a/helm/conjur-app-deploy/charts/app-summon-sidecar/templates/test-app-summon-sidecar.yaml
+++ b/helm/conjur-app-deploy/charts/app-summon-sidecar/templates/test-app-summon-sidecar.yaml
@@ -93,11 +93,11 @@ spec:
       {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret
-      {{- end }}
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534
         runAsUser: 65534
+      {{- end }}
       volumes:
         - name: conjur-access-token
           emptyDir:


### PR DESCRIPTION
Updating the start script and cleanup Openshift.

### What does this PR do?
Updating the start scripts running Openshift E2E tests on Jenkins.
Also updating the cleanup scripts to handle the unique conjur-oss
namespace and to check if resources exist before deleting to avoid
errors when it can't find the resources.

Also added a new dev-start script for developers to help with bringing up Openshift.

This also fixes an intermittent issue with GKE test failing with the error
'''
./2_admin_load_conjur_policies.sh: line 87: ./generated/app-test-f059b781-e.cluster-authn-svc.yml: Permission denied
'''
by changing the permissions of the generated directory.

### What ticket does this PR close?
Resolves #N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
