### PR TITLE
Adds file format annotation for Secrets Provider P2F helm chart

### DIFF
--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/test_app_secrets_provider_p2f.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f/templates/test_app_secrets_provider_p2f.yaml
@@ -43,6 +43,7 @@ spec:
           - test-secrets-provider-p2f-app-db/username
           - test-secrets-provider-p2f-app-db/password
         conjur.org/secret-file-path.p2f-app: "./application.yaml"
+        conjur.org/secret-file-format.p2f-app: template
         conjur.org/secret-file-template.p2f-app: |
           spring:
             datasource:


### PR DESCRIPTION
### Desired Outcome

When the E2E test scripts are run, including the deployment of an application that uses the Secrets Provider as an Init container in Push-to-File mode, and then that Deployment is modified to use a "freshly-built" Secrets Provider image (i.e. image built using most recent code from Secrets Provider branch), then the Pet Store application should successfully come up.

Currently, when a "freshly-built" Secrets Provider image is used, the Pet Store application fails because the secret file that is created is defaulting to YAML format (because the `secret-file-format.<secret-group>` annotation is not explicitly set to `template`). In this scenario, the secret file needs to be a Spring boot application format file, built using the custom template supplied via Annotation.

### Implemented Changes

Added an Annotation to explicitly set the secret file format to `template` for the corresponding Helm subchart.

### Connected Issue/Story

### Definition of Done

- [x] When the `bin/test-workflow` scripts are run, and a freshly-built Secrets Provider image is used for the deployment that uses SP in Init container mode running in push-to-file mode, the application successfully comes up.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
