### PR TITLE
Uses just-built test client image for E2E CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,14 +97,14 @@ pipeline {
         }
         stage('Openshift E2E Workflow Tests') {
           steps {
-            sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --platform oc'
+            sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --platform oc --tag dev'
           }
         }
         stage('Run E2E Tests') {
           parallel {
             stage('Enterprise and test app deployed to GKE') {
               steps {
-                sh 'cd bin/test-workflow && summon --environment gke ./start --enterprise --platform gke'
+                sh 'cd bin/test-workflow && summon --environment gke ./start --enterprise --platform gke --tag dev'
               }
             }
             stage('Enterprise deployed locally, test app deployed to GKE') {
@@ -112,7 +112,7 @@ pipeline {
                 sh '''
                   HOST_IP="$(curl http://169.254.169.254/latest/meta-data/public-ipv4)";
                   echo "HOST_IP=${HOST_IP}"
-                  cd bin/test-workflow && summon --environment gke ./start --enterprise --platform jenkins
+                  cd bin/test-workflow && summon --environment gke ./start --enterprise --platform jenkins --tag dev
                 '''
               }
             }

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -38,10 +38,11 @@ function git_commit_short() {
 }
 
 function push_conjur-k8s-cluster-test() {
-    echo "Pushing Helm test image to Dockerhub..."
-    source_image=conjur-k8s-cluster-test:dev
-    destination_image_name=conjur-k8s-cluster-test
-    echo "Tagging and pushing $REGISTRY/$destination_image_name:$tag"
-    docker tag $source_image "$REGISTRY/$destination_image_name:$tag"
-    docker push "$REGISTRY/$destination_image_name:$tag"
+  tag="$1"
+  echo "Pushing Helm test image to Dockerhub..."
+  source_image=conjur-k8s-cluster-test:dev
+  destination_image_name=conjur-k8s-cluster-test
+  echo "Tagging and pushing $REGISTRY/$destination_image_name:$tag"
+  docker tag $source_image "$REGISTRY/$destination_image_name:$tag"
+  docker push "$REGISTRY/$destination_image_name:$tag"
 }

--- a/bin/publish
+++ b/bin/publish
@@ -7,9 +7,8 @@ REDHAT_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb
 readonly REGISTRY="cyberark"
 
 if [[ $1 = "--edge" ]]; then
-    tag=edge
-    push_conjur-k8s-cluster-test
-    exit 0
+  push_conjur-k8s-cluster-test "edge"
+  exit 0
 fi
 
 # We take the version from the TAG_NAME variable - removing the "v" prefix
@@ -58,6 +57,5 @@ else
 fi
 
 for tag in "${TAGS[@]}" $(gen_versions "$VERSION"); do
-    push_conjur-k8s-cluster-test
+  push_conjur-k8s-cluster-test "$tag"
 done
-

--- a/bin/test-workflow/platform_login.sh
+++ b/bin/test-workflow/platform_login.sh
@@ -23,6 +23,7 @@ fi
 
 function main {
   if [[ "$CONJUR_PLATFORM" == "gke" || "$APP_PLATFORM" == "gke" ]]; then
+    announce "Logging into GKE platform, cluster $GCLOUD_CLUSTER_NAME"
     gcloud auth activate-service-account \
       --key-file "$GCLOUD_SERVICE_KEY"
     gcloud container clusters get-credentials "$GCLOUD_CLUSTER_NAME" \
@@ -32,6 +33,7 @@ function main {
       -u oauth2accesstoken \
       -p "$(gcloud auth print-access-token)"
   elif [[ "$CONJUR_PLATFORM" == "oc" || "$APP_PLATFORM" == "oc" ]]; then
+    announce "Logging into OpenShift platform at $OPENSHIFT_URL"
     oc login "$OPENSHIFT_URL" \
       --username="$OPENSHIFT_USERNAME" \
       --password="$OPENSHIFT_PASSWORD" \

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -30,6 +30,10 @@ Usage: ./start [options]:
                                 - summon-sidecar
                                 - secretless-broker
                                 - secrets-provider-standalone
+    -t, --tag <test tag>      Image tag to use for test container
+                              'cyberark/conjur-k8s-cluster-test'. Defaults to
+                              'edge' (built on latest merge to master branch).
+                              Set to 'dev' to test with just-built image.
     -n, --nocleanup           Do not run the cleanup scripts, all resources are maintained.
                               All other selections are rejected
     -h, --help                Show the help message
@@ -44,7 +48,12 @@ function cleanup {
   fi
 }
 
-declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
+declare -a supported_apps=(
+  "summon-sidecar"
+  "secretless-broker"
+  "secrets-provider-standalone"
+  "secrets-provider-init"
+)
 # Default: Test all applications
 declare -a install_apps=("${supported_apps[@]}")
 
@@ -56,9 +65,9 @@ while true; do
         if [[ ! " ${supported_apps[@]} " =~ " $app " ]]; then
           echo "$app is not a supported test app!"
           echo "Supported test apps include:"
-          echo "  - summon-sidecar"
-          echo "  - secretless-broker"
-          echo "  - secrets-provider-init"
+          for s in ${supported_apps[@]}; do
+            echo "  - $s"
+          done
           exit 1
         fi
       done
@@ -72,6 +81,11 @@ while true; do
       ;;
     -p|--platform )
       CONJUR_PLATFORM="$2"
+      shift
+      shift
+      ;;
+    -t|--tag )
+      TEST_CLIENT_IMAGE_TAG="$2"
       shift
       shift
       ;;
@@ -101,6 +115,7 @@ export INSTALL_APPS=$(IFS=','; echo "${install_apps[*]}")
 
 export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
 export RUN_CLIENT_CONTAINER="${RUN_CLIENT_CONTAINER:-true}"
+export TEST_CLIENT_IMAGE_TAG="${TEST_CLIENT_IMAGE_TAG:-edge}"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   if [[ -z "$CONJUR_PLATFORM" ]]; then
@@ -149,8 +164,8 @@ test_app_workflow="
 ./8_app_verify_authentication.sh"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
-  if [[ "$CONJUR_PLATFORM" == "oc" && "$RUN_CLIENT_CONTAINER" == "true" ]]; then
-    source "./0_prep_env.sh"
+  source "./0_prep_env.sh"
+  if [[ "$RUN_CLIENT_CONTAINER" == "true" ]]; then
     run_command_with_platform "./1_deploy_conjur.sh"
     run_command_with_platform "$conjur_prep"
     run_command_with_platform "$cluster_prep"
@@ -159,6 +174,7 @@ if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
     if [[ "$CONJUR_PLATFORM" == "oc" ]]; then
       ./platform_login.sh
     fi
+    ./1_deploy_conjur.sh
     eval "$conjur_init"
     eval "$conjur_prep"
     eval "$cluster_prep"

--- a/bin/test-workflow/utils.sh
+++ b/bin/test-workflow/utils.sh
@@ -303,6 +303,7 @@ function run_command_with_platform {
     -e CONJUR_FOLLOWER_URL \
     -e DEPLOY_MASTER_CLUSTER \
     -e HELM_RELEASE \
+    -e TEST_CLIENT_IMAGE_TAG \
     -e GCLOUD_CLUSTER_NAME \
     -e GCLOUD_ZONE \
     -e GCLOUD_PROJECT_NAME \


### PR DESCRIPTION
### What does this PR do?

This fixes the E2E Jenkins CI tests so that they use a just-built test client image (which is used for kubectl, oc, helm, openssl, etc. clients) when running E2E test scripts, rather than using the `edge` version of this container that had been published on the PREVIOUS merge to the master branch.

Without this fix, there could potentially be flaws in the current, just-built client container image, but the CI test run will not catch the issue. If this occurs e.g. on a merge to the master branch, then the flawed, just-built client container image will be published as the new `edge` version, and all subsequent test runs will be broken.

For anyone using the E2E test scripts locally/manually, the version tag for the test client image defaults to `edge`, so that our E2E scripts are not dependent upon having to do a build of container images. This is convenient for those who may want to use the E2E scripts to explore Conjur authentication.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
