### PR TITLE
Include Push-to-File Secrets Provider in E2E test workflow

### DIFF
--- a/.github/workflows/e2e-workflow.yaml
+++ b/.github/workflows/e2e-workflow.yaml
@@ -29,4 +29,4 @@ jobs:
           version: v3.3.0
 
       - name: Run Start
-        run: bin/test-workflow/start
+        run: bin/test-workflow/start --ci-apps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,12 +99,12 @@ pipeline {
           parallel {
             stage('Enterprise in GKE') {
               steps {
-                sh 'cd bin/test-workflow && summon --environment gke ./start --enterprise --platform gke'
+                sh 'cd bin/test-workflow && summon --environment gke ./start --enterprise --platform gke --ci-apps'
               }
             }
             stage('OSS in OpenShift') {
               steps {
-                sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --platform openshift'
+                sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --platform openshift --ci-apps'
               }
             }
           }
@@ -116,7 +116,7 @@ pipeline {
                 sh '''
                   HOST_IP="$(curl http://169.254.169.254/latest/meta-data/public-ipv4)";
                   echo "HOST_IP=${HOST_IP}"
-                  cd bin/test-workflow && summon --environment gke ./start --enterprise --platform jenkins
+                  cd bin/test-workflow && summon --environment gke ./start --enterprise --platform jenkins --ci-apps
                 '''
               }
             }
@@ -125,7 +125,7 @@ pipeline {
                 sh '''
                   HOST_IP="$(curl http://169.254.169.254/latest/meta-data/public-ipv4)";
                   echo "HOST_IP=${HOST_IP}"
-                  cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --enterprise --platform jenkins
+                  cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=current ./start --enterprise --platform jenkins --ci-apps
                 '''
               }
             }

--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -38,12 +38,17 @@ pushd ../../helm/conjur-app-deploy > /dev/null
     --set app-secrets-provider-init.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-init \
     --set app-secrets-provider-init.conjur.authnConfigMap.name=conjur-authn-configmap-secrets-provider-init \
     --set app-secrets-provider-init.app.platform=$PLATFORM"
+  secrets_provider_p2f_options="--set app-secrets-provider-p2f.enable=true \
+    --set app-secrets-provider-p2f.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-p2f \
+    --set app-secrets-provider-p2f.app.platform=$PLATFORM \
+    --set app-secrets-provider-p2f.secretsProvider.image.tag=edge"
 
   declare -A app_options
   app_options[summon-sidecar]="$summon_sidecar_options"
   app_options[secretless-broker]="$secretless_broker_options"
   app_options[secrets-provider-standalone]="$secrets_provider_standalone_options"
   app_options[secrets-provider-init]="$secrets_provider_init_options"
+  app_options[secrets-provider-p2f]="$secrets_provider_p2f_options"
 
   # restore array of apps to install
   declare -a install_apps=($(split_on_comma_delimiter $INSTALL_APPS))

--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -40,8 +40,7 @@ pushd ../../helm/conjur-app-deploy > /dev/null
     --set app-secrets-provider-init.app.platform=$PLATFORM"
   secrets_provider_p2f_options="--set app-secrets-provider-p2f.enabled=true \
     --set app-secrets-provider-p2f.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-p2f \
-    --set app-secrets-provider-p2f.app.platform=$PLATFORM \
-    --set app-secrets-provider-p2f.secretsProvider.image.tag=edge"
+    --set app-secrets-provider-p2f.app.platform=$PLATFORM"
 
   declare -A app_options
   app_options[summon-sidecar]="$summon_sidecar_options"

--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -38,7 +38,7 @@ pushd ../../helm/conjur-app-deploy > /dev/null
     --set app-secrets-provider-init.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-init \
     --set app-secrets-provider-init.conjur.authnConfigMap.name=conjur-authn-configmap-secrets-provider-init \
     --set app-secrets-provider-init.app.platform=$PLATFORM"
-  secrets_provider_p2f_options="--set app-secrets-provider-p2f.enable=true \
+  secrets_provider_p2f_options="--set app-secrets-provider-p2f.enabled=true \
     --set app-secrets-provider-p2f.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-p2f \
     --set app-secrets-provider-p2f.app.platform=$PLATFORM \
     --set app-secrets-provider-p2f.secretsProvider.image.tag=edge"

--- a/bin/test-workflow/8_app_verify_authentication.sh
+++ b/bin/test-workflow/8_app_verify_authentication.sh
@@ -26,6 +26,7 @@ function finish {
     "SECRETLESS_PORT_FORWARD_PID"
     "SECRETS_PROVIDER_STANDALONE_PID"
     "SECRETS_PROVIDER_INIT_PORT_FORWARD_PID"
+    "SECRETS_PROVIDER_P2F_PORT_FORWARD_PID"
   )
 
   # Upon error, dump some kubernetes resources and Conjur authentication policy
@@ -81,6 +82,7 @@ if [[ "$PLATFORM" == "openshift" ]]; then
   secretless_pod=$(get_pod_name test-app-secretless)
   secrets_provider_standalone_pod=$(get_pod_name test-app-secrets-provider-standalone)
   secrets_provider_init_pod=$(get_pod_name test-app-secrets-provider-init)
+  secrets_provider_p2f_pod=$(get_pod_name test-app-secrets-provider-p2f)
 
   # Routes are defined, but we need to do port-mapping to access them
   oc port-forward "$sidecar_pod" 8081:8080 > /dev/null 2>&1 &
@@ -91,12 +93,15 @@ if [[ "$PLATFORM" == "openshift" ]]; then
   SECRETS_PROVIDER_STANDALONE_PID=$!
   oc port-forward "$secrets_provider_init_pod" 8086:8080 > /dev/null 2>&1 &
   SECRETS_PROVIDER_INIT_PORT_FORWARD_PID=$!
+  oc port-forward "$secrets_provider_p2f_pod" 8087:8080 > /dev/null 2>&1 &
+  SECRETS_PROVIDER_P2F_PORT_FORWARD_PID=$!
 
   curl_cmd=curl
   sidecar_url="localhost:8081"
   secretless_url="localhost:8083"
   secrets_provider_standalone_url="localhost:8084"
   secrets_provider_init_url="localhost:8086"
+  secrets_provider_p2f_url="localhost:8087"
 else
   # Test by curling from a pod that is inside the KinD cluster.
   curl_cmd=pod_curl
@@ -104,6 +109,7 @@ else
   secretless_url="test-app-secretless-broker.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   secrets_provider_standalone_url="test-app-secrets-provider-standalone.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
   secrets_provider_init_url="test-app-secrets-provider-init.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
+  secrets_provider_p2f_url="test-app-secrets-provider-p2f.$TEST_APP_NAMESPACE_NAME.svc.cluster.local:8080"
 fi
 
 echo "Waiting for urls to be ready"
@@ -121,12 +127,14 @@ app_urls[summon-sidecar]="$sidecar_url"
 app_urls[secretless-broker]="$secretless_url"
 app_urls[secrets-provider-standalone]="$secrets_provider_standalone_url"
 app_urls[secrets-provider-init]="$secrets_provider_init_url"
+app_urls[secrets-provider-p2f]="$secrets_provider_p2f_url"
 
 declare -A app_pets
 app_pets[summon-sidecar]="Mr. Sidecar"
 app_pets[secretless-broker]="Mr. Secretless"
 app_pets[secrets-provider-standalone]="Mr. Standalone"
 app_pets[secrets-provider-init]="Mr. Provider"
+app_pets[secrets-provider-p2f]="Mr. FileProvider"
 
 # check connection to each installed test app
 for app in "${install_apps[@]}"; do

--- a/bin/test-workflow/8_app_verify_authentication.sh
+++ b/bin/test-workflow/8_app_verify_authentication.sh
@@ -82,8 +82,6 @@ declare -a install_apps=($(split_on_comma_delimiter $INSTALL_APPS))
 
 if [[ "$PLATFORM" == "openshift" ]]; then
   # Routes are defined, but we need to do port-mapping to access them.
-  # Port-mapping needs to be conditional - the process kill loop in function 'finish'
-  # causes nearly invisible failures tying to kill a process that isn't deployed.
   if [[ " ${install_apps[*]} " =~ " summon-sidecar " ]]; then
     sidecar_pod=$(get_pod_name test-app-summon-sidecar)
     oc port-forward "$sidecar_pod" 8081:8080 > /dev/null 2>&1 &

--- a/bin/test-workflow/policy/app-policy.yml
+++ b/bin/test-workflow/policy/app-policy.yml
@@ -73,6 +73,24 @@
       resources: *secrets-provider-init-variables
 
 - !policy
+  id: test-secrets-provider-p2f-app-db
+  annotations:
+    description: This policy contains the creds to access the secrets provider app DB
+
+  body:
+    - !group
+
+    - &secrets-provider-p2f-variables
+      - !variable password
+      - !variable url
+      - !variable username
+
+    - !permit
+      role: !group
+      privileges: [ read, execute ]
+      resources: *secrets-provider-p2f-variables
+
+- !policy
   id: test-secrets-provider-standalone-app-db
   annotations:
     description: This policy contains the creds to access the secrets provider app DB

--- a/bin/test-workflow/policy/load_policies.sh
+++ b/bin/test-workflow/policy/load_policies.sh
@@ -32,6 +32,7 @@ readonly APPS=(
   "test-summon-sidecar-app"
   "test-secretless-app"
   "test-secrets-provider-init-app"
+  "test-secrets-provider-p2f-app"
   "test-secrets-provider-standalone-app"
 )
 

--- a/bin/test-workflow/policy/templates/app-grants.template.yml
+++ b/bin/test-workflow/policy/templates/app-grants.template.yml
@@ -30,6 +30,12 @@
     - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/oc-test-app-secrets-provider-init
 
 - !grant
+  role: !group test-secrets-provider-p2f-app-db
+  members:
+    - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/test-app-secrets-provider-p2f
+    - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/oc-test-app-secrets-provider-p2f
+
+- !grant
   role: !group test-secrets-provider-standalone-app-db
   members:
     - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/test-app-secrets-provider-standalone

--- a/bin/test-workflow/policy/templates/app-identities-policy.template.yml
+++ b/bin/test-workflow/policy/templates/app-identities-policy.template.yml
@@ -62,6 +62,14 @@
           authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
           kubernetes: "{{ IS_KUBERNETES }}"
       - !host
+        id: test-app-secrets-provider-p2f
+        annotations:
+          authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+          authn-k8s/service-account: test-app-secrets-provider-p2f
+          authn-k8s/deployment: test-app-secrets-provider-p2f
+          authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
+          kubernetes: "{{ IS_KUBERNETES }}"
+      - !host
         id: test-app-secrets-provider-standalone
         annotations:
           authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
@@ -95,6 +103,13 @@
         annotations:
           authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
           authn-k8s/service-account: oc-test-app-secrets-provider-init
+          authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
+          kubernetes: "{{ IS_OPENSHIFT }}"
+      - !host
+        id: oc-test-app-secrets-provider-p2f
+        annotations:
+          authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+          authn-k8s/service-account: oc-test-app-secrets-provider-p2f
           authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
           kubernetes: "{{ IS_OPENSHIFT }}"
       - !host

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -29,6 +29,8 @@ Usage: ./start [options]:
                               Currently supports:
                                 - summon-sidecar
                                 - secretless-broker
+                                - secrets-provider-init
+                                - secrets-provider-p2f
                                 - secrets-provider-standalone
     -n, --nocleanup           Do not run the cleanup scripts, all resources are maintained.
                               All other selections are rejected
@@ -44,7 +46,7 @@ function cleanup {
   fi
 }
 
-declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
+declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init" "secrets-provider-p2f")
 # Default: Test all applications
 declare -a install_apps=("${supported_apps[@]}")
 
@@ -56,9 +58,9 @@ while true; do
         if [[ ! " ${supported_apps[@]} " =~ " $app " ]]; then
           echo "$app is not a supported test app!"
           echo "Supported test apps include:"
-          echo "  - summon-sidecar"
-          echo "  - secretless-broker"
-          echo "  - secrets-provider-init"
+          for app in "${supported_apps[@]}"; do
+            echo "  - $app"
+          done
           exit 1
         fi
       done

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -23,6 +23,12 @@ Usage: ./start [options]:
                                 - Defaults to 'gke'
                                 - Supports 'jenkins'
                               All other selections are rejected
+    -c, --ci-apps             Run the E2E workflow against the subset of apps tested in CI
+                              These include:
+                                - summon-sidecar
+                                - secretless-broker
+                                - secrets-provider-init
+                                - secrets-provider-standalone
     -a, --apps <app>[,<app>]  Specify which test apps to install
                               Multiple apps should be specified as a single comma-delimited string
                               Excluding this flag runs all supported apps
@@ -47,6 +53,7 @@ function cleanup {
 }
 
 declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init" "secrets-provider-p2f")
+declare -a run_in_ci_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
 # Default: Test all applications
 declare -a install_apps=("${supported_apps[@]}")
 
@@ -66,6 +73,10 @@ while true; do
       done
       install_apps=("${apps[@]}")
       shift
+      shift
+      ;;
+    -c|--ci-apps )
+      install_apps=("${run_in_ci_apps[@]}")
       shift
       ;;
     -e|--enterprise )

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -12,6 +12,9 @@ Runs the end-to-end workflow for testing Conjur Kubernetes authentication.
 By default, the workflow is run against Conjur Open Source, but can be run
 against Conjur Enterprise.
 
+Note: If both --apps and --ci-apps flags are used, the workflow defers to
+      the --apps flag and its explicit set of test apps.
+
 Usage: ./start [options]:
 
     -e, --enterprise          Run the E2E workflow against Conjur Enterprise
@@ -60,6 +63,10 @@ declare -a install_apps=("${supported_apps[@]}")
 while true; do
   case "$1" in
     -a|--apps )
+      if [[ ! "${install_apps[@]}" = "${supported_apps[@]}" ]]; then
+        echo "Both --ci-apps and --apps flags used."
+        echo "Deferring to those apps specified with --apps flag."
+      fi
       declare -a apps=($(split_on_comma_delimiter "$2"))
       for app in "${apps[@]}"; do
         if [[ ! " ${supported_apps[@]} " =~ " $app " ]]; then
@@ -76,7 +83,12 @@ while true; do
       shift
       ;;
     -c|--ci-apps )
-      install_apps=("${run_in_ci_apps[@]}")
+      if [[ ! "${install_apps[@]}" = "${supported_apps[@]}" ]]; then
+        echo "Both --ci-apps and --apps flags used."
+        echo "Deferring to those apps specified with --apps flag."
+      else
+        install_apps=("${run_in_ci_apps[@]}")
+      fi
       shift
       ;;
     -e|--enterprise )

--- a/helm/conjur-app-deploy/Chart.yaml
+++ b/helm/conjur-app-deploy/Chart.yaml
@@ -24,6 +24,10 @@ dependencies:
       repository: "file://charts/app-secrets-provider-init"
       version: ">= 0.0.1"
       condition: app-secrets-provider-init.enabled
+    - name: app-secrets-provider-p2f
+      repository: "file://charts/app-secrets-provider-p2f"
+      version: ">= 0.0.1"
+      consition: app-secrets-provider-init-p2f.enabled
     - name: app-secretless-broker
       repository: "file://charts/app-secretless-broker"
       version: ">= 0.0.1"

--- a/helm/conjur-app-deploy/Chart.yaml
+++ b/helm/conjur-app-deploy/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
     - name: app-secrets-provider-p2f
       repository: "file://charts/app-secrets-provider-p2f"
       version: ">= 0.0.1"
-      consition: app-secrets-provider-init-p2f.enabled
+      condition: app-secrets-provider-p2f.enabled
     - name: app-secretless-broker
       repository: "file://charts/app-secretless-broker"
       version: ">= 0.0.1"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/Chart.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: app-secrets-provider-p2f
+home: https://www.conjur.org
+version: 0.1.0
+description: A Helm chart deploying an application with a Secrets Provider init container in Push-to-File mode
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
+keywords:
+  - security
+  - "secrets management"
+sources:
+  - https://github.com/cyberark/conjur-authn-k8s-client
+  - https://github.com/cyberark/secrets-provider-for-k8s
+  - https://github.com/cyberark/conjur-oss-helm-chart
+  - https://github.com/cyberark/conjur
+maintainers:
+  - name: Conjur Maintainers
+    email: conj_maintainers@cyberark.com

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/README.md
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/README.md
@@ -1,0 +1,2 @@
+# Helm Chart to Deploy an Application that uses a Secrets Provider for K8S init container in Push-to-File mode
+

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/NOTES.txt
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/NOTES.txt
@@ -1,0 +1,5 @@
+The Application deployment is complete.
+The following have been deployed:
+- A sample application with a Secrets Provider init container in Push-to-File mode
+
+Application is now available at test-app-secrets-provider-p2f.{{ .Release.Namespace }}.svc.cluster.local

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/rbac.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-app-secrets-provider-p2f-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-app-secrets-provider-p2f-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: test-app-secrets-provider-p2f
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: test-app-secrets-provider-p2f-role
+  apiGroup: ""

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/test_app_secrets_provider_p2f.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/test_app_secrets_provider_p2f.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-secrets-provider-p2f
+  labels:
+    app: test-app-secrets-provider-p2f
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: test-app-secrets-provider-p2f
+  type: {{ .Values.global.appServiceType }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-app-secrets-provider-p2f
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app-secrets-provider-p2f
+  name: test-app-secrets-provider-p2f
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-secrets-provider-p2f
+  template:
+    metadata:
+      labels:
+        app: test-app-secrets-provider-p2f
+      annotations:
+        conjur.org/container-mode: "init"
+        conjur.org/debug-logging: "true"
+        conjur.org/authn-identity: {{ quote .Values.conjur.authnLogin }}
+        conjur.org/secrets-destination: "file"
+        conjur.org/conjur-secrets.p2f-app: |
+          - test-secrets-provider-p2f-app-db/url
+          - test-secrets-provider-p2f-app-db/username
+          - test-secrets-provider-p2f-app-db/password
+        conjur.org/secret-file-path.p2f-app: "./application.yaml"
+        conjur.org/secret-file-template.p2f-app: |
+          spring:
+            datasource:
+              platform: postgres
+              url: jdbc:{{ printf `{{ secret "url" }}` }}
+              username: {{ printf `{{ secret "username" }}` }}
+              password: {{ printf `{{ secret "password" }}` }}
+            jpa:
+              generate-ddl: true
+              hibernate:
+                ddl-auto: update
+    spec:
+      serviceAccountName: test-app-secrets-provider-p2f
+      containers:
+      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
+        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+        name: test-app
+        command: [ "java", "-jar", "/app.jar", {{ printf "--spring.config.location=file:%s/application.yaml" .Values.app.secretsMountPath }} ]
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /pets
+            port: http
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: secrets
+          mountPath: {{ .Values.app.secretsMountPath }}
+      initContainers:
+      - image: {{ printf "%s:%s" .Values.secretsProvider.image.repository .Values.secretsProvider.image.tag }}
+        imagePullPolicy: {{ .Values.secretsProvider.image.pullPolicy }}
+        name: cyberark-secrets-provider-for-k8s
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+        volumeMounts:
+        - name: conjur-access-token
+          mountPath: /run/conjur
+        - name: conjur-certs
+          mountPath: /etc/conjur/ssl
+        - name: podinfo
+          mountPath: /conjur/podinfo
+        - name: secrets
+          mountPath: /conjur/secrets
+      {{- if eq .Values.app.platform "kubernetes" }}
+      imagePullSecrets:
+        - name: dockerpullsecret
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
+      {{- end }}
+      volumes:
+      - name: conjur-access-token
+        emptyDir:
+          medium: Memory
+      - name: conjur-certs
+        emptyDir:
+          medium: Memory
+      - name: podinfo
+        downwardAPI:
+          items:
+          - path: annotations
+            fieldRef:
+              fieldPath: metadata.annotations
+      - name: secrets
+        emptyDir:
+          medium: Memory

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/test-schema
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/test-schema
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# This script tests the restrictions on chart values
+# as defined in the 'values.schema.json' file.
+#
+# Requirements:
+#   - Helm v3.5.3 or later
+
+# Run this script from the directory in which this script resides
+# regardless of where it is invoked.
+cd "$(dirname "$0")"
+chart_dir="$(pwd)"
+
+source ../../../common/utils.sh
+
+# Default required settings
+readonly DEFAULT_AUTHN_LOGIN="conjur.authnLogin=host/conjur/authn-k8s/my-id/my-group/my-app"
+
+# Global test state
+num_passed=0
+num_failed=0
+test_failed=false
+
+function global_conjur_conn_configmap_name_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "global.conjur.conjurConnConfigMap=$1"
+}
+
+function global_app_service_type_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "global.appServiceType=$1"
+}
+
+function app_image_repository_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "app.image.repository=$1"
+}
+
+function app_image_pull_policy_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "app.image.pullPolicy=$1"
+}
+
+function main() {
+    banner $BOLD "Running Helm schema tests for chart \"$chart_dir\""
+    check_helm_version
+
+    announce "Conjur Connect ConfigMap name with dashes is accepted"
+    global_conjur_conn_configmap_name_test "name-with-dashes"
+    update_results "$?"
+
+    announce "Conjur Connect ConfigMap name with dotted name is accepted"
+    global_conjur_conn_configmap_name_test "dotted.serviceaccount.name"
+    update_results "$?"
+
+    announce "Valid app image Docker repository accepted"
+    app_image_repository_test "my-org/abc_123"
+    update_results "$?"
+
+    announce "App image Docker repository with '#' is rejected"
+    app_image_repository_test "my-org/abc#123"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    declare -a pull_policy_types=("Always" "Never" "IfNotPresent")
+    for policy in "${pull_policy_types[@]}"; do
+        announce "App image pullPolicy of $policy is accepted"
+        app_image_pull_policy_test "$policy"
+        update_results "$?"
+    done
+
+    announce "App image pullPolicy of lower case 'always' is rejected"
+    app_image_pull_policy_test "always"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "ServiceAccount name with 253 characters is rejected"
+    conjur_authn_configmap_name_test "name-with-more-than-253-chars----------40--------50--------60--------70--------80--------90--------100-------110-------120--------130-------140-------150-------160-------170-------180-------190-------200-------210-------220-------230-------240-------2503"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    display_final_results
+    if [ "$num_failed" -ne 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/test-unit
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/test-unit
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Runs a Helm unit test using the 'helm-unittest' Helm plugin.
+# Reference: https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md
+
+# Run this script from the directory in which this script resides
+# regardless of where it is invoked.
+cd "$(dirname "$0")"
+chart_dir="$(pwd)"
+
+source ../../../common/utils.sh
+
+banner $BOLD "Running Helm unit tests for chart \"$chart_dir\""
+run_helm_unittest

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/tests/test_app_secrets_provider_p2f_test.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/tests/test_app_secrets_provider_p2f_test.yaml
@@ -1,0 +1,68 @@
+suite: test test_app_secrets_provider_p2f
+
+templates:
+  - test_app_secrets_provider_p2f.yaml
+
+tests:
+  #=======================================================================
+  - it: should use default values for Service 
+  #=======================================================================
+    set:
+
+    documentIndex: 0
+
+    asserts:
+     - isKind:
+         of: Service
+
+     - equal:
+          path: spec.type
+          value: NodePort
+     - equal:
+          path: metadata.name
+          value:  test-app-secrets-provider-p2f
+     - equal:
+          path: metadata.labels.app
+          value:  test-app-secrets-provider-p2f
+
+  #=======================================================================
+  - it: should use default values for ServiceAccount
+  #=======================================================================
+    set:
+
+    documentIndex: 1
+
+    asserts:
+     - hasDocuments:
+          count: 3
+     - isKind:
+         of: ServiceAccount
+
+  #=======================================================================
+  - it: should use default values for Deployment 
+  #=======================================================================
+    set:
+
+    documentIndex: 2
+
+    asserts:
+     - isKind:
+          of: Deployment
+     - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/cyberark/demo-app:latest"
+     - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"
+     - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: "/mounted/secrets"
+     - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "docker.io/cyberark/secrets-provider-for-k8s:latest"
+     - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: "Always"
+     - equal:
+          path: spec.template.spec.initContainers[0].envFrom[0].configMapRef.name
+          value: "conjur-connect"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/values.schema.json
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/values.schema.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "properties": {
+      "app": {
+        "properties": {
+          "image": {
+            "properties": {
+              "repository": {
+                "type": "string",
+                "pattern": "^[a-z0-9:./_-]+$"
+              },
+              "tag": {
+                "type": "string"
+              },
+              "pullPolicy": {
+                "type": "string",
+                "pattern": "^(Always|Never|IfNotPresent)$"
+              }
+            }
+          }
+        }
+      },
+      "conjur": {
+        "properties": {
+          "authnLogin": {
+            "type": "string"
+          }
+        }
+      },
+      "secretsProvider": {
+        "properties": {
+          "image": {
+            "properties": {
+              "repository": {
+                "type": "string"
+              },
+              "tag": {
+                "type": "string"
+              },
+              "pullPolicy": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/values.yaml
@@ -1,0 +1,27 @@
+# Default values for the Application with Secrets Provider init container in Push-to-File mode Helm chart
+# This is a YAML-formatted file.
+
+global:
+  conjur:
+    # name of the ConfigMap created by the conjur-config-namespace-prep chart
+    conjurConnConfigMap: "conjur-connect"
+  appServiceType: "NodePort"
+
+app:
+  image:
+    repository: "docker.io/cyberark/demo-app"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+  platform: "kubernetes"
+  secretsMountPath: "/mounted/secrets"
+
+secretsProvider:
+  image:
+    repository: "docker.io/cyberark/secrets-provider-for-k8s"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+
+conjur:
+  authnLogin: ""

--- a/helm/conjur-app-deploy/values.yaml
+++ b/helm/conjur-app-deploy/values.yaml
@@ -24,5 +24,8 @@ app-secretless-broker:
 app-secrets-provider-init:
   enabled: false
 
+app-secrets-provider-p2f:
+  enabled: false
+
 app-secrets-provider-standalone:
   enabled: false


### PR DESCRIPTION
### Desired Outcome

This PR includes a Helm subchart to test Secrets Provider in Push-to-File mode in the E2E environment.

### Implemented Changes

- Added a Helm subchart for a demo app with Secret Provider in Push-to-File mode
  - P2F writes a custom spring config file to the shared volume
  - The custom config file is set at runtime using the `--spring.config.location` flag when starting the demo app
- Adds schema and unit tests for the SP P2F subchart

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
