### PR TITLE
Remove pattern check in schema validation for cert file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Instead of getting K8S config object now you get Config Interface using NewConfigFromEnv() and ConfigFromEnv() [cyberark/conjur-authn-k8s-client#425](https://github.com/cyberark/conjur-authn-k8s-client/pull/425)
 - Instead of getting K8S authenticator object now you get Authenticator Interface using NewAuthenticator() and NewAuthenticatorWithAccessToken() [cyberark/conjur-authn-k8s-client#425](https://github.com/cyberark/conjur-authn-k8s-client/pull/425)
 
+### Fixed
+- Allows the Conjur certificate path in the conjur-config-cluster-prep Helm chart to be set to
+  any user specified directory. [cyberark/conjur-authn-k8s-client#434](https://github.com/cyberark/conjur-authn-k8s-client/pull/434)
+
 ## [0.22.0] - 2021-09-17
 ### Added
 - Introduces the `conjur-config-cluster-prep.yaml` and `conjur-config-namespace-prep.yaml` raw Kubernetes manifests generated from their corresponding Helm charts. These manifests provide an alternative method of configuring a Kubernetes cluster for the deployment of Conjur-authenticated applications for users unable to use  Helm in their environment.

--- a/bin/test-workflow/0_prep_env.sh
+++ b/bin/test-workflow/0_prep_env.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 ### PLATFORM DETAILS
 export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
-export UNIQUE_TEST_ID="$(uuidgen | tr "[:upper:]" "[:lower:]" | head -c 10)"
+export UNIQUE_TEST_ID="${UNIQUE_TEST_ID:-$(uuidgen | tr "[:upper:]" "[:lower:]" | head -c 10)}"
 
 # PLATFORM is used to differentiate between general Kubernetes platforms (kubernetes, openshift), while
 # CONJUR_PLATFORM is used to differentiate between sub-platforms (kind, gke, jenkins, openshift) for the Conjur deployment

--- a/helm/conjur-config-cluster-prep/test-schema
+++ b/helm/conjur-config-cluster-prep/test-schema
@@ -97,12 +97,12 @@ function main() {
     cert_file_test "files/conjur-cert.pem"
     update_results "$?"
 
-    announce "Conjur cert file beginning with 'tests/' is accepted"
-    cert_file_test "tests/test-cert.pem"
+    announce "Conjur cert file beginning with 'foo/' is accepted"
+    cert_file_test "foo/foobar.pem"
     update_results "$?"
 
-    announce "Conjur cert file beginning with 'foo/' is rejected"
-    cert_file_test "foo/foobar.pem"
+    announce "Empty Conjur cert file is rejected"
+    cert_file_test ""
     update_results "$?" "$EXPECT_FAILURE"
 
     announce "Base64-encoded Conjur cert with all valid characters is accepted"

--- a/helm/conjur-config-cluster-prep/values.schema.json
+++ b/helm/conjur-config-cluster-prep/values.schema.json
@@ -12,8 +12,7 @@
                 },
                 "certificateFilePath": {
                     "type": "string",
-                    "minLength": 1,
-                    "pattern": "(^files\/(.*))|(^tests\/(.*))"
+                    "minLength": 1
                 },
                 "certificateBase64": {
                     "type": "string",


### PR DESCRIPTION
The conjur-config-cluster-prep Helm schema tests check that the certificate file path
has `files` or `tests` in the path. The file path is not restricted
to those directories and it should allow other paths.

### Desired Outcome

The user should be able to specify an alternative path for the certificate file.
The files directory is only the default for the `get-conjur-cert.sh`
script but it is not required to be in this directory and the script is not required to be used,
this is only a helper script, the user can use an alternate method to get the cert.
Note that the certificate must be located inside the chart as Helm does not have access to
files outside the chart.

### Implemented Changes

Removed the check for `files` in the schema verification.

Also added a change to bin/test-workflow/0_prep_env.sh
to use an existing UNIQUE_TEST_ID if it exists. This is only for debugging and allows
the user to set this variable and then run ./start -n and ./stop independently.
Jenkins will not have this set and should create a new unique id each time. 

### Connected Issue/Story

CyberArk internal issue link: [ONYX-15540](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15540)

### Definition of Done
- [x] The certificate is not required to be in the files directory

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
