### PR TITLE
Update to Go 1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- The project Golang version is updated from the end-of-life v1.15 to version v1.16. [cyberark/conjur-authn-k8s-client#416](https://github.com/cyberark/conjur-authn-k8s-client/pull/416)
+
 ## [0.22.0] - 2021-09-17
 ### Added
 - Introduces the `conjur-config-cluster-prep.yaml` and `conjur-config-namespace-prep.yaml` raw Kubernetes manifests generated from their corresponding Helm charts. These manifests provide an alternative method of configuring a Kubernetes cluster for the deployment of Conjur-authenticated applications for users unable to use  Helm in their environment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM goboring/golang:1.15.6b5 as authenticator-client-builder
+FROM goboring/golang:1.16.7b7 as authenticator-client-builder
 MAINTAINER CyberArk Software Ltd.
 
 ENV GOOS=linux \

--- a/Dockerfile.junit
+++ b/Dockerfile.junit
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.16-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-junit-processor"
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.16-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-test-runner"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cyberark/conjur-authn-k8s-client
 
-go 1.15
+go 1.16
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/pkg/authenticator/authenticator_test.go
+++ b/pkg/authenticator/authenticator_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cyberark/conjur-authn-k8s-client/pkg/access_token/memory"


### PR DESCRIPTION
Fixes build failing due to goconvey dependency change

The rest is copied from https://github.com/cyberark/secrets-provider-for-k8s/pull/379:

### Desired Outcome

Jenkins builds of Docker images do NOT fail with errors such as the following:

```
[2021-10-26T21:50:18.036Z] #21 1.547 package embed: unrecognized import path "embed": import path does not begin with hostname
[2021-10-26T21:50:26.134Z] #21 8.793 package io/fs: unrecognized import path "io/fs": import path does not begin with hostname
[2021-10-26T21:50:32.671Z] #21 ERROR: executor failed running [/bin/sh -c go get -u github.com/jstemmer/go-junit-report &&     go get github.com/smartystreets/goconvey]: exit code: 1
```

### Implemented Changes

The version of Go used in our base Docker builder container is upgraded from Go v1.15 to Go v1.16.
This seems to eliminate the errors shown above.

### Connected Issue/Story

### Definition of Done

- Jenkins builds run with no errors.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
