### PR TITLE
Clear GoConvey from pkg/authenticate

### DIFF
--- a/pkg/authenticator/config/config_test.go
+++ b/pkg/authenticator/config/config_test.go
@@ -216,7 +216,10 @@ func TestValidate(t *testing.T) {
 
 	for _, tc := range TestCases {
 		t.Run(tc.description, func(t *testing.T) {
+			// SETUP & EXERCISE
 			errLogs := tc.settings.Validate(successfulMockReadFile)
+
+			// ASSERT
 			tc.assert(t, errLogs)
 		})
 	}
@@ -306,9 +309,11 @@ func TestFromEnv(t *testing.T) {
 
 	for _, tc := range TestCases {
 		t.Run(tc.description, func(t *testing.T) {
+			// SETUP & EXERCISE
 			setEnv(tc.env)
 			config, err := FromEnv(successfulMockReadFile)
 
+			// ASSERT
 			if tc.expectErr {
 				assert.Nil(t, config)
 				assert.NotNil(t, err)
@@ -363,8 +368,11 @@ func TestConjurVersion(t *testing.T) {
 		}
 
 		t.Run(tc.description, func(t *testing.T) {
+			// SETUP & EXERCISE
 			settings := GatherSettings(provideVersion)
 			errLogs := settings.Validate(successfulMockReadFile)
+
+			// ASSERT
 			tc.assert(t, errLogs)
 			if tc.expVersion != "" {
 				assert.Equal(t, tc.expVersion, settings["CONJUR_VERSION"])
@@ -452,12 +460,15 @@ func TestDebugLogging(t *testing.T) {
 	}
 
 	for _, tc := range TestCases {
+		// SETUP
 		var logBuffer bytes.Buffer
 		logger.InfoLogger = log.New(&logBuffer, "", 0)
 
+		// EXERCISE
 		config := tc.settings.NewConfig()
 		assert.NotNil(t, config)
 
+		// ASSERT
 		logMessages := logBuffer.String()
 		if tc.debugValue == "true" {
 			assert.Contains(t, logMessages, "CAKC052")

--- a/pkg/authenticator/requests_test.go
+++ b/pkg/authenticator/requests_test.go
@@ -3,26 +3,21 @@ package authenticator
 import (
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestRequests(t *testing.T) {
-	Convey("LoginRequest", t, func() {
-		conjurVersion := "5"
-		authnURL := "dummyURL"
-		csrBytes := []byte("dummyCSRBytes")
+func TestLoginRequest(t *testing.T) {
+	// SETUP
+	conjurVersion := "5"
+	authnURL := "dummyURL"
+	csrBytes := []byte("dummyCSRBytes")
 
-		Convey("Given a host's username prefix", func() {
-			usernamePrefix := "host.path.to.policy"
+	// EXERCISE
+	req, err := LoginRequest(authnURL, conjurVersion, csrBytes, "host.path.to.policy")
+	if !assert.NoError(t, err) {
+		return
+	}
 
-			req, err := LoginRequest(authnURL, conjurVersion, csrBytes, usernamePrefix)
-			Convey("Finishes without raising an error", func() {
-				So(err, ShouldBeNil)
-			})
-
-			Convey("Includes the username prefix in the 'Host-Id-Prefix' header", func() {
-				So(req.Header.Get("Host-Id-Prefix"), ShouldEqual, usernamePrefix)
-			})
-		})
-	})
+	// ASSERT
+	assert.Equal(t, "host.path.to.policy", req.Header.Get("Host-Id-Prefix"))
 }


### PR DESCRIPTION


### What does this PR do?
Strip out GoConvey in favour of using the standard Go testing tooling. This is in line with our style guide which relies on the standard testing package, and a lightweight assertion library

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
