### PR TITLE
Update golang to 1.17

### DIFF
--- a/Dockerfile.junit
+++ b/Dockerfile.junit
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine
+FROM golang:1.17-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-junit-processor"
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine
+FROM golang:1.17-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-test-runner"
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/cyberark/conjur-authn-k8s-client
 
-go 1.16
+go 1.17
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
Use the latest major version of Go

Note: `Dockerfile` uses the `goboring/golang` image for FIPS compliance (see https://github.com/cyberark/conjur-authn-k8s-client/blob/master/design/fips-compliance.md) which does not yet have a 1.17 release. This has been left to use 1.16 for the time being.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14556](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14556)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
