### PR TITLE
Fixes helm tests by adding openssl package to Helm test image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ LABEL description="The authentication client required to expose secrets from a C
 FROM alpine:3.14 as k8s-cluster-test
 
 # Install packages for testing
-RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl-dev
+RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl openssl-dev
 
 # Install bats-core in /usr/local
 RUN curl -#L https://github.com/bats-core/bats-core/archive/master.zip | unzip - && \


### PR DESCRIPTION
### What does this PR do?

This PR fixes failures that are happening for the Helm validation test GitHub actions by adding the latest version of openssl (in addition to the openssl-dev package which is already being loaded) to the Helm test Docker image.

We'll need a followup to this PR to modify the version of the `cyberark/conjur-k8s-cluster-test` container that we're using in `helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh`. We're currently using the `edge` version:
```
        kubectl create deployment "$openssl_deployment" \
            --image cyberark/conjur-k8s-cluster-test:edge
```

We should really be using the current version that was just built. When we use the `edge` version, we're really testing with the **previous** version from the last merge. So if the current, "just-built" version has a flaw, we won't realize it right away because we're testing with the **previous** version. And once the current version of code gets merged, then we'll see failures on any subsequent PRs.... unless we push up a new, fixed-up "edge" version.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
