### PR TITLE
ONYX-15241: Add automation for secretless-broker with JWT flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,20 +7,21 @@ For general contribution and community guidelines, please see the [community rep
 
 ## Table of Contents
 
-- [Contributing](#contributing)
-  * [Table of Contents](#table-of-contents)
-  * [Development](#development)
-    + [Prerequisites](#prerequisites)
-    + [Debug Using Delve](#debug-using-delve)
-  * [Testing](#testing)
-    + [Test Suites](#test-suites)
-    + [Demo Workflow](#demo-workflow)
-  * [Releases](#releases)
-    + [Update the version, changelog, and notices](#update-the-version--changelog--and-notices)
-    + [Add a git tag](#add-a-git-tag)
-    + [Publish the git release](#publish-the-git-release)
-    + [Publish the Red Hat image](#publish-the-red-hat-image)
-  * [Contributing](#contributing-1)
+[Contributing](#contributing)
+
+* [Table of Contents](#table-of-contents)
+* [Development](#development)
+  + [Prerequisites](#prerequisites)
+  + [Debug Using Delve](#debug-using-delve)
+* [Testing](#testing)
+  + [Test Suites](#test-suites)
+  + [Demo Workflow](#demo-workflow)
+* [Releases](#releases)
+  + [Update the version, changelog, and notices](#update-the-version--changelog--and-notices)
+  + [Add a git tag](#add-a-git-tag)
+  + [Publish the git release](#publish-the-git-release)
+  + [Publish the Red Hat image](#publish-the-red-hat-image)
+* [Contributing](#contributing-1)
 
 ## Development
 
@@ -154,6 +155,9 @@ You can create demo cluster of to check JWT sidecars on K8S. Please be aware thi
 2. Test secrets provider as init container :
 
    `./bin/test-workflow/start  -a secrets-provider-init-jwt --jwt`
+   
+3. Test secretless broker as sidecar container:
+./bin/test-workflow/start  -a secretess-broker --jwt
 
 Flags explanation :
 

--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -36,6 +36,9 @@ pushd ../../helm/conjur-app-deploy > /dev/null
     --set app-secretless-broker.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secretless-broker \
     --set app-secretless-broker.conjur.authnConfigMap.name=conjur-authn-configmap-secretless \
     --set app-secretless-broker.app.platform=$PLATFORM"
+  secretless_broker_jwt_options="--set app-secretless-broker-jwt.enabled=true \
+      --set app-secretless-broker.secretless.image.tag=$SECRETLESS_BROKER_TAG \
+      --set app-secretless-broker.app.platform=$PLATFORM"
   secrets_provider_standalone_options="--set app-secrets-provider-standalone.enabled=true \
     --set app-secrets-provider-standalone.secrets-provider.environment.conjur.authnLogin="$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-standalone" \
     --set app-secrets-provider-standalone.app.image.tag="$TEST_APP_TAG" \
@@ -58,6 +61,7 @@ pushd ../../helm/conjur-app-deploy > /dev/null
   app_options[summon-sidecar]="$summon_sidecar_options"
   app_options[summon-sidecar-jwt]="$summon_sidecar_jwt_options"
   app_options[secretless-broker]="$secretless_broker_options"
+  app_options[secretless-broker-jwt]="$secretless_broker_jwt_options"
   app_options[secrets-provider-standalone]="$secrets_provider_standalone_options"
   app_options[secrets-provider-init]="$secrets_provider_init_options"
   app_options[secrets-provider-init-jwt]="$secrets_provider_init_jwt_options"

--- a/bin/test-workflow/8_app_verify_authentication.sh
+++ b/bin/test-workflow/8_app_verify_authentication.sh
@@ -25,6 +25,7 @@ function finish {
     "SIDECAR_PORT_FORWARD_PID"
     "SIDECAR_JWT_PORT_FORWARD_PID"
     "SECRETLESS_PORT_FORWARD_PID"
+    "SECRETLESS_JWT_PORT_FORWARD_PID"
     "SECRETS_PROVIDER_STANDALONE_PID"
     "SECRETS_PROVIDER_INIT_PORT_FORWARD_PID"
     "SECRETS_PROVIDER_INIT_JWT_PORT_FORWARD_PID"
@@ -102,6 +103,12 @@ if [[ "$PLATFORM" == "openshift" ]]; then
     SECRETLESS_PORT_FORWARD_PID=$!
   fi
 
+  if [[ " ${install_apps[*]} " =~ " secretless-broker-jwt " ]]; then
+    secretless_jwt_pod=$(get_pod_name test-app-secretless-jwt)
+    oc port-forward "secretless_jwt_pod" 8083:8080 > /dev/null 2>&1 &
+    SECRETLESS_JWT_PORT_FORWARD_PID=$!
+  fi
+
   if [[ " ${install_apps[*]} " =~ " secrets-provider-standalone " ]]; then
     secrets_provider_standalone_pod=$(get_pod_name test-app-secrets-provider-standalone)
     oc port-forward "$secrets_provider_standalone_pod" 8084:8080 > /dev/null 2>&1 &
@@ -153,6 +160,7 @@ declare -A app_urls
 app_urls[summon-sidecar]="$sidecar_url"
 app_urls[summon-sidecar-jwt]="$sidecar_url"
 app_urls[secretless-broker]="$secretless_url"
+app_urls[secretless-broker-jwt]="$secretless_url"
 app_urls[secrets-provider-standalone]="$secrets_provider_standalone_url"
 app_urls[secrets-provider-init]="$secrets_provider_init_url"
 app_urls[secrets-provider-init-jwt]="$secrets_provider_init_url"
@@ -162,6 +170,7 @@ declare -A app_pets
 app_pets[summon-sidecar]="Mr. Sidecar"
 app_pets[summon-sidecar-jwt]="Mr. Sidecar JWT"
 app_pets[secretless-broker]="Mr. Secretless"
+app_pets[secretless-broker-jwt]="Mr. Secretless JWT"
 app_pets[secrets-provider-standalone]="Mr. Standalone"
 app_pets[secrets-provider-init]="Mr. Provider"
 app_pets[secrets-provider-init-jwt]="Mr. JWT Provider"

--- a/bin/test-workflow/policy/app-policy.yml
+++ b/bin/test-workflow/policy/app-policy.yml
@@ -72,6 +72,25 @@
       resources: *secretless-variables
 
 - !policy
+  id: test-secretless-jwt-app-db
+  annotations:
+    description: This policy contains the creds to access the secretless app DB
+  body:
+    - !group
+
+    - &secretless-jwt-variables
+      - !variable password
+      - !variable url
+      - !variable port
+      - !variable host
+      - !variable username
+
+    - !permit
+      role: !group
+      privileges: [ read, execute ]
+      resources: *secretless-jwt-variables
+
+- !policy
   id: test-secrets-provider-init-app-db
   annotations:
     description: This policy contains the creds to access the secrets provider app DB

--- a/bin/test-workflow/policy/load_policies.sh
+++ b/bin/test-workflow/policy/load_policies.sh
@@ -33,6 +33,7 @@ readonly APPS=(
   "test-summon-sidecar-app"
   "test-summon-sidecar-jwt-app"
   "test-secretless-app"
+  "test-secretless-jwt-app"
   "test-secrets-provider-init-app"
   "test-secrets-provider-init-jwt-app"
   "test-secrets-provider-p2f-app"
@@ -61,7 +62,7 @@ for app_name in "${APPS[@]}"; do
   db_host="test-app-backend.$TEST_APP_NAMESPACE_NAME.svc.cluster.local"
   db_address="$db_host:$PORT"
 
-  if [[ "$app_name" = "test-secretless-app" ]]; then
+  if [[ "$app_name" = "test-secretless-app"  ||  "$app_name" = "test-secretless-jwt-app" ]]; then
     # Secretless doesn't require the full connection URL, just the host/port
     conjur variable values add "$app_name-db/url" "$db_address"
     conjur variable values add "$app_name-db/port" "$PORT"

--- a/bin/test-workflow/policy/templates/app-grants.template.yml
+++ b/bin/test-workflow/policy/templates/app-grants.template.yml
@@ -34,6 +34,11 @@
     - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/oc-test-app-secretless-broker
 
 - !grant
+  role: !group test-secretless-jwt-app-db
+  members:
+    - !host conjur/authn-jwt/{{ AUTHENTICATOR_ID }}/apps/system:serviceaccount:app-test:test-secretless-app-jwt
+
+- !grant
   role: !group test-secrets-provider-init-app-db
   members:
     - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/test-app-secrets-provider-init

--- a/bin/test-workflow/policy/templates/app-identities-policy-jwt.template.yml
+++ b/bin/test-workflow/policy/templates/app-identities-policy-jwt.template.yml
@@ -21,6 +21,11 @@
         annotations:
           authn-jwt/{{ AUTHENTICATOR_ID }}/sub: system:serviceaccount:app-test:test-app-secrets-provider-init-jwt
 
+      - !host
+        id: system:serviceaccount:app-test:test-secretless-app-jwt
+        annotations:
+          authn-jwt/{{ AUTHENTICATOR_ID }}/sub: system:serviceaccount:app-test:test-secretless-app-jwt
+
     - !grant
       role: !group
       members: *hosts

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -39,7 +39,9 @@ Usage: ./start [options]:
                                 - summon-sidecar
                                 - summon-sidecar-jwt
                                 - secretless-broker
+                                - secretless-broker-jwt
                                 - secrets-provider-init
+                                - secrets-provider-init-jwt
                                 - secrets-provider-p2f
                                 - secrets-provider-standalone
     --jwt                     Perform jwt authentication instead of k8s
@@ -57,7 +59,7 @@ function cleanup {
   fi
 }
 
-declare -a supported_apps=("summon-sidecar" "summon-sidecar-jwt" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init" "secrets-provider-init-jwt" "secrets-provider-p2f")
+declare -a supported_apps=("summon-sidecar" "summon-sidecar-jwt" "secretless-broker" "secretless-broker-jwt" "secrets-provider-standalone" "secrets-provider-init" "secrets-provider-init-jwt" "secrets-provider-p2f")
 declare -a run_in_ci_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
 # Default: Test all applications
 declare -a install_apps=("${supported_apps[@]}")

--- a/helm/conjur-app-deploy/Chart.yaml
+++ b/helm/conjur-app-deploy/Chart.yaml
@@ -40,6 +40,10 @@ dependencies:
       repository: "file://charts/app-secretless-broker"
       version: ">= 0.0.1"
       condition: app-secretless-broker.enabled
+    - name: app-secretless-broker-jwt
+      repository: "file://charts/app-secretless-broker-jwt"
+      version: ">= 0.0.1"
+      condition: app-secretless-broker-jwt.enabled
     - name: app-secrets-provider-standalone
       repository: "file://charts/app-secrets-provider-standalone"
       version: ">= 0.0.1"

--- a/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/Chart.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: app-secretless-broker-jwt
+home: https://www.conjur.org
+version: 0.1.0
+description: A Helm chart deploying an application with a Secretless Broker sidecar
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
+keywords:
+  - security
+  - "secrets management"
+sources:
+  - https://github.com/cyberark/conjur-authn-k8s-client
+  - https://github.com/cyberark/secretless-broker
+  - https://github.com/cyberark/conjur-oss-helm-chart
+  - https://github.com/cyberark/conjur
+maintainers:
+  - name: Conjur Maintainers
+    email: conj_maintainers@cyberark.com

--- a/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/README.md
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/README.md
@@ -1,0 +1,2 @@
+# Helm Chart to Deploy an Application that uses a Secretless Broker sidecar
+

--- a/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/files/secretless_config.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/files/secretless_config.yaml
@@ -1,0 +1,19 @@
+version: "2"
+services:
+  test-app-pg:
+    protocol: pg
+    listenOn: tcp://0.0.0.0:5432
+    credentials:
+      host:
+        from: conjur
+        get: test-secretless-jwt-app-db/host
+      port:
+        from: conjur
+        get: test-secretless-jwt-app-db/port
+      username:
+        from: conjur
+        get: test-secretless-jwt-app-db/username
+      password:
+        from: conjur
+        get: test-secretless-jwt-app-db/password
+      sslmode: disable

--- a/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/templates/NOTES.txt
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/templates/NOTES.txt
@@ -1,0 +1,8 @@
+The Application deployment is complete.
+The following have been deployed:
+{{ if .Values.conjur.authnConfigMap.create -}}
+- A Conjur authentication configmap
+{{ end -}}
+- An application with a Secretless Broker sidecar
+
+Application is now available at test-app-secretless-broker.{{ .Release.Namespace }}.svc.cluster.local

--- a/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/templates/secretless_config_configmap.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/templates/secretless_config_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: secretless-config-configmap
+  labels:
+    app: test-app-secretless-broker
+data:
+  secretless_config.yaml: |-
+{{ .Files.Get "files/secretless_config.yaml" | indent 4 }}

--- a/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/templates/test_app_secretless_broker.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/templates/test_app_secretless_broker.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-secretless-broker
+  labels:
+    app: test-app-secretless-broker
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: test-app-secretless-broker
+  type: {{ .Values.global.appServiceType }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-secretless-app-jwt
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app-secretless-broker
+  name: test-app-secretless-broker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-secretless-broker
+  template:
+    metadata:
+      labels:
+        app: test-app-secretless-broker
+    spec:
+      serviceAccountName: test-secretless-app-jwt
+      containers:
+      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
+        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+        name: test-app
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /pets
+            port: http
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        env:
+          - name: DB_URL
+            value: postgresql://localhost:5432/test_app
+      - image: {{ printf "%s:%s" .Values.secretless.image.repository .Values.secretless.image.tag }}
+        imagePullPolicy: {{ .Values.secretless.image.pullPolicy }}
+        name: secretless
+        args: ["-f", "/etc/secretless/secretless_config.yaml"]
+        ports:
+        - containerPort: 5432
+        env:
+          - name: CONTAINER_MODE
+            value: sidecar
+          - name: JWT_TOKEN_PATH
+            value: /var/run/secrets/tokens/jwt
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/secretless
+          readOnly: true
+        - name: conjur-access-token
+          mountPath: /run/conjur
+        - name: conjur-certs
+          mountPath: /etc/conjur/ssl
+        - mountPath: /var/run/secrets/tokens
+          name: jwt-token
+      {{- if eq .Values.app.platform "kubernetes" }}
+      imagePullSecrets:
+        - name: dockerpullsecret
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: secretless-config-configmap
+      - name: conjur-access-token
+        emptyDir:
+          medium: Memory
+      - name: conjur-certs
+        emptyDir:
+          medium: Memory
+      - name: jwt-token
+        projected:
+          sources:
+            - serviceAccountToken:
+                path: jwt
+                expirationSeconds: 6000
+                audience: conjur

--- a/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/values.schema.json
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/values.schema.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "properties": {
+      "app": {
+        "properties": {
+          "image": {
+            "properties": {
+              "repository": {
+                "type": "string",
+                "pattern": "^[a-z0-9:./_-]+$"
+              },
+              "tag": {
+                "type": "string"
+              },
+              "pullPolicy": {
+                "type": "string",
+                "pattern": "^(Always|Never|IfNotPresent)$"
+              }
+            }
+          }
+        }
+      },
+      "conjur": {
+        "properties": {
+          "authnConfigMap": {
+            "properties": {
+              "create": {
+                "type": "boolean"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "authnLogin": {
+            "type": "string"
+          }
+        }
+      },
+      "secretless": {
+        "properties": {
+          "image": {
+            "properties": {
+              "repository": {
+                "type": "string"
+              },
+              "tag": {
+                "type": "string"
+              },
+              "pullPolicy": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+}

--- a/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-secretless-broker-jwt/values.yaml
@@ -1,0 +1,29 @@
+# Default values for the Application with Secretless sidecar Helm chart
+# This is a YAML-formatted file
+
+global:
+  conjur:
+    # name of the ConfigMap created by the conjur-config-namespace-prep chart
+    conjurConnConfigMap: "conjur-connect"
+  appServiceType: "NodePort"
+
+app:
+  image:
+    repository: "docker.io/cyberark/demo-app"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+  platform: "kubernetes"
+
+secretless:
+  image:
+    repository: "docker.io/cyberark/secretless-broker"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+
+conjur:
+  authnConfigMap:
+    create: true
+    name: "conjur-authn-configmap"
+  authnLogin: ""

--- a/helm/conjur-app-deploy/values.yaml
+++ b/helm/conjur-app-deploy/values.yaml
@@ -24,6 +24,9 @@ app-summon-sidecar-jwt:
 app-secretless-broker:
   enabled: false
 
+app-secretless-broker-jwt:
+  enabled: false
+
 app-secrets-provider-init:
   enabled: false
 


### PR DESCRIPTION
Added automation for secretless broker as side car running on local kind cluster with conjur oss in the cluster
Currently not part of CI but can be in the future when conjur-oss with public keys released



### Connected Issue/Story

ONYX-15241

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
