### PR TITLE
Uses just-built test client image for E2E CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,13 +97,11 @@ pipeline {
         }
         stage('Test app with') {
           parallel {
-            /*
             stage('Enterprise in GKE') {
               steps {
                 sh 'cd bin/test-workflow && summon --environment gke ./start --enterprise --platform gke --tag dev'
               }
             }
-            */
             stage('OSS in OpenShift') {
               steps {
                 sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --platform openshift --tag dev'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,12 +99,12 @@ pipeline {
           parallel {
             stage('Enterprise in GKE') {
               steps {
-                sh 'cd bin/test-workflow && summon --environment gke ./start --enterprise --platform gke'
+                sh 'cd bin/test-workflow && summon --environment gke ./start --enterprise --platform gke --tag dev'
               }
             }
             stage('OSS in OpenShift') {
               steps {
-                sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --platform openshift'
+                sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --platform openshift --tag dev'
               }
             }
           }
@@ -116,7 +116,7 @@ pipeline {
                 sh '''
                   HOST_IP="$(curl http://169.254.169.254/latest/meta-data/public-ipv4)";
                   echo "HOST_IP=${HOST_IP}"
-                  cd bin/test-workflow && summon --environment gke ./start --enterprise --platform jenkins
+                  cd bin/test-workflow && summon --environment gke ./start --enterprise --platform jenkins --tag dev
                 '''
               }
             }
@@ -125,7 +125,7 @@ pipeline {
                 sh '''
                   HOST_IP="$(curl http://169.254.169.254/latest/meta-data/public-ipv4)";
                   echo "HOST_IP=${HOST_IP}"
-                  cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --enterprise --platform jenkins
+                  cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --enterprise --platform jenkins --tag dev
                 '''
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,11 +97,13 @@ pipeline {
         }
         stage('Test app with') {
           parallel {
+            /*
             stage('Enterprise in GKE') {
               steps {
                 sh 'cd bin/test-workflow && summon --environment gke ./start --enterprise --platform gke --tag dev'
               }
             }
+            */
             stage('OSS in OpenShift') {
               steps {
                 sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --platform openshift --tag dev'

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -38,10 +38,11 @@ function git_commit_short() {
 }
 
 function push_conjur-k8s-cluster-test() {
-    echo "Pushing Helm test image to Dockerhub..."
-    source_image=conjur-k8s-cluster-test:dev
-    destination_image_name=conjur-k8s-cluster-test
-    echo "Tagging and pushing $REGISTRY/$destination_image_name:$tag"
-    docker tag $source_image "$REGISTRY/$destination_image_name:$tag"
-    docker push "$REGISTRY/$destination_image_name:$tag"
+  tag="$1"
+  echo "Pushing Helm test image to Dockerhub..."
+  source_image=conjur-k8s-cluster-test:dev
+  destination_image_name=conjur-k8s-cluster-test
+  echo "Tagging and pushing $REGISTRY/$destination_image_name:$tag"
+  docker tag $source_image "$REGISTRY/$destination_image_name:$tag"
+  docker push "$REGISTRY/$destination_image_name:$tag"
 }

--- a/bin/publish
+++ b/bin/publish
@@ -7,9 +7,8 @@ REDHAT_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb
 readonly REGISTRY="cyberark"
 
 if [[ $1 = "--edge" ]]; then
-    tag=edge
-    push_conjur-k8s-cluster-test
-    exit 0
+  push_conjur-k8s-cluster-test "edge"
+  exit 0
 fi
 
 # We take the version from the TAG_NAME variable - removing the "v" prefix
@@ -58,6 +57,5 @@ else
 fi
 
 for tag in "${TAGS[@]}" $(gen_versions "$VERSION"); do
-    push_conjur-k8s-cluster-test
+  push_conjur-k8s-cluster-test "$tag"
 done
-

--- a/bin/test-workflow/2_admin_load_conjur_policies.sh
+++ b/bin/test-workflow/2_admin_load_conjur_policies.sh
@@ -26,10 +26,10 @@ announce "Generating Conjur policy."
 prepare_conjur_cli_image() {
   announce "Pulling and pushing Conjur CLI image."
 
-  docker pull cyberark/conjur-cli:"$CONJUR_VERSION"-latest
+  docker pull "cyberark/conjur-cli:$CONJUR_VERSION-latest"
 
   cli_app_image="$(platform_image_for_push conjur-cli $CONJUR_NAMESPACE_NAME)"
-  docker tag cyberark/conjur-cli:"$CONJUR_VERSION"-latest "$cli_app_image"
+  docker tag "cyberark/conjur-cli:$CONJUR_VERSION-latest" "$cli_app_image"
 
   docker push "$cli_app_image"
 }

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -26,6 +26,8 @@ if [[ "$TEST_CLIENT_IMAGE_TAG" != "edge" ]]; then
   docker tag "$source_image:$TEST_CLIENT_IMAGE_TAG" "$test_client_image"
 
   docker push "$test_client_image"
+
+  docker image ls
 fi
 
 # Prepare our cluster with conjur and authnK8s credentials in a golden configmap

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -7,7 +7,6 @@ TIMEOUT="${TIMEOUT:-5m0s}"
 TEST_CLIENT_IMAGE_TAG="${TEST_CLIENT_IMAGE_TAG:-edge}"
 
 source utils.sh
-source ../build_utils
 
 check_env_var CONJUR_APPLIANCE_URL
 check_env_var CONJUR_NAMESPACE_NAME
@@ -21,7 +20,12 @@ set_namespace default
 
 if [[ "$TEST_CLIENT_IMAGE_TAG" != "edge" ]]; then
   announce "Pushing test client image conjur-k8s-cluster-test:$TEST_CLIENT_IMAGE_TAG"
-  push_conjur-k8s-cluster-test "$TEST_CLIENT_IMAGE_TAG"
+
+  source_image="conjur-k8s-cluster-test:$TEST_CLIENT_IMAGE_TAG"
+  test_client_image="$(platform_image_for_push $source_image $CONJUR_NAMESPACE_NAME)"
+  docker tag "$source_image" "$test_client_image"
+
+  docker push "$test_client_image"
 fi
 
 # Prepare our cluster with conjur and authnK8s credentials in a golden configmap

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euox pipefail
 cd "$(dirname "$0")" || ( echo "cannot cd into dir" && exit 1 )
 
 TIMEOUT="${TIMEOUT:-5m0s}"
@@ -21,9 +21,9 @@ set_namespace default
 if [[ "$TEST_CLIENT_IMAGE_TAG" != "edge" ]]; then
   announce "Pushing test client image conjur-k8s-cluster-test:$TEST_CLIENT_IMAGE_TAG"
 
-  source_image="conjur-k8s-cluster-test:$TEST_CLIENT_IMAGE_TAG"
+  source_image="conjur-k8s-cluster-test"
   test_client_image="$(platform_image_for_push $source_image $CONJUR_NAMESPACE_NAME)"
-  docker tag "$source_image" "$test_client_image"
+  docker tag "$source_image:$TEST_CLIENT_IMAGE_TAG" "$test_client_image"
 
   docker push "$test_client_image"
 fi

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -36,15 +36,15 @@ pushd ../../helm/conjur-config-cluster-prep > /dev/null
 
   if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
     conjur_url="$CONJUR_APPLIANCE_URL"
-    get_cert_options="-v -i -s -t $TEST_CLIENT_IMAGE_TAG -u"
+    get_cert_options="-v -i -s -t $CONJUR_NAMESPACE_NAME -u"
     service_account_options=""
   else
     conjur_url="$CONJUR_FOLLOWER_URL"
     if [[ "$CONJUR_PLATFORM" == "gke" ]]; then
-      get_cert_options="-v -i -s -t $TEST_CLIENT_IMAGE_TAG -u"
+      get_cert_options="-v -i -s -t $CONJUR_NAMESPACE_NAME -u"
       service_account_options="--set authnK8s.serviceAccount.create=false --set authnK8s.serviceAccount.name=conjur-cluster"
     elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
-      get_cert_options="-v -s -t $TEST_CLIENT_IMAGE_TAG -u"
+      get_cert_options="-v -s -t $CONJUR_NAMESPACE_NAME -u"
       service_account_options=""
     fi
   fi

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -36,15 +36,15 @@ pushd ../../helm/conjur-config-cluster-prep > /dev/null
 
   if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
     conjur_url="$CONJUR_APPLIANCE_URL"
-    get_cert_options="-v -i -s -t $CONJUR_NAMESPACE_NAME -u"
+    get_cert_options="-v -i -s -t $TEST_CLIENT_IMAGE_TAG -u"
     service_account_options=""
   else
     conjur_url="$CONJUR_FOLLOWER_URL"
     if [[ "$CONJUR_PLATFORM" == "gke" ]]; then
-      get_cert_options="-v -i -s -t $CONJUR_NAMESPACE_NAME -u"
+      get_cert_options="-v -i -s -t $TEST_CLIENT_IMAGE_TAG -u"
       service_account_options="--set authnK8s.serviceAccount.create=false --set authnK8s.serviceAccount.name=conjur-cluster"
     elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
-      get_cert_options="-v -s -t $CONJUR_NAMESPACE_NAME -u"
+      get_cert_options="-v -s -t $TEST_CLIENT_IMAGE_TAG -u"
       service_account_options=""
     fi
   fi

--- a/bin/test-workflow/platform_login.sh
+++ b/bin/test-workflow/platform_login.sh
@@ -23,6 +23,7 @@ fi
 
 function main {
   if [[ "$CONJUR_PLATFORM" == "gke" || "$APP_PLATFORM" == "gke" ]]; then
+    announce "Logging into GKE platform, cluster $GCLOUD_CLUSTER_NAME"
     gcloud auth activate-service-account \
       --key-file "$GCLOUD_SERVICE_KEY"
     gcloud container clusters get-credentials "$GCLOUD_CLUSTER_NAME" \
@@ -32,6 +33,7 @@ function main {
       -u oauth2accesstoken \
       -p "$(gcloud auth print-access-token)"
   elif [[ "$CONJUR_PLATFORM" == "openshift" || "$APP_PLATFORM" == "openshift" ]]; then
+    announce "Logging into OpenShift platform at $OPENSHIFT_URL"
     oc login "$OPENSHIFT_URL" \
       --username="$OPENSHIFT_USERNAME" \
       --password="$OPENSHIFT_PASSWORD" \

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -30,6 +30,10 @@ Usage: ./start [options]:
                                 - summon-sidecar
                                 - secretless-broker
                                 - secrets-provider-standalone
+    -t, --tag <test tag>      Image tag to use for test container
+                              'cyberark/conjur-k8s-cluster-test'. Defaults to
+                              'edge' (built on latest merge to master branch).
+                              Set to 'dev' to test with just-built image.
     -n, --nocleanup           Do not run the cleanup scripts, all resources are maintained.
                               All other selections are rejected
     -h, --help                Show the help message
@@ -44,7 +48,12 @@ function cleanup {
   fi
 }
 
-declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
+declare -a supported_apps=(
+  "summon-sidecar"
+  "secretless-broker"
+  "secrets-provider-standalone"
+  "secrets-provider-init"
+)
 # Default: Test all applications
 declare -a install_apps=("${supported_apps[@]}")
 
@@ -56,9 +65,9 @@ while true; do
         if [[ ! " ${supported_apps[@]} " =~ " $app " ]]; then
           echo "$app is not a supported test app!"
           echo "Supported test apps include:"
-          echo "  - summon-sidecar"
-          echo "  - secretless-broker"
-          echo "  - secrets-provider-init"
+          for s in ${supported_apps[@]}; do
+            echo "  - $s"
+          done
           exit 1
         fi
       done
@@ -72,6 +81,11 @@ while true; do
       ;;
     -p|--platform )
       CONJUR_PLATFORM="$2"
+      shift
+      shift
+      ;;
+    -t|--tag )
+      TEST_CLIENT_IMAGE_TAG="$2"
       shift
       shift
       ;;
@@ -101,6 +115,7 @@ export INSTALL_APPS=$(IFS=','; echo "${install_apps[*]}")
 
 export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
 export RUN_CLIENT_CONTAINER="${RUN_CLIENT_CONTAINER:-true}"
+export TEST_CLIENT_IMAGE_TAG="${TEST_CLIENT_IMAGE_TAG:-edge}"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   if [[ -z "$CONJUR_PLATFORM" ]]; then
@@ -149,8 +164,8 @@ test_app_workflow="
 ./8_app_verify_authentication.sh"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
-  if [[ "$CONJUR_PLATFORM" == "openshift" && "$RUN_CLIENT_CONTAINER" == "true" ]]; then
-    source "./0_prep_env.sh"
+  source "./0_prep_env.sh"
+  if [[ "$RUN_CLIENT_CONTAINER" == "true" ]]; then
     run_command_with_platform "./1_deploy_conjur.sh"
     run_command_with_platform "$conjur_prep"
     run_command_with_platform "$cluster_prep"
@@ -159,6 +174,7 @@ if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
     if [[ "$CONJUR_PLATFORM" == "openshift" ]]; then
       ./platform_login.sh
     fi
+    ./1_deploy_conjur.sh
     eval "$conjur_init"
     eval "$conjur_prep"
     eval "$cluster_prep"

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -175,7 +175,6 @@ if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
       ./platform_login.sh
     fi
     ./1_deploy_conjur.sh
-    eval "$conjur_init"
     eval "$conjur_prep"
     eval "$cluster_prep"
     eval "$test_app_workflow"

--- a/bin/test-workflow/utils.sh
+++ b/bin/test-workflow/utils.sh
@@ -303,6 +303,7 @@ function run_command_with_platform {
     -e CONJUR_FOLLOWER_URL \
     -e DEPLOY_MASTER_CLUSTER \
     -e HELM_RELEASE \
+    -e TEST_CLIENT_IMAGE_TAG \
     -e GCLOUD_CLUSTER_NAME \
     -e GCLOUD_ZONE \
     -e GCLOUD_PROJECT_NAME \

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -248,12 +248,13 @@ function ensure_openssl_pod_created() {
     existing_deployment="$(get_openssl_pod $openssl_deployment)"
     if [ -n "$existing_deployment" ]; then
         echo "Deleting existing SSL deployment $openssl_deployment"
-        oc delete deployment "$openssl_deployment"
+        kubectl delete deployment "$openssl_deployment"
+        sleep 5
 
         echo "Creating new SSL deployment $openssl_deployment"
         echo "Using image conjur-k8s-cluster-test:$test_image_tag"
-        oc create deployment "$openssl_deployment" \
-            --image conjur-k8s-cluster-test:"$test_image_tag"
+        kubectl create deployment "$openssl_deployment" \
+            --image "default-route-openshift-image-registry.apps.openshift-47-fips-enc.ci.conjur.net/$CONJUR_NAMESPACE_NAME/conjur-k8s-cluster-test:$CONJUR_NAMESPACE_NAME"
         # Remember that we need to clean up the deployment that we just created
         deployment_was_created=true
         # Wait for Pod to be ready
@@ -263,7 +264,7 @@ function ensure_openssl_pod_created() {
         # TODO: Remove sleep after this is fixed in kubectl
         sleep 5
         # Wait for Pod to be ready
-        oc wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
+        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
     fi
 
     if [ -z "$existing_deployment" ]; then

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -248,11 +248,11 @@ function ensure_openssl_pod_created() {
     existing_deployment="$(get_openssl_pod $openssl_deployment)"
     if [ -n "$existing_deployment" ]; then
         echo "Deleting existing SSL deployment $openssl_deployment"
-        kubectl delete deployment "$openssl_deployment"
+        oc delete deployment "$openssl_deployment"
 
         echo "Creating new SSL deployment $openssl_deployment"
         echo "Using image conjur-k8s-cluster-test:$test_image_tag"
-        kubectl create deployment "$openssl_deployment" \
+        oc create deployment "$openssl_deployment" \
             --image conjur-k8s-cluster-test:"$test_image_tag"
         # Remember that we need to clean up the deployment that we just created
         deployment_was_created=true
@@ -263,7 +263,7 @@ function ensure_openssl_pod_created() {
         # TODO: Remove sleep after this is fixed in kubectl
         sleep 5
         # Wait for Pod to be ready
-        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
+        oc wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
     fi
 
     if [ -z "$existing_deployment" ]; then

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -296,7 +296,7 @@ function ensure_openssl_pod_created() {
     # TODO: Remove sleep after this is fixed in kubectl
     sleep 5
     # Wait for Pod to be ready
-    oc wait --for=condition=ready pod -l "app=$openssl_deployment" || oc describe pod -l "app=$openssl_deployment"
+    oc wait --for=condition=ready pod -l "app=$openssl_deployment" || (oc describe pod -l "app=$openssl_deployment" && oc delete deployment "$openssl_deployment")
 }
 
 function k8s_retrieve_certificate() {

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -280,7 +280,7 @@ function ensure_openssl_pod_created() {
         # TODO: Remove sleep after this is fixed in kubectl
         sleep 5
         # Wait for Pod to be ready
-        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment"
+        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" --timeout=500s
     fi
 }
 

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -247,8 +247,8 @@ function ensure_openssl_pod_created() {
     # Create a test deployment if it hasn't been created already
     existing_deployment="$(get_openssl_pod $openssl_deployment)"
     if [ -n "$existing_deployment" ]; then
-        echo "Deleting existing SSL deployment $existing_deployment"
-        kubectl delete deployment "$existing_deployment"
+        echo "Deleting existing SSL deployment $openssl_deployment"
+        kubectl delete deployment "$openssl_deployment"
 
         echo "Creating new SSL deployment $openssl_deployment"
         echo "Using image conjur-k8s-cluster-test:$test_image_tag"

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -248,9 +248,9 @@ function ensure_openssl_pod_created() {
     existing_deployment="$(get_openssl_pod $openssl_deployment)"
     if [ -z "$existing_deployment" ]; then
         echo "Creating SSL deployment $openssl_deployment"
-        echo "Using image cyberark/conjur-k8s-cluster-test:$test_image_tag"
+        echo "Using image conjur-k8s-cluster-test:$test_image_tag"
         kubectl create deployment "$openssl_deployment" \
-            --image cyberark/conjur-k8s-cluster-test:"$test_image_tag"
+            --image conjur-k8s-cluster-test:"$test_image_tag"
         # Remember that we need to clean up the deployment that we just created
         deployment_was_created=true
         # Wait for Pod to be ready

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -274,45 +274,29 @@ function ensure_openssl_pod_created() {
         echo "Deleting existing SSL deployment $openssl_deployment"
         kubectl delete deployment "$openssl_deployment"
         sleep 5
-
-        echo "Creating new SSL deployment $openssl_deployment"
-        
-        conjur_k8s_cluster_test_image="$(platform_image_for_pull conjur-k8s-cluster-test $CONJUR_NAMESPACE_NAME)"
-        echo "Using image $conjur_k8s_cluster_test_image"
-
-        kubectl create deployment "$openssl_deployment" \
-            --image "$conjur_k8s_cluster_test_image"
-        
-        #kubectl create deployment "$openssl_deployment" \
-        #    --image "default-route-openshift-image-registry.apps.openshift-47-fips-enc.ci.conjur.net/$CONJUR_NAMESPACE_NAME/conjur-k8s-cluster-test:$CONJUR_NAMESPACE_NAME"
-        # Remember that we need to clean up the deployment that we just created
-        deployment_was_created=true
-        # Wait for Pod to be ready
-        echo "Waiting for OpenSSL test pod to be ready"
-        # Some flakiness here - wait currently will fail if the resource doesn't exist yet
-        # See https://github.com/kubernetes/kubernetes/issues/83242
-        # TODO: Remove sleep after this is fixed in kubectl
-        sleep 5
-        # Wait for Pod to be ready
-        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
     fi
 
-    if [ -z "$existing_deployment" ]; then
-        echo "Creating SSL deployment $openssl_deployment"
-        echo "Using image conjur-k8s-cluster-test:$test_image_tag"
-        kubectl create deployment "$openssl_deployment" \
-            --image conjur-k8s-cluster-test:"$test_image_tag"
-        # Remember that we need to clean up the deployment that we just created
-        deployment_was_created=true
-        # Wait for Pod to be ready
-        echo "Waiting for OpenSSL test pod to be ready"
-        # Some flakiness here - wait currently will fail if the resource doesn't exist yet
-        # See https://github.com/kubernetes/kubernetes/issues/83242
-        # TODO: Remove sleep after this is fixed in kubectl
-        sleep 5
-        # Wait for Pod to be ready
-        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
-    fi
+    echo "Creating new SSL deployment $openssl_deployment"
+    
+    conjur_k8s_cluster_test_image="$(platform_image_for_pull conjur-k8s-cluster-test $CONJUR_NAMESPACE_NAME)"
+    echo "Using image $conjur_k8s_cluster_test_image"
+
+    kubectl create deployment "$openssl_deployment" \
+        --image "$conjur_k8s_cluster_test_image"
+    
+    #kubectl create deployment "$openssl_deployment" \
+    #    --image "default-route-openshift-image-registry.apps.openshift-47-fips-enc.ci.conjur.net/$CONJUR_NAMESPACE_NAME/conjur-k8s-cluster-test:$CONJUR_NAMESPACE_NAME"
+    
+    # Remember that we need to clean up the deployment that we just created
+    deployment_was_created=true
+    # Wait for Pod to be ready
+    echo "Waiting for OpenSSL test pod to be ready"
+    # Some flakiness here - wait currently will fail if the resource doesn't exist yet
+    # See https://github.com/kubernetes/kubernetes/issues/83242
+    # TODO: Remove sleep after this is fixed in kubectl
+    sleep 5
+    # Wait for Pod to be ready
+    kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
 }
 
 function k8s_retrieve_certificate() {

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -247,13 +247,13 @@ function ensure_openssl_pod_created() {
     # Create a test deployment if it hasn't been created already
     existing_deployment="$(get_openssl_pod $openssl_deployment)"
     if [ -n "$existing_deployment" ]; then
-        echo "Deleting existing SSL deployment $openssl_deployment"
-        kubectl delete deployment "$openssl_deployment"
+        echo "Deleting existing SSL deployment $existing_deployment"
+        kubectl delete deployment "$existing_deployment"
 
         echo "Creating new SSL deployment $openssl_deployment"
-        echo "Using image cyberark/conjur-k8s-cluster-test:$test_image_tag"
+        echo "Using image conjur-k8s-cluster-test:$test_image_tag"
         kubectl create deployment "$openssl_deployment" \
-            --image cyberark/conjur-k8s-cluster-test:"$test_image_tag"
+            --image conjur-k8s-cluster-test:"$test_image_tag"
         # Remember that we need to clean up the deployment that we just created
         deployment_was_created=true
         # Wait for Pod to be ready
@@ -263,14 +263,14 @@ function ensure_openssl_pod_created() {
         # TODO: Remove sleep after this is fixed in kubectl
         sleep 5
         # Wait for Pod to be ready
-        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" --timeout=500s || kubectl describe pod -l "app=$openssl_deployment"
+        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
     fi
 
     if [ -z "$existing_deployment" ]; then
         echo "Creating SSL deployment $openssl_deployment"
-        echo "Using image cyberark/conjur-k8s-cluster-test:$test_image_tag"
+        echo "Using image conjur-k8s-cluster-test:$test_image_tag"
         kubectl create deployment "$openssl_deployment" \
-            --image cyberark/conjur-k8s-cluster-test:"$test_image_tag"
+            --image conjur-k8s-cluster-test:"$test_image_tag"
         # Remember that we need to clean up the deployment that we just created
         deployment_was_created=true
         # Wait for Pod to be ready
@@ -280,7 +280,7 @@ function ensure_openssl_pod_created() {
         # TODO: Remove sleep after this is fixed in kubectl
         sleep 5
         # Wait for Pod to be ready
-        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" --timeout=500s || kubectl describe pod -l "app=$openssl_deployment"
+        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
     fi
 }
 

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -252,9 +252,15 @@ function ensure_openssl_pod_created() {
         sleep 5
 
         echo "Creating new SSL deployment $openssl_deployment"
-        echo "Using image conjur-k8s-cluster-test:$test_image_tag"
+        
+        conjur_k8s_cluster_test_image="$(platform_image_for_pull conjur-k8s-cluster-test $CONJUR_NAMESPACE_NAME)"
+        echo "Using image $conjur_k8s_cluster_test_image"
+
         kubectl create deployment "$openssl_deployment" \
-            --image "default-route-openshift-image-registry.apps.openshift-47-fips-enc.ci.conjur.net/$CONJUR_NAMESPACE_NAME/conjur-k8s-cluster-test:$CONJUR_NAMESPACE_NAME"
+            --image "$conjur_k8s_cluster_test_image"
+        
+        #kubectl create deployment "$openssl_deployment" \
+        #    --image "default-route-openshift-image-registry.apps.openshift-47-fips-enc.ci.conjur.net/$CONJUR_NAMESPACE_NAME/conjur-k8s-cluster-test:$CONJUR_NAMESPACE_NAME"
         # Remember that we need to clean up the deployment that we just created
         deployment_was_created=true
         # Wait for Pod to be ready

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -263,7 +263,7 @@ function ensure_openssl_pod_created() {
         # TODO: Remove sleep after this is fixed in kubectl
         sleep 5
         # Wait for Pod to be ready
-        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment"
+        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" --timeout=500s || kubectl describe pod -l "app=$openssl_deployment"
     fi
 
     if [ -z "$existing_deployment" ]; then
@@ -280,7 +280,7 @@ function ensure_openssl_pod_created() {
         # TODO: Remove sleep after this is fixed in kubectl
         sleep 5
         # Wait for Pod to be ready
-        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" --timeout=500s
+        kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" --timeout=500s || kubectl describe pod -l "app=$openssl_deployment"
     fi
 }
 

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -241,6 +241,30 @@ function get_openssl_pod() {
     kubectl get pod -l "app=$openssl_deployment" -o jsonpath='{.items[*].metadata.name}'
 }
 
+function platform_image_for_pull() {
+    local image="$1"
+    local namespace="$2"
+    if [[ ${PLATFORM} = "openshift" ]]; then
+      echo "${PULL_DOCKER_REGISTRY_PATH}/$namespace/$1:$namespace"
+    elif [[ "$USE_DOCKER_LOCAL_REGISTRY" = "true" ]]; then
+      echo "${PULL_DOCKER_REGISTRY_URL}/$1:$CONJUR_NAMESPACE_NAME"
+    else
+      echo "${PULL_DOCKER_REGISTRY_PATH}/$1:$CONJUR_NAMESPACE_NAME"
+    fi
+}
+
+function platform_image_for_push() {
+    local image="$1"
+    local namespace="$2"
+    if [[ ${PLATFORM} = "openshift" ]]; then
+      echo "${DOCKER_REGISTRY_PATH}/$namespace/$1:$namespace"
+    elif [[ "$USE_DOCKER_LOCAL_REGISTRY" = "true" ]]; then
+      echo "${DOCKER_REGISTRY_URL}/$1:$CONJUR_NAMESPACE_NAME"
+    else
+      echo "${DOCKER_REGISTRY_PATH}/$1:$CONJUR_NAMESPACE_NAME"
+    fi
+}
+
 function ensure_openssl_pod_created() {
     openssl_deployment="$1"
 

--- a/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
+++ b/helm/conjur-config-cluster-prep/bin/get-conjur-cert.sh
@@ -272,7 +272,7 @@ function ensure_openssl_pod_created() {
     existing_deployment="$(get_openssl_pod $openssl_deployment)"
     if [ -n "$existing_deployment" ]; then
         echo "Deleting existing SSL deployment $openssl_deployment"
-        kubectl delete deployment "$openssl_deployment"
+        oc delete deployment "$openssl_deployment"
         sleep 5
     fi
 
@@ -281,7 +281,7 @@ function ensure_openssl_pod_created() {
     conjur_k8s_cluster_test_image="$(platform_image_for_pull conjur-k8s-cluster-test $CONJUR_NAMESPACE_NAME)"
     echo "Using image $conjur_k8s_cluster_test_image"
 
-    kubectl create deployment "$openssl_deployment" \
+    oc create deployment "$openssl_deployment" \
         --image "$conjur_k8s_cluster_test_image"
     
     #kubectl create deployment "$openssl_deployment" \
@@ -296,7 +296,7 @@ function ensure_openssl_pod_created() {
     # TODO: Remove sleep after this is fixed in kubectl
     sleep 5
     # Wait for Pod to be ready
-    kubectl wait --for=condition=ready pod -l "app=$openssl_deployment" || kubectl describe pod -l "app=$openssl_deployment"
+    oc wait --for=condition=ready pod -l "app=$openssl_deployment" || oc describe pod -l "app=$openssl_deployment"
 }
 
 function k8s_retrieve_certificate() {


### PR DESCRIPTION
This fixes the E2E Jenkins CI tests so that they use a just-built
test client image (which is used for kubectl, oc, helm, openssl, etc.
clients) when running E2E test scripts, rather than using the `edge`
version of this container that had been published on the PREVIOUS
merge to the master branch.

Without this fix, there could potentially be flaws in the current,
just-built client container image, but the CI test run will not catch
the issue. If this occurs e.g. on a merge to the master branch, then
the flawed, just-built client container image will be published as
the new `edge` version, and all subsequent test runs will be broken.

For anyone using the E2E test scripts locally/manually, the version tag
for the test client image defaults to `edge`, so that our E2E scripts
are not dependent upon having to do a build of container images. This is
convenient for those who may want to use the E2E scripts to explore
Conjur authentication.

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
