### PR TITLE
Updating Openssl in the Helm docker images to resolve CVE-2021-3711

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Security
+- Upgrades Openssl in Alpine to resolve CVE-2021-3711.
+  [cyberark/conjur-authn-k8s-client#392](https://github.com/cyberark/conjur-authn-k8s-client/issues/392)
 - Upgrades Alpine to v3.14 to resolve CVE-2021-36159.
   [cyberark/conjur-authn-k8s-client#374](https://github.com/cyberark/conjur-authn-k8s-client/issues/374)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,9 @@ RUN apk add -u shadow libc6-compat && \
     chmod 770 /etc/conjur/ssl \
               /run/conjur
 
+# Ensure openssl development libraries are always up to date
+RUN apk add --no-cache openssl-dev
+
 USER authenticator
 
 VOLUME /run/conjur
@@ -127,7 +130,7 @@ LABEL description="The authentication client required to expose secrets from a C
 FROM alpine:3.14 as k8s-cluster-test
 
 # Install packages for testing
-RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl
+RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl-dev
 
 # Install bats-core in /usr/local
 RUN curl -#L https://github.com/bats-core/bats-core/archive/master.zip | unzip - && \


### PR DESCRIPTION
### What does this PR do?
Updating Openssl in the Alpine images to resolve CVE-2021-3711

### What ticket does this PR close?
Resolves #392 
### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
