### PR TITLE
ONYX-14404: Add JWT Flow To E2E Automation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ For general contribution and community guidelines, please see the [community rep
 
 ### Debug Using Delve
 
-![DebugFlow](/Users/Tamir.Zheleznyak/Documents/Code/conjur-authn-k8s-client/dev/DebugFlow.png)
+![DebugFlow](dev/DebugFlow.png)
 
 For development porupuses you may want to debug your code on K8S pod. There are the steps to do it:
 
@@ -142,6 +142,28 @@ To run the test suite, run `./bin/build` and `./bin/test`.
 To run a sample deployment of the Helm charts located in `/helm`, run `./bin/test-workflow`. This
 will download and run the `conjur-oss-helm-chart` project example, then consecutively install the 
 `helm/conjur-config-cluster-prep`, `helm/conjur-config-namespace-prep`, and `helm/conjur-app-deploy` charts, in that order.
+
+#### Demo Workflow JWT
+
+You can create demo cluster of to check JWT sidecars on K8S. Please be aware this is now only for local kind cluster and not part of the pipleline because it requires open of K8S API for unauthenticated users. These are two options to run it.
+
+1. Test conjur-authn-k8s-client as sidecar container
+
+   `./bin/test-workflow/start  -a summon-sidecar-jwt --jwt` 
+
+2. Test secrets provider as init container :
+
+   `./bin/test-workflow/start  -a secrets-provider-init-jwt --jwt`
+
+Flags explanation :
+
+* -n Can be added for remaing the environment after script finished
+* -a Is for stating the app flow name
+* --jwt To enable jwt needed configurations to the cluster:
+  * Install K8S ca in Conjur so it will be able to fetch jwks from K8S API
+  * Open K8S JWKS API for unauthenticated user
+
+You can use the kubectl edit command to edit the images in the deployment and replacing them with you develop and debug images for development porpuses. And fill free to play with the policy and the application K8S manifests to check convinently things on the sidecars.
 
 ## Releases
 

--- a/bin/test-workflow/3_admin_init_conjur_cert_authority.sh
+++ b/bin/test-workflow/3_admin_init_conjur_cert_authority.sh
@@ -10,6 +10,8 @@ check_env_var CONJUR_OSS_HELM_INSTALLED
 check_env_var CONJUR_ACCOUNT
 check_env_var AUTHENTICATOR_ID
 
+TEST_JWT_FLOW="${TEST_JWT_FLOW:-false}"
+
 announce "Initializing Conjur certificate authority."
 
 if [[ "$CONJUR_PLATFORM" != "jenkins" ]]; then
@@ -19,6 +21,13 @@ fi
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   $cli exec "$conjur_master" -c conjur-oss -- bash -c "CONJUR_ACCOUNT=$CONJUR_ACCOUNT rake authn_k8s:ca_init['conjur/authn-k8s/$AUTHENTICATOR_ID']"
+
+  if [[ "$TEST_JWT_FLOW" == "true" ]]; then
+    announce "Install k8s api cert"
+    hash=$($cli exec "$conjur_master" -c conjur-oss -- bash -c "openssl x509 -hash -in /var/run/secrets/kubernetes.io/serviceaccount/..data/ca.crt -out /dev/null")
+    $cli exec "$conjur_master" -c conjur-oss -- bash -c "ln -s /var/run/secrets/kubernetes.io/serviceaccount/..data/ca.crt /etc/ssl/certs/$hash.0"
+  fi
+
 elif [[ "$CONJUR_PLATFORM" == "gke" ]]; then
   $cli exec "$conjur_master" -- chpst -u conjur conjur-plugin-service possum rake authn_k8s:ca_init["conjur/authn-k8s/$AUTHENTICATOR_ID"]
 elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -11,6 +11,7 @@ check_env_var CONJUR_APPLIANCE_URL
 check_env_var CONJUR_NAMESPACE_NAME
 check_env_var CONJUR_ACCOUNT
 check_env_var AUTHENTICATOR_ID
+
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "false" ]]; then
   check_env_var CONJUR_FOLLOWER_URL
 fi
@@ -24,15 +25,15 @@ pushd ../../helm/conjur-config-cluster-prep > /dev/null
   if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
     conjur_url="$CONJUR_APPLIANCE_URL"
     get_cert_options="-v -i -s -u"
-    service_account_options=""
+    additional_options=""
   else
     conjur_url="$CONJUR_FOLLOWER_URL"
     if [[ "$CONJUR_PLATFORM" == "gke" ]]; then
       get_cert_options="-v -i -s -u"
-      service_account_options="--set authnK8s.serviceAccount.create=false --set authnK8s.serviceAccount.name=conjur-cluster"
+      additional_options="--set authnK8s.serviceAccount.create=false --set authnK8s.serviceAccount.name=conjur-cluster"
     elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
       get_cert_options="-v -s -u"
-      service_account_options=""
+      additional_options=""
     fi
   fi
 
@@ -44,6 +45,6 @@ pushd ../../helm/conjur-config-cluster-prep > /dev/null
       --set conjur.certificateFilePath="files/conjur-cert.pem" \
       --set authnK8s.authenticatorID="$AUTHENTICATOR_ID" \
       --set authnK8s.clusterRole.name="conjur-clusterrole-$UNIQUE_TEST_ID" \
-      $service_account_options
+      $additional_options
 
 popd > /dev/null

--- a/bin/test-workflow/5_app_namespace_prep.sh
+++ b/bin/test-workflow/5_app_namespace_prep.sh
@@ -9,8 +9,13 @@ source utils.sh
 
 check_env_var TEST_APP_NAMESPACE_NAME
 check_env_var CONJUR_NAMESPACE_NAME
-
+TEST_JWT_FLOW="${TEST_JWT_FLOW:-false}"
+export AUTHN_STRATEGY="authn-k8s"
 set_namespace default
+
+if [[ "$TEST_JWT_FLOW" == "true" ]]; then
+  AUTHN_STRATEGY="authn-jwt"
+fi
 
 # Prepare a given namespace with a subset of credentials from the golden configmap
 announce "Installing namespace prep chart"
@@ -19,6 +24,7 @@ pushd ../../helm/conjur-config-namespace-prep > /dev/null
     helm upgrade --install "namespace-prep-$UNIQUE_TEST_ID" . -n "$TEST_APP_NAMESPACE_NAME" --debug --wait --timeout "$TIMEOUT" \
         --create-namespace \
         --set authnK8s.goldenConfigMap="conjur-configmap" \
-        --set authnK8s.namespace="$CONJUR_NAMESPACE_NAME"
+        --set authnK8s.namespace="$CONJUR_NAMESPACE_NAME" \
+        --set conjurConfigMap.authnStrategy=$AUTHN_STRATEGY
 
 popd > /dev/null

--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -27,6 +27,10 @@ pushd ../../helm/conjur-app-deploy > /dev/null
     --set app-summon-sidecar.app.image.repository=$TEST_APP_REPO \
     --set app-summon-sidecar.conjur.authnConfigMap.name=conjur-authn-configmap-summon-sidecar \
     --set app-summon-sidecar.app.platform=$PLATFORM"
+  summon_sidecar_jwt_options="--set app-summon-sidecar-jwt.enabled=true \
+    --set app-summon-sidecar-jwt.app.image.tag=$TEST_APP_TAG \
+    --set app-summon-sidecar-jwt.app.image.repository=$TEST_APP_REPO \
+    --set app-summon-sidecar-jwt.app.platform=$PLATFORM"
   secretless_broker_options="--set app-secretless-broker.enabled=true \
     --set app-secretless-broker.secretless.image.tag=$SECRETLESS_BROKER_TAG \
     --set app-secretless-broker.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secretless-broker \
@@ -42,6 +46,9 @@ pushd ../../helm/conjur-app-deploy > /dev/null
     --set app-secrets-provider-init.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-init \
     --set app-secrets-provider-init.conjur.authnConfigMap.name=conjur-authn-configmap-secrets-provider-init \
     --set app-secrets-provider-init.app.platform=$PLATFORM"
+  secrets_provider_init_jwt_options="--set app-secrets-provider-init-jwt.enabled=true \
+    --set app-secrets-provider-init-jwt.secretsProvider.image.tag=$SECRETS_PROVIDER_TAG \
+    --set app-secrets-provider-init-jwt.app.platform=$PLATFORM"
   secrets_provider_p2f_options="--set app-secrets-provider-p2f.enabled=true \
     --set app-secrets-provider-p2f.secretsProvider.image.tag=$SECRETS_PROVIDER_TAG \
     --set app-secrets-provider-p2f.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-p2f \
@@ -49,9 +56,11 @@ pushd ../../helm/conjur-app-deploy > /dev/null
 
   declare -A app_options
   app_options[summon-sidecar]="$summon_sidecar_options"
+  app_options[summon-sidecar-jwt]="$summon_sidecar_jwt_options"
   app_options[secretless-broker]="$secretless_broker_options"
   app_options[secrets-provider-standalone]="$secrets_provider_standalone_options"
   app_options[secrets-provider-init]="$secrets_provider_init_options"
+  app_options[secrets-provider-init-jwt]="$secrets_provider_init_jwt_options"
   app_options[secrets-provider-p2f]="$secrets_provider_p2f_options"
 
   # restore array of apps to install

--- a/bin/test-workflow/8_app_verify_authentication.sh
+++ b/bin/test-workflow/8_app_verify_authentication.sh
@@ -23,9 +23,11 @@ function finish {
 
   readonly PIDS=(
     "SIDECAR_PORT_FORWARD_PID"
+    "SIDECAR_JWT_PORT_FORWARD_PID"
     "SECRETLESS_PORT_FORWARD_PID"
     "SECRETS_PROVIDER_STANDALONE_PID"
     "SECRETS_PROVIDER_INIT_PORT_FORWARD_PID"
+    "SECRETS_PROVIDER_INIT_JWT_PORT_FORWARD_PID"
     "SECRETS_PROVIDER_P2F_PORT_FORWARD_PID"
   )
 
@@ -88,6 +90,12 @@ if [[ "$PLATFORM" == "openshift" ]]; then
     SIDECAR_PORT_FORWARD_PID=$!
   fi
 
+  if [[ " ${install_apps[*]} " =~ " summon-sidecar-jwt " ]]; then
+    sidecar_jwt_pod=$(get_pod_name test-app-summon-sidecar-jwt)
+    oc port-forward "$sidecar_jwt_pod" 8081:8080 > /dev/null 2>&1 &
+    SIDECAR_JWT_PORT_FORWARD_PID=$!
+  fi
+
   if [[ " ${install_apps[*]} " =~ " secretless-broker " ]]; then
     secretless_pod=$(get_pod_name test-app-secretless)
     oc port-forward "$secretless_pod" 8083:8080 > /dev/null 2>&1 &
@@ -104,6 +112,12 @@ if [[ "$PLATFORM" == "openshift" ]]; then
     secrets_provider_init_pod=$(get_pod_name test-app-secrets-provider-init)
     oc port-forward "$secrets_provider_init_pod" 8086:8080 > /dev/null 2>&1 &
     SECRETS_PROVIDER_INIT_PORT_FORWARD_PID=$!
+  fi
+
+  if [[ " ${install_apps[*]} " =~ " secrets-provider-init-jwt " ]]; then
+    secrets_provider_init_jwt_pod=$(get_pod_name test-app-secrets-provider-init-jwt)
+    oc port-forward "$secrets_provider_init_jwt_pod" 8086:8080 > /dev/null 2>&1 &
+    SECRETS_PROVIDER_INIT_JWT_PORT_FORWARD_PID=$!
   fi
   
   if [[ " ${install_apps[*]} " =~ " secrets-provider-p2f " ]]; then
@@ -137,16 +151,20 @@ check_url(){
 # declare associative arrays of app urls and pet names
 declare -A app_urls
 app_urls[summon-sidecar]="$sidecar_url"
+app_urls[summon-sidecar-jwt]="$sidecar_url"
 app_urls[secretless-broker]="$secretless_url"
 app_urls[secrets-provider-standalone]="$secrets_provider_standalone_url"
 app_urls[secrets-provider-init]="$secrets_provider_init_url"
+app_urls[secrets-provider-init-jwt]="$secrets_provider_init_url"
 app_urls[secrets-provider-p2f]="$secrets_provider_p2f_url"
 
 declare -A app_pets
 app_pets[summon-sidecar]="Mr. Sidecar"
+app_pets[summon-sidecar-jwt]="Mr. Sidecar JWT"
 app_pets[secretless-broker]="Mr. Secretless"
 app_pets[secrets-provider-standalone]="Mr. Standalone"
 app_pets[secrets-provider-init]="Mr. Provider"
+app_pets[secrets-provider-init-jwt]="Mr. JWT Provider"
 app_pets[secrets-provider-p2f]="Mr. FileProvider"
 
 # check connection to each installed test app

--- a/bin/test-workflow/policy/app-policy.yml
+++ b/bin/test-workflow/policy/app-policy.yml
@@ -35,6 +35,23 @@
       resources: *sidecar-variables
 
 - !policy
+  id: test-summon-sidecar-jwt-app-db
+  annotations:
+    description: This policy contains the creds to access the summon sidecar app DB
+  body:
+    - !group
+
+    - &sidecar-variables-jwt
+      - !variable password
+      - !variable url
+      - !variable username
+
+    - !permit
+      role: !group
+      privileges: [ read, execute ]
+      resources: *sidecar-variables-jwt
+
+- !policy
   id: test-secretless-app-db
   annotations:
     description: This policy contains the creds to access the secretless app DB
@@ -71,6 +88,23 @@
       role: !group
       privileges: [ read, execute ]
       resources: *secrets-provider-init-variables
+
+- !policy
+  id: test-secrets-provider-init-jwt-app-db
+  annotations:
+    description: This policy contains the creds to access the secrets provider app DB
+  body:
+    - !group
+
+    - &secrets-provider-init-jwt-variables
+      - !variable password
+      - !variable url
+      - !variable username
+
+    - !permit
+      role: !group
+      privileges: [ read, execute ]
+      resources: *secrets-provider-init-jwt-variables
 
 - !policy
   id: test-secrets-provider-p2f-app-db

--- a/bin/test-workflow/policy/load_policies.sh
+++ b/bin/test-workflow/policy/load_policies.sh
@@ -17,6 +17,7 @@ readonly POLICY_DIR="/policy"
 readonly POLICY_FILES=(
   "$POLICY_DIR/generated/$TEST_APP_NAMESPACE_NAME.authenticator-policy.yml"
   "$POLICY_DIR/generated/$TEST_APP_NAMESPACE_NAME.app-identities-policy.yml"
+  "$POLICY_DIR/generated/$TEST_APP_NAMESPACE_NAME.app-identities-policy-jwt.yml"
   "$POLICY_DIR/app-policy.yml"
   "$POLICY_DIR/generated/$TEST_APP_NAMESPACE_NAME.app-grants.yml"
 )
@@ -30,8 +31,10 @@ done
 readonly APPS=(
   "test-summon-init-app"
   "test-summon-sidecar-app"
+  "test-summon-sidecar-jwt-app"
   "test-secretless-app"
   "test-secrets-provider-init-app"
+  "test-secrets-provider-init-jwt-app"
   "test-secrets-provider-p2f-app"
   "test-secrets-provider-standalone-app"
 )
@@ -80,6 +83,12 @@ for app_name in "${APPS[@]}"; do
   conjur variable values add "my-app-db/prod/username" "prod-env-username"
   conjur variable values add "my-app-db/prod/port"     "12345"
   conjur variable values add "my-app-db/prod/cert-base64" "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lRRmZuTzFld2c1bUNoUi8rUlRWeDJQekFOQmdrcWhraUc5dzBCQVFzRkFEQVkKTVJZd0ZBWURWUVFERXcxamIyNXFkWEl0YjNOekxXTmhNQjRYRFRJeE1USXdOekUzTlRneE9Wb1hEVEl5TVRJdwpOekUzTlRneE9Wb3dHekVaTUJjR0ExVUVBeE1RWTI5dWFuVnlMbTE1YjNKbkxtTnZiVENDQVNJd0RRWUpLb1pJCmh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHZ1SEIwMWo2YytnVVBTaW5Ub2czQ09FeWUrd1RxZ2VPYlgKK1YwSnNlQnhSTnpHTWlSeWljWXIxWG9MeWh1MXpYcHEzQ1JKbDdZaDc1TGtQWENCblo3UlBxYW1yZXFxMWYyZwp2ODJidnNxRkhKQ3Y2WlhLVlNTRTJQY2xEMDZOZjFCUzVoc1FhTjhlblJCRURnTzRqbUszUjBUajBuWGNXMjJBCmZjSlVxQ3MvZm9GVHNVOWxmYitLNDVSWlBGWjRJNnpCQ25QcHg3bzJXVjNPUnpqQ0s5M1lDb2U3OHVVWmNFaGwKK2ZIdGtnQ3N2T1pFa2EvYjRpUjJZRUJmNWlxLzdjSjU4OFpEdVZwL0FyWW9tNHB0dnc0R2srbEdxRytaSjg5eQo1UElBaEplS3NvS3N6Y0xyR0tvYndQdERMY3doYzhQaTJNS2FMZTJsUUhRU1J5cDF1djhDQXdFQUFhT0I1akNCCjR6QU9CZ05WSFE4QkFmOEVCQU1DQmFBd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSEF3RUdDQ3NHQVFVRkJ3TUMKTUF3R0ExVWRFd0VCL3dRQ01BQXdId1lEVlIwakJCZ3dGb0FVN3J3RmVJV0lhbmNtQkdoMGFjUjZPY0pBTHN3dwpnWUlHQTFVZEVRUjdNSG1DRUdOdmJtcDFjaTV0ZVc5eVp5NWpiMjJDQ21OdmJtcDFjaTF2YzNPQ0ZXTnZibXAxCmNpMXZjM011WTI5dWFuVnlMVzl6YzRJWlkyOXVhblZ5TFc5emN5NWpiMjVxZFhJdGIzTnpMbk4yWTRJblkyOXUKYW5WeUxXOXpjeTVqYjI1cWRYSXRiM056TG5OMll5NWpiSFZ6ZEdWeUxteHZZMkZzTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQzRjZEtWMGZ4NC96WkZwYUx1bmM0MGY0blkwUHZzRFRaZUNCM0w1M1c5M29hVGFjeTFEcWVFCnVScWxVT05yWWNsQitzOUYyTWVmRHBTK0swTHlVV21hVG9oM05JWGtKTDZHNS9TTHVuN01ZRXJwMXN0YVpDY3UKMkxQcjR1bDJMRmY3UVJjRytwRXIvTmxmay9RaENNb1NCYk1MNmZvYWtSQzNpTzA2bEUrMWk2MHBSdzdkdW90YgpoV3R0cUhqSTFMc1QxZ09neDhOVTNLeUczNERqNURGZFdQbU1FckdjWlNpMXNjdmlLL0UvMTkyUUxGbnB4UlR2CnltQ1J0eWpaUjFyaUM5ZkhqcUhuNGZ1bVV3eUJ5aEJpUmVmNXhGVHBiL2lQZzB6a0lIeENzd3ZQY3lod1djaHMKZGlYeElPUEVxWGNNN0xRbnNvalBoUEt0VXlJRytKdWwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQoK"
+
+  echo "Adding JWT variables"
+  conjur variable values add conjur/authn-jwt/$AUTHENTICATOR_ID/jwks-uri $JWKS_URI
+  conjur variable values add conjur/authn-jwt/$AUTHENTICATOR_ID/token-app-property "sub"
+  conjur variable values add conjur/authn-jwt/$AUTHENTICATOR_ID/issuer $ISSUER
+  conjur variable values add conjur/authn-jwt/$AUTHENTICATOR_ID/identity-path "conjur/authn-jwt/$AUTHENTICATOR_ID/apps"
 done
 
 conjur authn logout

--- a/bin/test-workflow/policy/templates/app-grants.template.yml
+++ b/bin/test-workflow/policy/templates/app-grants.template.yml
@@ -1,8 +1,13 @@
 # Grant permission for hosts in the apps group to authenticate via kubernetes authenticator
 - !grant
-  role: !group conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/consumers
+  role: !group conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/k8s-consumers
   members:
     - !group conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps
+
+- !grant
+  role: !group conjur/authn-jwt/{{ AUTHENTICATOR_ID }}/jwt-consumers
+  members:
+    - !group conjur/authn-jwt/{{ AUTHENTICATOR_ID }}/apps
 
 # Grant permission for the appropriate hosts to read and execute app variables
 - !grant
@@ -18,6 +23,11 @@
     - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/oc-test-app-summon-sidecar
 
 - !grant
+  role: !group test-summon-sidecar-jwt-app-db
+  members:
+    - !host conjur/authn-jwt/{{ AUTHENTICATOR_ID }}/apps/system:serviceaccount:app-test:test-app-summon-sidecar
+
+- !grant
   role: !group test-secretless-app-db
   members:
     - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/test-app-secretless-broker
@@ -28,6 +38,11 @@
   members:
     - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/test-app-secrets-provider-init
     - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/oc-test-app-secrets-provider-init
+
+- !grant
+  role: !group test-secrets-provider-init-jwt-app-db
+  members:
+    - !host conjur/authn-jwt/{{ AUTHENTICATOR_ID }}/apps/system:serviceaccount:app-test:test-app-secrets-provider-init-jwt
 
 - !grant
   role: !group test-secrets-provider-p2f-app-db

--- a/bin/test-workflow/policy/templates/app-identities-policy-jwt.template.yml
+++ b/bin/test-workflow/policy/templates/app-identities-policy-jwt.template.yml
@@ -1,0 +1,26 @@
+---
+# This policy defines a group of whitelisted identities permitted to authenticate to the authn-jwt endpoint.
+- !policy
+  id: conjur/authn-jwt/{{ AUTHENTICATOR_ID }}/apps
+  annotations:
+    description: Identities permitted to authenticate
+  body:
+    - !group
+      annotations:
+        description: Group of authenticator identities permitted to call authn svc
+
+    - &hosts
+      - !host
+        id: system:serviceaccount:app-test:test-app-summon-sidecar
+        annotations:
+          authn-jwt/{{ AUTHENTICATOR_ID }}/kubernetes.io/namespace: app-test
+          authn-jwt/{{ AUTHENTICATOR_ID }}/kubernetes.io/serviceaccount/name: test-app-summon-sidecar
+
+      - !host
+        id: system:serviceaccount:app-test:test-app-secrets-provider-init-jwt
+        annotations:
+          authn-jwt/{{ AUTHENTICATOR_ID }}/sub: system:serviceaccount:app-test:test-app-secrets-provider-init-jwt
+
+    - !grant
+      role: !group
+      members: *hosts

--- a/bin/test-workflow/policy/templates/authenticator-policy.template.yml
+++ b/bin/test-workflow/policy/templates/authenticator-policy.template.yml
@@ -15,9 +15,31 @@
     - !variable ca/cert
 
     # define group of whitelisted authn ids permitted to call authn service
-    - !group consumers
+    - !group k8s-consumers
 
     - !permit
       resource: !webservice
       privilege: [ read, authenticate ]
-      role: !group consumers
+      role: !group k8s-consumers
+
+# This policy defines an authn-jwt endpoint
+- !policy
+  id: conjur/authn-jwt/{{ AUTHENTICATOR_ID }}
+  annotations:
+    description: Namespace defs for the Conjur cluster in dev
+  body:
+    - !webservice
+      annotations:
+        description: authn service for cluster
+    - !variable jwks-uri
+    - !variable issuer
+    - !variable token-app-property
+    - !variable identity-path
+
+    # define group of whitelisted authn ids permitted to call authn service
+    - !group jwt-consumers
+
+    - !permit
+      resource: !webservice
+      privilege: [ read, authenticate ]
+      role: !group jwt-consumers

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -37,10 +37,12 @@ Usage: ./start [options]:
                               Excluding this flag runs all supported apps
                               Currently supports:
                                 - summon-sidecar
+                                - summon-sidecar-jwt
                                 - secretless-broker
                                 - secrets-provider-init
                                 - secrets-provider-p2f
                                 - secrets-provider-standalone
+    --jwt                     Perform jwt authentication instead of k8s
     -n, --nocleanup           Do not run the cleanup scripts, all resources are maintained.
                               All other selections are rejected
     -h, --help                Show the help message
@@ -55,7 +57,7 @@ function cleanup {
   fi
 }
 
-declare -a supported_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init" "secrets-provider-p2f")
+declare -a supported_apps=("summon-sidecar" "summon-sidecar-jwt" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init" "secrets-provider-init-jwt" "secrets-provider-p2f")
 declare -a run_in_ci_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
 # Default: Test all applications
 declare -a install_apps=("${supported_apps[@]}")
@@ -78,6 +80,7 @@ while true; do
           exit 1
         fi
       done
+      TEST_JWT_FLOW="false"
       install_apps=("${apps[@]}")
       shift
       shift
@@ -87,6 +90,7 @@ while true; do
         echo "Both --ci-apps and --apps flags used."
         echo "Deferring to those apps specified with --apps flag."
       else
+        TEST_JWT_FLOW="false"
         install_apps=("${run_in_ci_apps[@]}")
       fi
       shift
@@ -102,6 +106,11 @@ while true; do
       ;;
     -n|--nocleanup )
       do_cleanup="false"
+      shift
+      ;;
+    --jwt )
+      echo "Going to test authn-jwt instead of authn-k8s"
+      TEST_JWT_FLOW="true"
       shift
       ;;
     -h|--help )
@@ -125,6 +134,7 @@ done
 export INSTALL_APPS=$(IFS=','; echo "${install_apps[*]}")
 
 export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
+export TEST_JWT_FLOW="${TEST_JWT_FLOW:-false}"
 export RUN_CLIENT_CONTAINER="${RUN_CLIENT_CONTAINER:-true}"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
@@ -193,7 +203,6 @@ elif [[ "$CONJUR_PLATFORM" == "gke" ]]; then
   eval "$conjur_init"
   run_command_with_platform "$conjur_prep"
   run_command_with_platform "$cluster_prep"
-  run_command_with_platform "$test_app_workflow"
 elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
   eval "$conjur_init"
   eval "$conjur_prep"

--- a/helm/conjur-app-deploy/Chart.yaml
+++ b/helm/conjur-app-deploy/Chart.yaml
@@ -20,10 +20,18 @@ dependencies:
       repository: "file://charts/app-summon-sidecar"
       version: ">= 0.0.1"
       condition: app-summon-sidecar.enabled
+    - name: app-summon-sidecar-jwt
+      repository: "file://charts/app-summon-sidecar-jwt"
+      version: ">= 0.0.1"
+      condition: app-summon-sidecar-jwt.enabled
     - name: app-secrets-provider-init
       repository: "file://charts/app-secrets-provider-init"
       version: ">= 0.0.1"
       condition: app-secrets-provider-init.enabled
+    - name: app-secrets-provider-init-jwt
+      repository: "file://charts/app-secrets-provider-init-jwt"
+      version: ">= 0.0.1"
+      condition: app-secrets-provider-init-jwt.enabled
     - name: app-secrets-provider-p2f
       repository: "file://charts/app-secrets-provider-p2f"
       version: ">= 0.0.1"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/Chart.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: app-secrets-provider-init-jwt
+home: https://www.conjur.org
+version: 0.1.0
+description: A Helm chart deploying an application with a Secrets Provider init container
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
+keywords:
+  - security
+  - "secrets management"
+sources:
+  - https://github.com/cyberark/conjur-authn-k8s-client
+  - https://github.com/cyberark/secrets-provider-for-k8s
+  - https://github.com/cyberark/conjur-oss-helm-chart
+  - https://github.com/cyberark/conjur
+maintainers:
+  - name: Conjur Maintainers
+    email: conj_maintainers@cyberark.com

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/README.md
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/README.md
@@ -1,0 +1,2 @@
+# Helm Chart to Deploy an Application that uses a Secrets Provider for K8S init container with JWT flow
+

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/templates/NOTES.txt
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/templates/NOTES.txt
@@ -1,0 +1,8 @@
+The Application deployment is complete.
+The following have been deployed:
+{{ if .Values.conjur.authnConfigMap.create -}}
+- A Conjur authentication configmap
+{{ end -}}
+- A sample application with a Secrets Provider init container
+
+Application is now available at test-app-secrets-provider-init.{{ .Release.Namespace }}.svc.cluster.local

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/templates/rbac.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/templates/rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-app-secrets-provider-init-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-app-secrets-provider-init-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: test-app-secrets-provider-init-jwt
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: test-app-secrets-provider-init-role
+  apiGroup: ""

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/templates/secret.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-app-secrets-provider-init-jwt-secret
+type: Opaque
+stringData:
+  conjur-map: |-
+    DB_URL: test-secrets-provider-init-jwt-app-db/url
+    DB_USERNAME: test-secrets-provider-init-jwt-app-db/username
+    DB_PASSWORD: test-secrets-provider-init-jwt-app-db/password

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/templates/test_app_secrets_provider_init.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/templates/test_app_secrets_provider_init.yaml
@@ -1,0 +1,128 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-secrets-provider-init
+  labels:
+    app: test-app-secrets-provider-init
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: test-app-secrets-provider-init
+  type: {{ .Values.global.appServiceType }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-app-secrets-provider-init-jwt
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app-secrets-provider-init
+  name: test-app-secrets-provider-init
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-secrets-provider-init
+  template:
+    metadata:
+      labels:
+        app: test-app-secrets-provider-init
+    spec:
+      serviceAccountName: test-app-secrets-provider-init-jwt
+      containers:
+      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
+        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+        name: test-app
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /pets
+            port: http
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        env:
+          - name: DB_URL
+            valueFrom:
+              secretKeyRef:
+                name: test-app-secrets-provider-init-jwt-secret
+                key: DB_URL
+          - name: DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: test-app-secrets-provider-init-jwt-secret
+                key: DB_USERNAME
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-app-secrets-provider-init-jwt-secret
+                key: DB_PASSWORD
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+      initContainers:
+      - image:  {{ printf "%s:%s" .Values.secretsProvider.image.repository .Values.secretsProvider.image.tag }}
+        imagePullPolicy: {{ .Values.secretsProvider.image.pullPolicy }}
+        name: cyberark-secrets-provider-for-k8s
+        env:
+          - name: CONTAINER_MODE
+            value: init
+          - name: JWT_TOKEN_PATH
+            value: /var/run/secrets/tokens/jwt
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: K8S_SECRETS
+            value: test-app-secrets-provider-init-jwt-secret
+          - name: SECRETS_DESTINATION
+            value: k8s_secrets
+          - name: DEBUG
+            value: "true"
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+        volumeMounts:
+        - name: conjur-access-token
+          mountPath: /run/conjur
+        - name: conjur-certs
+          mountPath: /etc/conjur/ssl
+        - name: podinfo
+          mountPath: /conjur/podinfo
+        - mountPath: /var/run/secrets/tokens
+          name: jwt-token
+      {{- if eq .Values.app.platform "kubernetes" }}
+      imagePullSecrets:
+        - name: dockerpullsecret
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
+      {{- end }}
+      volumes:
+      - name: conjur-access-token
+        emptyDir:
+          medium: Memory
+      - name: conjur-certs
+        emptyDir:
+          medium: Memory
+      - name: podinfo
+        downwardAPI:
+          items:
+          - path: annotations
+            fieldRef:
+              fieldPath: metadata.annotations
+      - name: jwt-token
+        projected:
+          sources:
+            - serviceAccountToken:
+                path: jwt
+                expirationSeconds: 6000
+                audience: conjur

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/values.schema.json
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/values.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "properties": {
+    "app": {
+      "properties": {
+        "image": {
+          "properties": {
+            "repository": {
+              "type": "string",
+              "pattern": "^[a-z0-9:./_-]+$"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "pattern": "^(Always|Never|IfNotPresent)$"
+            }
+          }
+        }
+      }
+    },
+    "conjur": {
+      "properties": {
+        "authnConfigMap": {
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "authnLogin": {
+          "type": "string"
+        }
+      }
+    },
+    "secretsProvider": {
+      "properties": {
+        "image": {
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-init-jwt/values.yaml
@@ -1,0 +1,30 @@
+# Default values for the Application with Secrets Provider init container Helm chart
+# This is a YAML-formatted file.
+
+global:
+  conjur:
+    # name of the ConfigMap created by the conjur-config-namespace-prep chart
+    conjurConnConfigMap: "conjur-connect"
+  appServiceType: "NodePort"
+
+app:
+  image:
+    repository: "docker.io/cyberark/demo-app"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+  platform: "kubernetes"
+
+secretsProvider:
+  image:
+    repository: "docker.io/cyberark/secrets-provider-for-k8s"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+
+conjur:
+  authnConfigMap:
+    create: true
+    name: "conjur-authn-configmap"
+  # host/conjur/authn-k8s/<authenticator-ID>/<conjur-policy-layer-or-group>/<app-host-id>
+  authnLogin: ""

--- a/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/Chart.yaml
+++ b/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: app-summon-sidecar-jwt
+home: https://www.conjur.org
+version: 0.1.0
+description: A Helm chart deploying an application with a Summon sidecar with JWT flow
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
+keywords:
+  - security
+  - "secrets management"
+sources:
+  - https://github.com/cyberark/conjur-authn-k8s-client
+  - https://github.com/cyberark/conjur-oss-helm-chart
+  - https://github.com/cyberark/conjur
+maintainers:
+  - name: Conjur Maintainers
+    email: conj_maintainers@cyberark.com

--- a/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/README.md
+++ b/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/README.md
@@ -1,0 +1,2 @@
+# Helm Chart to Deploy an Application that uses Summon and a Conjur Authenticator Client sidecar with JWT flow
+

--- a/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/templates/NOTES.txt
+++ b/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/templates/NOTES.txt
@@ -1,0 +1,5 @@
+The Application deployment is complete.
+The following have been deployed:
+- An authnJWT application with a summon sidecar
+
+Application is now available at test-app-summon-sidecar.{{ .Release.Namespace }}.svc.cluster.local

--- a/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/templates/secrets-configmap.yml
+++ b/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/templates/secrets-configmap.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: secrets-configmap
+    labels:
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      conjur.org/name: "secrets-configmap"
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+data:
+    secrets.yml: |
+      DB_URL: !var test-summon-sidecar-jwt-app-db/url
+      DB_USERNAME: !var test-summon-sidecar-jwt-app-db/username
+      DB_PASSWORD: !var test-summon-sidecar-jwt-app-db/password

--- a/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/templates/test-app-summon-sidecar.yaml
+++ b/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/templates/test-app-summon-sidecar.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-summon-sidecar
+  labels:
+    app: test-app-summon-sidecar
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: test-app-summon-sidecar
+  type: {{ .Values.global.appServiceType }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-app-summon-sidecar
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app-summon-sidecar
+  name: test-app-summon-sidecar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-summon-sidecar
+  template:
+    metadata:
+      labels:
+        app: test-app-summon-sidecar
+    spec:
+      serviceAccountName: test-app-summon-sidecar
+      containers:
+      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
+        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+        command: ["summon", "--provider", "summon-conjur", "-f", "/etc/conjur/secrets.yml", "java", "-jar", "/app.jar"]
+        name: test-app
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /pets
+            port: http
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        env:
+          - name: CONJUR_AUTHN_TOKEN_FILE
+            value: /run/conjur/access-token
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+        volumeMounts:
+          - mountPath: /run/conjur
+            name: conjur-access-token
+            readOnly: true
+          - mountPath: /etc/conjur
+            name: secrets-config
+            readOnly: true
+      - image: {{ printf "%s:%s" .Values.authnClient.image.repository .Values.authnClient.image.tag }}
+        imagePullPolicy: {{ .Values.authnClient.image.pullPolicy }}
+        name: authenticator
+        env:
+          - name: CONTAINER_MODE
+            value: sidecar
+          - name: JWT_TOKEN_PATH
+            value: /var/run/secrets/tokens/jwt
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+        volumeMounts:
+          - mountPath: /run/conjur
+            name: conjur-access-token
+          - mountPath: /etc/conjur/ssl
+            name: conjur-certs
+          - mountPath: /var/run/secrets/tokens
+            name: jwt-token
+      {{- if eq .Values.app.platform "kubernetes" }}
+      imagePullSecrets:
+        - name: dockerpullsecret
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
+      {{- end }}
+      volumes:
+        - name: conjur-access-token
+          emptyDir:
+            medium: Memory
+        - name: conjur-certs
+          emptyDir:
+            medium: Memory
+        - name: secrets-config
+          configMap:
+            name: secrets-configmap
+            items:
+            - key: "secrets.yml"
+              path: "secrets.yml"
+        - name: jwt-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: jwt
+                  expirationSeconds: 6000
+                  audience: conjur

--- a/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/values.schema.json
+++ b/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/values.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "properties": {
+    "app": {
+      "properties": {
+        "image": {
+          "properties": {
+            "repository": {
+              "type": "string",
+              "pattern": "^[a-z0-9:./_-]+$"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "pattern": "^(Always|Never|IfNotPresent)$"
+            }
+          }
+        }
+      }
+    },
+    "conjur": {
+      "properties": {
+        "authnConfigMap": {
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "authnLogin": {
+          "type": "string"
+        }
+      }
+    },
+    "authnClient": {
+      "properties": {
+        "image": {
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-summon-sidecar-jwt/values.yaml
@@ -1,0 +1,23 @@
+# Default values for the Application with Summon sidecar Helm chart
+# This is a YAML-formatted file.
+
+global:
+  conjur:
+    # name of the ConfigMap created by the conjur-config-namespace-prep chart
+    conjurConnConfigMap: "conjur-connect"
+  appServiceType: "NodePort"
+
+app:
+  image:
+    repository: "localhost:5000/test-sidecar-app"
+    tag: "conjur-oss"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+  platform: "kubernetes"
+ 
+authnClient:
+  image:
+    repository: "docker.io/cyberark/conjur-authn-k8s-client"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"

--- a/helm/conjur-app-deploy/values.yaml
+++ b/helm/conjur-app-deploy/values.yaml
@@ -18,10 +18,16 @@ app-summon-init:
 app-summon-sidecar:
   enabled: false
 
+app-summon-sidecar-jwt:
+  enabled: false
+
 app-secretless-broker:
   enabled: false
 
 app-secrets-provider-init:
+  enabled: false
+
+app-secrets-provider-init-jwt:
   enabled: false
 
 app-secrets-provider-p2f:

--- a/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
+++ b/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
@@ -21,7 +21,7 @@ metadata:
 data:
   CONJUR_ACCOUNT: {{ get $g "conjurAccount" }}
   CONJUR_APPLIANCE_URL: {{ get $g "conjurApplianceUrl" }}
-  CONJUR_AUTHN_URL: {{ printf "%s/authn-k8s/%s" (get $g "conjurApplianceUrl") (get $g "authnK8sAuthenticatorID") }}
+  CONJUR_AUTHN_URL: {{ printf "%s/%s/%s" (get $g "conjurApplianceUrl") (.Values.conjurConfigMap.authnStrategy) (get $g "authnK8sAuthenticatorID") }}
   CONJUR_SSL_CERTIFICATE: |- 
 {{ get $g "conjurSslCertificate" | indent 4 }}
   CONJUR_AUTHENTICATOR_ID: {{ get $g "authnK8sAuthenticatorID" }}

--- a/helm/conjur-config-namespace-prep/tests/conjur_connect_configmap_test.yaml
+++ b/helm/conjur-config-namespace-prep/tests/conjur_connect_configmap_test.yaml
@@ -24,7 +24,7 @@ tests:
       # Set required values
       <<: *defaultRequired
       test.mock.enable: true
-
+      conjurConfigMap.authnStrategy: "authn-k8s"
 
     asserts:
       # Confirm that a ConfigMap has been created

--- a/helm/conjur-config-namespace-prep/values.schema.json
+++ b/helm/conjur-config-namespace-prep/values.schema.json
@@ -22,6 +22,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "authnStrategy": {
+                    "type": "string"
                 }
             }
         },

--- a/helm/conjur-config-namespace-prep/values.yaml
+++ b/helm/conjur-config-namespace-prep/values.yaml
@@ -10,6 +10,7 @@ authnRoleBinding:
 conjurConfigMap:
   create: true
   name: conjur-connect
+  authnStrategy: authn-k8s
 
 test:
   mock:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/73157235/148782749-c743077e-0a8b-488e-bb6c-3ecd5b5e3e56.png)
Automation flow for authn jwt added.

Can be run with 
./bin/test-workflow/start -n -a summon-sidecar-jwt --jwt

Currently draft PR : 
* Need to validate current pipeline passes
* How to add this to the pipeline
* Try remove --jwt flag
* Not hardcode the CONJUR_AUTHN_URL in app-summon-sidecar-jwt