### PR TITLE
Adds dump of K8s resources and announces failure on E2E test fail

### DIFF
--- a/bin/test-workflow/1_deploy_conjur.sh
+++ b/bin/test-workflow/1_deploy_conjur.sh
@@ -5,6 +5,9 @@ cd "$(dirname "$0")" || ( echo "cannot cd into dir" && exit 1 )
 
 source utils.sh
 
+# Upon error, dump kubernetes resources in the Conjur Namespace
+trap dump_conjur_namespace_upon_error EXIT
+
 function setup_conjur_enterprise {
   docker pull "$CONJUR_APPLIANCE_IMAGE"
 

--- a/bin/test-workflow/2_admin_load_conjur_policies.sh
+++ b/bin/test-workflow/2_admin_load_conjur_policies.sh
@@ -7,6 +7,9 @@ PLATFORM="${PLATFORM:-kubernetes}"
 
 source utils.sh
 
+# Upon error, dump kubernetes resources in the Conjur Namespace
+trap dump_conjur_namespace_upon_error EXIT
+
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   export CONJUR_ADMIN_PASSWORD="$(get_admin_password)"
 fi
@@ -98,8 +101,6 @@ pushd policy > /dev/null
 
   sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/app-grants.template.yml > ./generated/"$TEST_APP_NAMESPACE_NAME".app-grants.yml
 popd > /dev/null
-
-
 
 if [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
   JWKS_URI="NONE"

--- a/bin/test-workflow/3_admin_init_conjur_cert_authority.sh
+++ b/bin/test-workflow/3_admin_init_conjur_cert_authority.sh
@@ -12,6 +12,9 @@ check_env_var AUTHENTICATOR_ID
 
 TEST_JWT_FLOW="${TEST_JWT_FLOW:-false}"
 
+# Upon error, dump kubernetes resources in the Conjur Namespace
+trap dump_conjur_namespace_upon_error EXIT
+
 announce "Initializing Conjur certificate authority."
 
 if [[ "$CONJUR_PLATFORM" != "jenkins" ]]; then

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -16,6 +16,9 @@ if [[ "$CONJUR_OSS_HELM_INSTALLED" == "false" ]]; then
   check_env_var CONJUR_FOLLOWER_URL
 fi
 
+# Upon error, dump kubernetes resources in the Conjur Namespace
+trap dump_conjur_namespace_upon_error EXIT
+
 set_namespace default
 
 # Prepare our cluster with conjur and authnK8s credentials in a golden configmap
@@ -38,7 +41,7 @@ pushd ../../helm/conjur-config-cluster-prep > /dev/null
   fi
 
   ./bin/get-conjur-cert.sh $get_cert_options "$conjur_url"
-  helm upgrade --install "cluster-prep-$UNIQUE_TEST_ID" . -n "$CONJUR_NAMESPACE_NAME" --debug --wait --timeout "$TIMEOUT" \
+  helm upgrade --install "cluster-prep-$UNIQUE_TEST_ID" . -n "$CONJUR_NAMESPACE_NAME" --wait --timeout "$TIMEOUT" \
       --create-namespace \
       --set conjur.account="$CONJUR_ACCOUNT" \
       --set conjur.applianceUrl="$conjur_url" \

--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -12,6 +12,9 @@ check_env_var CONJUR_AUTHN_LOGIN_PREFIX
 check_env_var SECRETS_PROVIDER_TAG
 check_env_var SECRETLESS_BROKER_TAG
 
+# Upon error, dump kubernetes resources in the application Namespace
+trap dump_application_namespace_upon_error EXIT
+
 set_namespace "$TEST_APP_NAMESPACE_NAME"
 
 pushd ../../helm/conjur-app-deploy > /dev/null
@@ -84,7 +87,7 @@ pushd ../../helm/conjur-app-deploy > /dev/null
   done
 
   announce "Deploying test apps in $TEST_APP_NAMESPACE_NAME"
-  helm install test-apps . -n "$TEST_APP_NAMESPACE_NAME" --debug --wait --timeout "$TIMEOUT" \
+  helm install test-apps . -n "$TEST_APP_NAMESPACE_NAME" --wait --timeout "$TIMEOUT" \
     --render-subchart-notes \
     --set global.conjur.conjurConnConfigMap="conjur-connect" \
     $options_string

--- a/bin/test-workflow/8_app_verify_authentication.sh
+++ b/bin/test-workflow/8_app_verify_authentication.sh
@@ -19,7 +19,13 @@ RETRIES=150
 RETRY_WAIT=2
 
 function finish {
-  exit_code=$?
+  if [ $? -eq 0 ]; then
+    announce "Test PASSED!!!!"
+  else
+    announce "Test FAILED!!!! Displaying resources in application Namespace"
+    dump_kubernetes_resources "$TEST_APP_NAMESPACE_NAME"
+    dump_authentication_policy
+  fi
 
   readonly PIDS=(
     "SIDECAR_PORT_FORWARD_PID"
@@ -31,12 +37,6 @@ function finish {
     "SECRETS_PROVIDER_P2F_PORT_FORWARD_PID"
   )
 
-  # Upon error, dump some kubernetes resources and Conjur authentication policy
-  if [ $exit_code -ne 0 ]; then
-    dump_kubernetes_resources
-    dump_authentication_policy
-  fi
-
   set +u
 
   echo -e "\n\nStopping all port-forwarding"
@@ -46,12 +46,6 @@ function finish {
       kill "${!pid}" > /dev/null 2>&1
     fi
   done
-
-  if [ $exit_code -eq 0 ]; then
-    announce "Test PASSED!!!!"
-  else
-    announce "Test FAILED!!!!"
-  fi
 }
 trap finish EXIT
 

--- a/bin/test-workflow/utils.sh
+++ b/bin/test-workflow/utils.sh
@@ -208,30 +208,45 @@ function urlencode() {
 }
 
 function dump_kubernetes_resources() {
-  echo "Status of pods in namespace $TEST_APP_NAMESPACE_NAME:"
-  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" pods
-  echo "Display pods in namespace $TEST_APP_NAMESPACE_NAME:"
-  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" pods -o yaml
-  echo "Describe pods in namespace $TEST_APP_NAMESPACE_NAME:"
-  "$cli" describe -n "$TEST_APP_NAMESPACE_NAME" pods
-  echo "Services:in namespace $TEST_APP_NAMESPACE_NAME:"
-  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" svc
-  echo "ServiceAccounts:in namespace $TEST_APP_NAMESPACE_NAME:"
-  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" serviceaccounts
-  echo "Deployments in namespace $TEST_APP_NAMESPACE_NAME:"
-  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" deployments
+  namespace="$1"
+  echo "Status of pods in namespace $namespace:"
+  "$cli" get -n "$namespace" pods
+  echo "Display pods in namespace $namespace:"
+  "$cli" get -n "$namespace" pods -o yaml
+  echo "Describe pods in namespace $namespace:"
+  "$cli" describe -n "$namespace" pods
+  echo "Services:in namespace $namespace:"
+  "$cli" get -n "$namespace" svc
+  echo "ServiceAccounts:in namespace $namespace:"
+  "$cli" get -n "$namespace" serviceaccounts
+  echo "Deployments in namespace $namespace:"
+  "$cli" get -n "$namespace" deployments
   if [[ "$PLATFORM" == "openshift" ]]; then
-    echo "DeploymentConfigs in namespace $TEST_APP_NAMESPACE_NAME:"
-    "$cli" get -n "$TEST_APP_NAMESPACE_NAME" deploymentconfigs
+    echo "DeploymentConfigs in namespace $namespace:"
+    "$cli" get -n "$namespace" deploymentconfigs
   fi
-  echo "Roles in namespace $TEST_APP_NAMESPACE_NAME:"
-  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" roles
-  echo "RoleBindings in namespace $TEST_APP_NAMESPACE_NAME:"
-  "$cli" get -n "$TEST_APP_NAMESPACE_NAME" rolebindings
+  echo "Roles in namespace $namespace:"
+  "$cli" get -n "$namespace" roles
+  echo "RoleBindings in namespace $namespace:"
+  "$cli" get -n "$namespace" rolebindings
   echo "ClusterRoles in the cluster:"
   "$cli" get clusterroles
   echo "ClusterRoleBindings in the cluster:"
   "$cli" get clusterrolebindings
+}
+
+function dump_conjur_namespace_upon_error {
+  if [ $? -ne 0 ]; then
+    announce "Test FAILED!!!! Displaying resources in Conjur Namespace"
+    dump_kubernetes_resources "$CONJUR_NAMESPACE_NAME"
+  fi
+}
+
+function dump_application_namespace_upon_error {
+  if [ $? -ne 0 ]; then
+    announce "Test FAILED!!!! Displaying resources in application Namespace"
+    dump_kubernetes_resources "$TEST_APP_NAMESPACE_NAME"
+  fi
 }
 
 function dump_authentication_policy {


### PR DESCRIPTION
### Desired Outcome

When the E2E test scripts fail:
- Kubernetes resources are dumped from either the Conjur namespace or the application namespace (depending upon at which point the tests fail)
- The test failure is announced in a banner as soon as a fatal error is detected (before any dumping of Kubernetes resources and before everything is cleaned up) so that it's clearer exactly where the error occurs.

Also, run Helm install commands without the `--debug` flag to make test output much less verbose for successful test runs.

### Implemented Changes

- Bash trap functions are added to test scripts to trap on EXIT. In the trap functions, if exit status is non-zero,  an announcement (i.e. banner msg) that the test has failed is displayed, and a dump of Kubernetes resources is performed before test cleanup begins.
- The `--debug` flag is removed from helm install commands in E2E test scripts to make successful test runs less verbose.

### Connected Issue/Story

N/A

### Definition of Done

- [ ] Jenkins CI passes

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
