### PR TITLE
Adds volume to expose Annotations for Secrets Provider init app

### DIFF
--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
@@ -98,6 +98,8 @@ spec:
           mountPath: /run/conjur
         - name: conjur-certs
           mountPath: /etc/conjur/ssl
+        - name: podinfo
+          mountPath: /conjur/podinfo
       {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret
@@ -113,3 +115,9 @@ spec:
       - name: conjur-certs
         emptyDir:
           medium: Memory
+      - name: podinfo
+        downwardAPI:
+          items:
+          - path: annotations
+            fieldRef:
+              fieldPath: metadata.annotations


### PR DESCRIPTION
### What does this PR do?

This change adds a Volume and VolumeMount for the Secrets Provider init container application Helm chart so that Pod Annotations can be exposed to the Secrets Provider via the Kubernetes Downward API.

This will help with testing the M1 Push-to-File feature for the Secrets Provider.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
