### PR TITLE
Add Jaeger tracing to E2E Scripts

### DIFF
--- a/bin/test-workflow/0_prep_env.sh
+++ b/bin/test-workflow/0_prep_env.sh
@@ -85,6 +85,14 @@ fi
 export CONJUR_APPLIANCE_URL=${CONJUR_APPLIANCE_URL:-https://$conjur_service.$CONJUR_NAMESPACE_NAME.svc.cluster.local}
 export SAMPLE_APP_BACKEND_DB_PASSWORD="$(openssl rand -hex 12)"
 
+if [[ "$BENCHMARK_WITH_JAEGER" == "true" ]]; then
+  JAEGER_NAMESPACE_NAME="${TEST_APP_NAMESPACE_NAME}-jaeger"
+  JAEGER_COLLECTOR_URL="http://jaeger-collector.$JAEGER_NAMESPACE_NAME.svc.cluster.local:14268/api/traces"
+fi
+
+export JAEGER_NAMESPACE_NAME="${JAEGER_NAMESPACE_NAME:-}"
+export JAEGER_COLLECTOR_URL="${JAEGER_COLLECTOR_URL:-}"
+
 ### PLATFORM SPECIFIC CONFIG
 if [[ "$CONJUR_PLATFORM" == "gke" ]]; then
   export CONJUR_FOLLOWER_URL="https://conjur-follower.$CONJUR_NAMESPACE_NAME.svc.cluster.local"

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -47,3 +47,7 @@ pushd ../../helm/conjur-config-cluster-prep > /dev/null
       $service_account_options
 
 popd > /dev/null
+
+if [[ "$JAEGER_COLLECTOR_URL" != "" ]]; then
+  ./setup_tracing.sh
+fi

--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -37,9 +37,11 @@ pushd ../../helm/conjur-app-deploy > /dev/null
   secrets_provider_init_options="--set app-secrets-provider-init.enabled=true \
     --set app-secrets-provider-init.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-init \
     --set app-secrets-provider-init.conjur.authnConfigMap.name=conjur-authn-configmap-secrets-provider-init \
+    --set app-secrets-provider-init.conjur.jaegerCollectorUrl=$JAEGER_COLLECTOR_URL \
     --set app-secrets-provider-init.app.platform=$PLATFORM"
   secrets_provider_p2f_options="--set app-secrets-provider-p2f.enabled=true \
     --set app-secrets-provider-p2f.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-p2f \
+    --set app-secrets-provider-p2f.conjur.jaegerCollectorUrl=$JAEGER_COLLECTOR_URL \
     --set app-secrets-provider-p2f.app.platform=$PLATFORM"
 
   declare -A app_options

--- a/bin/test-workflow/cleanup_namespaces.sh
+++ b/bin/test-workflow/cleanup_namespaces.sh
@@ -4,3 +4,7 @@ source ./utils.sh
 
 $cli delete namespace "$CONJUR_NAMESPACE_NAME" --ignore-not-found
 $cli delete namespace "$TEST_APP_NAMESPACE_NAME" --ignore-not-found
+
+if [[ "$JAEGER_NAMESPACE_NAME" != "" ]]; then
+    $cli delete namespace "$JAEGER_NAMESPACE_NAME" --ignore-not-found
+fi

--- a/bin/test-workflow/setup_tracing.sh
+++ b/bin/test-workflow/setup_tracing.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source utils.sh
+
+announce "Setting up Jaeger for tracing"
+
+helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+$cli create namespace "${JAEGER_NAMESPACE_NAME}"
+set_namespace "${JAEGER_NAMESPACE_NAME}"
+helm install jaeger jaegertracing/jaeger \
+    --set provisionDataStore.cassandra=false \
+    --set provisionDataStore.elasticsearch=true \
+    --set storage.type=elasticsearch \
+    --set elasticsearch.replicas=1 \
+    --set elasticsearch.minimumMasterNodes=1
+
+wait_for_it 300 "has_resource 'app.kubernetes.io/instance=jaeger,app.kubernetes.io/component=collector' '$JAEGER_NAMESPACE_NAME'"
+# TODO: Even when the pods are available, the collector refuses connections. We need to wait until the collector is actually ready to
+# accept requests. Workaround is to run `kubectl delete pod test-app-secrets-provider-init-...` so the pod will be recreated after the
+# collector is ready.

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -41,6 +41,8 @@ Usage: ./start [options]:
                                 - secrets-provider-init
                                 - secrets-provider-p2f
                                 - secrets-provider-standalone
+    -b, --benchmark           Run benchmark tracing with Jaeger.
+                              Otherwise trace output will be appended to the init container's log.
     -n, --nocleanup           Do not run the cleanup scripts, all resources are maintained.
                               All other selections are rejected
     -h, --help                Show the help message
@@ -100,6 +102,10 @@ while true; do
       shift
       shift
       ;;
+    -b|--benchmark )
+      BENCHMARK_WITH_JAEGER="true"
+      shift
+      ;;
     -n|--nocleanup )
       do_cleanup="false"
       shift
@@ -126,6 +132,7 @@ export INSTALL_APPS=$(IFS=','; echo "${install_apps[*]}")
 
 export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
 export RUN_CLIENT_CONTAINER="${RUN_CLIENT_CONTAINER:-true}"
+export BENCHMARK_WITH_JAEGER"${BENCHMARK_WITH_JAEGER:-false}"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   if [[ -z "$CONJUR_PLATFORM" ]]; then
@@ -200,4 +207,12 @@ elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
   run_command_with_platform "$cluster_prep"
   ./conjur_outside_k8s_vars.sh
   run_command_with_platform "$test_app_workflow"
+fi
+
+if [[ "$BENCHMARK_WITH_JAEGER" == "true" ]]; then
+  announce "Go to http://127.0.0.1:8080/ to view benchmark results in Jaeger. Press Ctrl+C to stop.\
+Note: Run 'kubectl delete pod <secrets-provider pod name> -n $TEST_APP_NAMESPACE_NAME' to force the pod to recreate which will generate new metrics."
+
+  pod_name=$(kubectl get pods --namespace $JAEGER_NAMESPACE_NAME -l "app.kubernetes.io/instance=jaeger,app.kubernetes.io/component=query" -o jsonpath="{.items[0].metadata.name}")
+  kubectl port-forward --namespace $JAEGER_NAMESPACE_NAME $pod_name 8080:16686 > /dev/null
 fi

--- a/bin/test-workflow/utils.sh
+++ b/bin/test-workflow/utils.sh
@@ -63,7 +63,8 @@ has_namespace() {
 
 has_resource() {
   local selector="$1"
-  local num_matching_resources=$("$cli" get pods -n "$CONJUR_NAMESPACE_NAME" --selector "$selector" --no-headers 2>/dev/null | wc -l)
+  local namespace="${2:-$CONJUR_NAMESPACE_NAME}"
+  local num_matching_resources=$("$cli" get pods -n "$namespace" --selector "$selector" --no-headers 2>/dev/null | wc -l)
   if [ $num_matching_resources -gt 0 ]; then
     return 0
   else

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init/templates/test_app_secrets_provider_init.yaml
@@ -88,6 +88,10 @@ spec:
             value: k8s_secrets
           - name: DEBUG
             value: "true"
+          - name: JAEGER_COLLECTOR_URL
+            value: {{ .Values.conjur.jaegerCollectorUrl }}
+          - name: LOG_TRACES
+            value: "true"
         envFrom:
         - configMapRef:
             name: {{ .Values.conjur.authnConfigMap.name }}

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/test_app_secrets_provider_p2f.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/test_app_secrets_provider_p2f.yaml
@@ -36,6 +36,8 @@ spec:
       annotations:
         conjur.org/container-mode: "init"
         conjur.org/debug-logging: "true"
+        conjur.org/log-traces: "true"
+        conjur.org/jaeger-collector-url: {{ quote .Values.conjur.jaegerCollectorUrl }}
         conjur.org/authn-identity: {{ quote .Values.conjur.authnLogin }}
         conjur.org/secrets-destination: "file"
         conjur.org/conjur-secrets.p2f-app: |


### PR DESCRIPTION
Depends on #417 and https://github.com/cyberark/secrets-provider-for-k8s/pull/398

### Desired Outcome

This could either spin up a [Jaeger instance](https://www.jaegertracing.io/docs/1.29/getting-started/#all-in-one) and display the results, or use the console exporter and post-process the trace output into something more readable.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14604](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14604)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
