### PR TITLE
Add exit on failure.

### DIFF
--- a/bin/test-workflow/6_app_deploy_backend.sh
+++ b/bin/test-workflow/6_app_deploy_backend.sh
@@ -73,4 +73,5 @@ if [[ "$ret_val" != 0 ]]; then
   $cli version
   $cli get statefulset -n "$TEST_APP_NAMESPACE_NAME"
   $cli describe statefulset test-app-backend -n "$TEST_APP_NAMESPACE_NAME"
+  exit $ret_val
 fi


### PR DESCRIPTION
When running KinD in a VM, there was an error with Insufficient cpu.

```
Events:
  Type     Reason            Age                From               Message
  ----     ------            ----               ----               -------
  Warning  FailedScheduling  4s (x4 over 112s)  default-scheduler  0/1 nodes are available: 1 Insufficient cpu.
```

### What does this PR do?

Adding an exit inside
```
if [[ "$ret_val" != 0 ]]; then
```
The purpose of this check is to display debug information if the Helm chart fails, but we
should exit after so it is clear what fails.

### What ticket does this PR close?
Resolves #N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
