### PR TITLE
Generate release file as single archive

### DIFF
--- a/bin/package-release-artifacts.sh
+++ b/bin/package-release-artifacts.sh
@@ -11,8 +11,8 @@ pushd helm > /dev/null
   # manifests for non-helm deployment
   # include version in manifest filename
   for chart in "${HELM_CHARTS[@]}"; do
-    version=$(yq eval '.version' $chart/Chart.yaml)
-    mv $chart/generated/$chart.yaml $chart/generated/$chart-$version.yaml
+    version=$(yq eval '.version' "$chart/Chart.yaml")
+    mv "$chart/generated/$chart.yaml" "$chart/generated/$chart-$version.yaml"
   done
 
   mkdir -p artifacts/raw-k8s-manifests
@@ -24,11 +24,11 @@ pushd helm > /dev/null
 
   # helm charts
   for chart in "${HELM_CHARTS[@]}"; do
-    helm package $chart
+    helm package "$chart"
   done
 
   mkdir -p artifacts/helm-charts/
-  mv *.tgz artifacts/helm-charts/
+  mv ./*.tgz artifacts/helm-charts/
   cp conjur-config-cluster-prep/bin/get-conjur-cert.sh artifacts/
 
   # combine all the artifacts into a single archive file
@@ -36,13 +36,13 @@ pushd helm > /dev/null
   readonly REPO_NAME="${GITHUB_REPOSITORY##*/}"
   readonly TAG_NAME="${GITHUB_REF##*/}"
   readonly ARCHIVE_FILENAME="$REPO_NAME-$TAG_NAME.tar.gz"
-  tar -czf $ARCHIVE_FILENAME artifacts
+  tar -czf "$ARCHIVE_FILENAME" artifacts
 
   rm -r artifacts/*
-  mv $ARCHIVE_FILENAME artifacts/
+  mv "$ARCHIVE_FILENAME" artifacts/
 
   # cleanup
   for chart in "${HELM_CHARTS[@]}"; do
-    git restore $chart/generated
+    git restore "$chart/generated"
   done
 popd > /dev/null


### PR DESCRIPTION
### What does this PR do?
- Previously the release would emit multiple artifacts and they had to be combined into a single .tar.gz file manually. This change automates this process.

### What ticket does this PR close?
Resolves ONYX-13020

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
