### PR TITLE
ONYX-13586-refactor-authenticate-tests

### DIFF
--- a/pkg/authenticator/authenticator_test.go
+++ b/pkg/authenticator/authenticator_test.go
@@ -48,7 +48,7 @@ func TestAuthenticator_GenerateCSR(t *testing.T) {
 
 	// EXERCISE
 	// Generate the CSR
-	csr, err := authn.GenerateCSR("host.path.to.policy")
+	csr, err := authn.generateCSR("host.path.to.policy")
 	assert.NoError(t, err)
 
 	// ASSERT
@@ -82,7 +82,7 @@ func TestAuthenticator_IsCertExpired(t *testing.T) {
 		}
 
 		// EXERCISE
-		isExpired := authn.IsCertExpired()
+		isExpired := authn.isCertExpired()
 
 		// ASSERT
 		assert.False(t, isExpired)
@@ -97,7 +97,7 @@ func TestAuthenticator_IsCertExpired(t *testing.T) {
 		}
 
 		// EXERCISE
-		isExpired := authn.IsCertExpired()
+		isExpired := authn.isCertExpired()
 
 		// ASSERT
 		assert.True(t, isExpired)

--- a/pkg/authenticator/authenticator_test.go
+++ b/pkg/authenticator/authenticator_test.go
@@ -1,173 +1,170 @@
 package authenticator
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
+	"bytes"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/pem"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cyberark/conjur-authn-k8s-client/pkg/access_token/memory"
 	"github.com/cyberark/conjur-authn-k8s-client/pkg/authenticator/config"
+	"github.com/cyberark/conjur-authn-k8s-client/pkg/log"
 )
 
-func parseCert(filename string) (*x509.Certificate, error) {
-	certPEMBlock, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	certDERBlock, certPEMBlock := pem.Decode(certPEMBlock)
-	cert, err := x509.ParseCertificate(certDERBlock.Bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return cert, nil
-}
-
-func TestAuthenticator_GenerateCSR(t *testing.T) {
-	// SETUP
-	// Create a minimal authenticator with a minimal config
-	authnConfig := config.Config{
-		PodName:      "testPodName",
-		PodNamespace: "testPodNamespace",
-	}
-	signingKey, err := rsa.GenerateKey(rand.Reader, 1024)
-	assert.NoError(t, err)
-
-	authn := &Authenticator{
-		Config:     authnConfig,
-		privateKey: signingKey,
-	}
-
-	// EXERCISE
-	// Generate the CSR
-	csr, err := authn.generateCSR("host.path.to.policy")
-	assert.NoError(t, err)
-
-	// ASSERT
-	// Parse the generated CSR using the stdlib to ensure
-	// it has the properties we expect
-	parsedCsr, err := x509.ParseCertificateRequest(csr)
-	assert.NoError(t, err)
-
-	// Assert on common name
-	assert.Equal(t, "host.path.to.policy", parsedCsr.Subject.CommonName)
-
-	// Assert on spiffe SAN
-	assert.Len(t, parsedCsr.Extensions, 1)
-	var sans []asn1.RawValue
-	_, _ = asn1.Unmarshal(parsedCsr.Extensions[0].Value, &sans)
-	assert.Len(t, sans, 1)
-	assert.Equal(
-		t,
-		"spiffe://cluster.local/namespace/testPodNamespace/podname/testPodName",
-		string(sans[0].Bytes),
-	)
-}
-
-func TestAuthenticator_IsCertExpired(t *testing.T) {
-	t.Run("Active cert", func(t *testing.T) {
-		// SETUP
-		activeCert, err := parseCert("testdata/good_cert.crt")
-		assert.NoError(t, err)
-		authn := Authenticator{
-			PublicCert: activeCert,
-		}
-
-		// EXERCISE
-		isExpired := authn.isCertExpired()
-
-		// ASSERT
-		assert.False(t, isExpired)
-	})
-
-	t.Run("Expired cert", func(t *testing.T) {
-		// SETUP
-		expiredCert, err := parseCert("testdata/expired_cert.crt")
-		assert.NoError(t, err)
-		authn := Authenticator{
-			PublicCert: expiredCert,
-		}
-
-		// EXERCISE
-		isExpired := authn.isCertExpired()
-
-		// ASSERT
-		assert.True(t, isExpired)
-	})
-}
-
-func Test_consumeInectClientCertError(t *testing.T) {
-	// SETUP
-	path := "/tmp/test_file"
-	expectedErr := "some\ntext\n"
-	err := ioutil.WriteFile(path, []byte(expectedErr), 0644)
-	assert.NoError(t, err)
-
-	// EXERCISE
-	consumedErr := consumeInjectClientCertError(path)
-
-	// ASSERT
-	assert.Equal(t, expectedErr, consumedErr)
-	assert.NoFileExists(t, path)
-
-}
+type assertFunc func(t *testing.T,
+	authn *Authenticator,
+	err error,
+	loginCsr *x509.CertificateRequest,
+	loginCsrErr error,
+	logTxt string,
+)
 
 func TestAuthenticator_Authenticate(t *testing.T) {
-	t.Run("happy path", func(t *testing.T) {
-		// Create a temporary file for storing the client cert. This will allow multiple tests to run in parallel
-		tmpDir := t.TempDir()
-		clientCertPath := filepath.Join(tmpDir, "etc:conjur:ssl:client.pem")
-		certLogPath := filepath.Join(tmpDir, "tmp:conjur_copy_text_output.log")
-		tokenPath := filepath.Join(tmpDir, "run:conjur:access-token")
+	testCases := []struct {
+		name               string
+		podName            string
+		podNamespace       string
+		skipWritingCSRFile bool
+		assert             assertFunc
+	}{
+		{
+			name:         "happy path",
+			podName:      "testPodName",
+			podNamespace: "testPodNamespace",
+			assert: func(t *testing.T, authn *Authenticator, err error, loginCsr *x509.CertificateRequest, loginCsrErr error, _ string) {
+				assert.NoError(t, err)
 
-		// Start up a test server to mock the Conjur server's auth endpoints
-		ts := testServer(clientCertPath, "some token")
-		defer ts.Close()
+				// Check the CSR
+				assert.NotNil(t, loginCsr)
+				assert.NoError(t, loginCsrErr)
 
-		// Create an authenticator with dummy config
-		at, _ := memory.NewAccessToken()
-		sslcert := pem.EncodeToMemory(&pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: ts.Certificate().Raw,
+				// Assert on common name
+				assert.Equal(t, "test-user", loginCsr.Subject.CommonName)
+
+				// Assert on spiffe SAN
+				assert.Len(t, loginCsr.Extensions, 1)
+				var sans []asn1.RawValue
+				_, _ = asn1.Unmarshal(loginCsr.Extensions[0].Value, &sans)
+				assert.Len(t, sans, 1)
+
+				assert.Equal(
+					t,
+					"spiffe://cluster.local/namespace/testPodNamespace/podname/testPodName",
+					string(sans[0].Bytes),
+				)
+
+				// Check that the access token was set correctly
+				token, _ := authn.AccessToken.Read()
+				assert.Equal(t, token, []byte("some token"))
+			},
+		},
+		{
+			name:         "empty podname",
+			podName:      "",
+			podNamespace: "",
+			assert: func(t *testing.T, authn *Authenticator, err error, loginCsr *x509.CertificateRequest, _ error, _ string) {
+				assert.NoError(t, err)
+
+				// Assert empty spiffe
+				assert.Len(t, loginCsr.Extensions, 1)
+				var sans []asn1.RawValue
+				_, _ = asn1.Unmarshal(loginCsr.Extensions[0].Value, &sans)
+				assert.Len(t, sans, 1)
+				assert.Equal(t, "", string(sans[0].Bytes))
+			},
+		},
+		{
+			name:         "expired cert",
+			podName:      "testPodName",
+			podNamespace: "testPodNamespace",
+			assert: func(t *testing.T, authn *Authenticator, err error, _ *x509.CertificateRequest, _ error, _ string) {
+				assert.NoError(t, err)
+				// Set the expiration date to now, and try to authenticate again
+				// This will cause the authenticator to try to refresh the cert
+				authn.PublicCert.NotAfter = time.Now()
+				err = authn.Authenticate()
+				assert.NoError(t, err)
+
+				// Check that the cert was renewed
+				assert.True(t, authn.PublicCert.NotAfter.After(time.Now()))
+			},
+		},
+		{
+			name:               "injects log on failure",
+			podName:            "testPodName",
+			podNamespace:       "testPodNamespace",
+			skipWritingCSRFile: true,
+			assert: func(t *testing.T, _ *Authenticator, err error, _ *x509.CertificateRequest, _ error, logTxt string) {
+				assert.Error(t, err)
+				// Check logs for the expected error
+				assert.Contains(t, logTxt, "error writing csr file")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// SETUP
+			// Create a temporary file for storing the client cert. This will allow multiple tests to run in parallel
+			tmpDir := t.TempDir()
+			clientCertPath := filepath.Join(tmpDir, "etc:conjur:ssl:client.pem")
+			certLogPath := filepath.Join(tmpDir, "tmp:conjur_copy_text_output.log")
+			tokenPath := filepath.Join(tmpDir, "run:conjur:access-token")
+			var loginCsr *x509.CertificateRequest
+			var loginCsrErr error
+
+			// Start up a test server to mock the Conjur server's auth endpoints
+			ts := NewTestAuthServer(clientCertPath, certLogPath, "some token", tc.skipWritingCSRFile)
+			ts.HandleLogin = func(csr *x509.CertificateRequest, err error) {
+				loginCsr = csr
+				loginCsrErr = err
+			}
+			defer ts.Server.Close()
+
+			// Create an authenticator with dummy config
+			at, _ := memory.NewAccessToken()
+			sslcert := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: ts.Server.Certificate().Raw,
+			})
+			username, _ := config.NewUsername("host/test-user")
+
+			cfg := config.Config{
+				Account:                   "account",
+				ClientCertPath:            clientCertPath,
+				ClientCertRetryCountLimit: 0,
+				ContainerMode:             "doesntmatter",
+				ConjurVersion:             "5",
+				InjectCertLogPath:         certLogPath,
+				PodName:                   tc.podName,
+				PodNamespace:              tc.podNamespace,
+				SSLCertificate:            sslcert,
+				TokenFilePath:             tokenPath,
+				TokenRefreshTimeout:       0,
+				URL:                       ts.Server.URL,
+				Username:                  username,
+			}
+
+			// EXERCISE
+			authn, err := NewWithAccessToken(cfg, at)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Intercept the logs to check for the cert placement error
+			var logTxt bytes.Buffer
+			log.ErrorLogger.SetOutput(&logTxt)
+
+			// Call the main method of the authenticator. This is where most of the internal implementation happens
+			err = authn.Authenticate()
+
+			// ASSERT
+			tc.assert(t, authn, err, loginCsr, loginCsrErr, logTxt.String())
 		})
-		username, _ := config.NewUsername("host/test-user")
-
-		cfg := config.Config{
-			Account:                   "account",
-			ClientCertPath:            clientCertPath,
-			ClientCertRetryCountLimit: 1,
-			ContainerMode:             "doesntmatter",
-			ConjurVersion:             "5",
-			InjectCertLogPath:         certLogPath,
-			PodName:                   "somepodname",
-			PodNamespace:              "somepodnamespace",
-			SSLCertificate:            sslcert,
-			TokenFilePath:             tokenPath,
-			TokenRefreshTimeout:       0,
-			URL:                       ts.URL,
-			Username:                  username,
-		}
-
-		authn, err := NewWithAccessToken(cfg, at)
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		err = authn.Authenticate()
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		// Check that the access token was set correctly
-		token, _ := authn.AccessToken.Read()
-		assert.Equal(t, token, []byte("some token"))
-	})
+	}
 }


### PR DESCRIPTION
### What does this PR do?
- Refactor unit test on the Authenticator class to test all scenarios through the public interface (i.e. the `Authenticate()` method) as opposed to directly testing internal implementation methods (e.g. `generateCSR()`)

- Privatise methods that are not used externally (ie. in main.go)

### What ticket does this PR close?
[ONYX-13586](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-13586)

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Manual tests
**If you are preparing for a release**, have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local authn-k8s client image build
