### PR TITLE
Log the master IPS when there is a login in error

### DIFF
--- a/pkg/authenticator/k8s/authenticator.go
+++ b/pkg/authenticator/k8s/authenticator.go
@@ -173,6 +173,7 @@ func (auth *Authenticator) login(ctx context.Context, tracer trace.Tracer) error
 	_, span = tracer.Start(ctx, "Send login request")
 	resp, err := auth.client.Do(req)
 	if err != nil {
+		logIPS(req.Host)
 		span.RecordErrorAndSetStatus(err)
 		span.End()
 		return log.RecordedError(log.CAKC028, err)
@@ -422,4 +423,13 @@ func consumeInjectClientCertError(path string) string {
 	}
 
 	return string(content)
+}
+
+func logIPS(host string) {
+	ips, lookUpError := net.LookupIP(host)
+	if lookUpError != nil {
+		fmt.Printf("Could not get IPs: %v\n", lookUpError)
+	} else if len(ips) > 0 {
+		fmt.Printf("IP Address of master: %v\n", ips[0].String())
+	}
 }


### PR DESCRIPTION
### Desired Outcome

Log the requests IP address when there is a login error

### Implemented Changes

Add a function to find and print he ip address taken from the host name.

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14476](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14476)

### Definition of Done
Improved error message in authenticator client when request goes to an unhealthy master (502 error code doesn't reveal what IP address the name resolved to). Log the node's IP address when the connection fails.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
