### PR TITLE
Fix Docker-based builds to work on CyberArk NG laptops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ bin/test-workflow/output/
 bin/test-workflow/bash-lib/
 
 .idea/
+
+# Temporary directory to store the CyberArk proxy CA certificate
+build_ca_certificate/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,17 @@ ENV GOOS=linux \
 # this value changes in ./bin/build
 ARG TAG_SUFFIX="-dev"
 
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 WORKDIR /opt/conjur-authn-k8s-client
 COPY . /opt/conjur-authn-k8s-client
 

--- a/bin/build
+++ b/bin/build
@@ -4,30 +4,39 @@ set -euo pipefail
 
 . bin/build_utils
 
-# Supports two different tags to represent a tagged build (./bin/build) and dev build
-# (env GOOS=darwin GOARCH=amd64 go build) of project binaries
-IMAGE_NAME=conjur-authn-k8s-client
-TAG=dev
-VERSION="$(short_version_tag)"
+function main() {
+  retrieve_cyberark_ca_cert
+  build_docker_images
+}
 
-echo "---"
-echo "Building ${IMAGE_NAME} with tag ${TAG} <<"
+function build_docker_images {
+  # Supports two different tags to represent a tagged build (./bin/build) and
+  # dev build (env GOOS=darwin GOARCH=amd64 go build) of project binaries
+  IMAGE_NAME=conjur-authn-k8s-client
+  TAG=dev
+  VERSION="$(short_version_tag)"
 
-docker build --tag "${IMAGE_NAME}:${TAG}" \
-             --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
-             --target "authenticator-client" \
-             .
+  echo "---"
+  echo "Building ${IMAGE_NAME} with tag ${TAG} <<"
 
-docker build --tag "${IMAGE_NAME}-redhat:${TAG}" \
-             --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
-             --build-arg VERSION="$VERSION" \
-             --target "authenticator-client-redhat" \
-             .
+  docker build --tag "${IMAGE_NAME}:${TAG}" \
+               --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
+               --target "authenticator-client" \
+               .
 
-docker build --tag conjur-k8s-cluster-test:${TAG} \
-             --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
-             --build-arg VERSION="$VERSION" \
-             --target "k8s-cluster-test" \
-             .
+  docker build --tag "${IMAGE_NAME}-redhat:${TAG}" \
+               --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
+               --build-arg VERSION="$VERSION" \
+               --target "authenticator-client-redhat" \
+               .
 
-echo "---"
+  docker build --tag conjur-k8s-cluster-test:${TAG} \
+               --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
+               --build-arg VERSION="$VERSION" \
+               --target "k8s-cluster-test" \
+               .
+
+  echo "---"
+}
+
+main

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -45,3 +45,31 @@ function push_conjur-k8s-cluster-test() {
     docker tag $source_image "$REGISTRY/$destination_image_name:$tag"
     docker push "$REGISTRY/$destination_image_name:$tag"
 }
+
+function retrieve_cyberark_ca_cert() {
+  # On CyberArk dev laptops, golang module dependencies are downloaded with a
+  # corporate proxy in the middle. For these connections to succeed we need to
+  # configure the proxy CA certificate in build containers.
+  #
+  # To allow this script to also work on non-CyberArk laptops where the CA
+  # certificate is not available, we update container certificates based on
+  # a (potentially empty) certificate directory, rather than relying on the
+  # CA file itself.
+  mkdir -p "$(repo_root)/build_ca_certificate"
+
+  # Only attempt to extract the certificate if the security
+  # command is available.
+  #
+  # The certificate file must have the .crt extension to be imported
+  # by `update-ca-certificates`.
+  if command -v security &> /dev/null
+  then
+    security find-certificate \
+      -a -c "CyberArk Enterprise Root CA" \
+      -p > build_ca_certificate/cyberark_root.crt
+  fi
+}
+
+repo_root() {
+  git rev-parse --show-toplevel
+}


### PR DESCRIPTION
Background:
On CyberArk dev laptops, golang module dependencies are
downloaded with a corporate proxy in the middle. For these connections to
succeed we need to configure the proxy CA certificate in build containers.)

### Desired Outcome

Docker-based build of the conjur-authn-k8s images (using `./bin/build`) works on
a CyberArk NG laptop.

Currently, this build fails when Go modules (new dependencies) are being loaded
on CyberArk dev laptops, since this is done with a corporate proxy at the
corporate network edge. The Docker containers used for this build do not
natively have the CyberArk CA certificate loaded in their trusted certificate store,
so the connection fails with an unknown certificate error.

### Implemented Changes

When builds are run on CyberArk NG laptops, the corporate CA cert is downloaded
using the `security find-certificate ...` command. The Dockerfile has been changed
to load the directory where the certificate is copied (this will be an empty directory
on non-CyberArk laptops, but the CA cert isn't needed there), and build any
certificates from that directory into the build containers CA cert trust.

### Connected Issue/Story

N/A

### Definition of Done

- [x] Builds work on CyberArk NG laptops

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
