### PR TITLE
Run only authn-k8s applications for OpenShift(next) Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
                 expression { params.TEST_OCP_NEXT }
               }
               steps {
-                sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=next ./start --platform openshift'
+                sh 'cd bin/test-workflow && summon --environment openshift -D ENV=ci -D VER=next ./start --platform openshift --ci-apps'
               }
             }
           }

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -4,7 +4,6 @@ set -eo pipefail
 cd "$(dirname "$0")" || ( echo "cannot cd into dir" && exit 1 )
 
 source ./utils.sh
-do_cleanup=true
 
 function print_help {
   cat << EOF
@@ -26,25 +25,27 @@ Usage: ./start [options]:
                                 - Defaults to 'gke'
                                 - Supports 'jenkins'
                               All other selections are rejected
-    -c, --ci-apps             Run the E2E workflow against the subset of apps tested in CI
+    -c, --ci-apps             Run the E2E workflow against the subset of apps tested in CI.
                               These include:
                                 - summon-sidecar
                                 - secretless-broker
                                 - secrets-provider-init
                                 - secrets-provider-standalone
-    -a, --apps <app>[,<app>]  Specify which test apps to install
-                              Multiple apps should be specified as a single comma-delimited string
-                              Excluding this flag runs all supported apps
-                              Currently supports:
+    -a, --apps <app>[,<app>]  Specify which test apps to install.
+                              Multiple apps should be specified as a single comma-delimited string.
+                              Defaults to running all supported 'authn-k8s' apps if '--jwt'
+                              flag is not used, or all JWT based apps if '--jwt' flag is used.
+                              If the '--jwt' flag is NOT used, supported apps include:
                                 - summon-sidecar
-                                - summon-sidecar-jwt
                                 - secretless-broker
-                                - secretless-broker-jwt
                                 - secrets-provider-init
-                                - secrets-provider-init-jwt
                                 - secrets-provider-p2f
                                 - secrets-provider-standalone
-    --jwt                     Perform jwt authentication instead of k8s
+                              If the '--jwt' flag is used, supported apps include:
+                                - summon-sidecar-jwt
+                                - secretless-broker-jwt
+                                - secrets-provider-init-jwt
+    -j, --jwt                 Perform jwt authentication instead of k8s
     -n, --nocleanup           Do not run the cleanup scripts, all resources are maintained.
                               All other selections are rejected
     -h, --help                Show the help message
@@ -59,46 +60,41 @@ function cleanup {
   fi
 }
 
-declare -a supported_apps=("summon-sidecar" "summon-sidecar-jwt" "secretless-broker" "secretless-broker-jwt" "secrets-provider-standalone" "secrets-provider-init" "secrets-provider-init-jwt" "secrets-provider-p2f")
+declare -a supported_authn_k8s_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init" "secrets-provider-p2f")
+declare -a supported_jwt_apps=("summon-sidecar-jwt" "secretless-broker-jwt" "secrets-provider-init-jwt")
 declare -a run_in_ci_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
-# Default: Test all applications
-declare -a install_apps=("${supported_apps[@]}")
+# Default: Test all authn-k8s applications
+declare -a install_apps=("${supported_authn_k8s_apps[@]}")
+
+export TEST_JWT_FLOW="${TEST_JWT_FLOW:-false}"
+do_cleanup=true
+apps_flag_used=false
+ci_apps_flag_used=false
 
 while true; do
   case "$1" in
     -a|--apps )
-      if [[ ! "${install_apps[@]}" = "${supported_apps[@]}" ]]; then
+      apps_flag_used=true
+      if [ "$ci_apps_flag_used" = "true" ]; then
         echo "Both --ci-apps and --apps flags used."
         echo "Deferring to those apps specified with --apps flag."
       fi
-      declare -a apps=($(split_on_comma_delimiter "$2"))
-      for app in "${apps[@]}"; do
-        if [[ ! " ${supported_apps[@]} " =~ " $app " ]]; then
-          echo "$app is not a supported test app!"
-          echo "Supported test apps include:"
-          for app in "${supported_apps[@]}"; do
-            echo "  - $app"
-          done
-          exit 1
-        fi
-      done
-      TEST_JWT_FLOW="false"
-      install_apps=("${apps[@]}")
+      install_apps=($(split_on_comma_delimiter "$2"))
       shift
       shift
       ;;
     -c|--ci-apps )
-      if [[ ! "${install_apps[@]}" = "${supported_apps[@]}" ]]; then
+      ci_apps_flag_used=true
+      if [ "$apps_flag_used" = "true" ]; then
         echo "Both --ci-apps and --apps flags used."
         echo "Deferring to those apps specified with --apps flag."
       else
-        TEST_JWT_FLOW="false"
         install_apps=("${run_in_ci_apps[@]}")
       fi
       shift
       ;;
     -e|--enterprise )
-      CONJUR_OSS_HELM_INSTALLED="false"
+      CONJUR_OSS_HELM_INSTALLED=false
       shift
       ;;
     -p|--platform )
@@ -107,12 +103,15 @@ while true; do
       shift
       ;;
     -n|--nocleanup )
-      do_cleanup="false"
+      do_cleanup=false
       shift
       ;;
-    --jwt )
+    -j|--jwt )
       echo "Going to test authn-jwt instead of authn-k8s"
-      TEST_JWT_FLOW="true"
+      if [ "$apps_flag_used" = "false" ] && [ "$ci_apps_flag_used" = "false" ]; then
+        install_apps=("${supported_jwt_apps[@]}")
+      fi
+      TEST_JWT_FLOW=true
       shift
       ;;
     -h|--help )
@@ -130,13 +129,35 @@ while true; do
   esac
 done
 
+# Confirm that the selected apps are valid depending upon authentication mode
+for app in "${install_apps[@]}"; do
+  if [ "$TEST_JWT_FLOW" = "false" ] ; then
+    if [[ ! " ${supported_authn_k8s_apps[@]} " =~ " $app " ]]; then
+      echo "$app is not a supported test app for 'authn-k8s' authentication!"
+      echo "Supported 'authn-k8s' test apps include:"
+      for app in "${supported_authn_k8s_apps[@]}"; do
+        echo "  - $app"
+      done
+      exit 1
+    fi
+  else
+    if [[ ! " ${supported_jwt_apps[@]} " =~ " $app " ]]; then
+      echo "$app is not a supported test app for 'jwt' authentication!"
+      echo "Supported 'jwt' authentication test apps include:"
+      for app in "${supported_jwt_apps[@]}"; do
+        echo "  - $app"
+      done
+      exit 1
+    fi
+  fi
+done
+
 # Bash arrays cannot be exported to the environment for use between scripts.
 # Here, export a version that complies with the bash environment,
 # and can be reassembled when it's needed
 export INSTALL_APPS=$(IFS=','; echo "${install_apps[*]}")
 
 export CONJUR_OSS_HELM_INSTALLED="${CONJUR_OSS_HELM_INSTALLED:-true}"
-export TEST_JWT_FLOW="${TEST_JWT_FLOW:-false}"
 export RUN_CLIENT_CONTAINER="${RUN_CLIENT_CONTAINER:-true}"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then


### PR DESCRIPTION
### Desired Outcome

Builds on Conjur OSS in OpenShift v(next) don't fail with the following error:

     `helm.go:81: [debug] serviceaccounts "test-app-summon-sidecar" already exists`

### Implemented Changes

The E2E workflow test scripts in this repo are designed to run either `authn-k8s` applications exclusively, or `jwt` authentication applications exclusively (depending upon whether the `--jwt` flag is selected or not). If an `authn-k8s` application is being deployed (e.g. `summon-sidecar`), and its equivalent `jwt` authentication based application is also deployed (e.g. `summon-sidecar-jwt`), then there will be K8s resource name conflicts for resources in the `app-test` Namespace.

The Jenkins CI runs for OpenShift "next" platform version was not using the `--ci-apps` flag, and was not explicitly selecting applications to be deployed via the `--apps` flag. Because of this, both `authn-k8s` applications and `jwt` based applications were being deployed, resulting in K8s resource name conflicts.

To fix this, the following changes are made:
- For the OpenShift "next" Jenkins CI runs, added a `--ci-apps` flag to the start command. This should run `authn-k8s` based applications exclusively.
- Modified the start script to only allow `authn-k8s` based applications if the `--jwt` flag is NOT set, and to only allow `jwt` authentication based applications if the `--jwt` flag is set.
- Modified the start script so that the `--jwt`, `--apps`, and `--ci-apps` flags can appear in any order on the command line.

### Connected Issue/Story

N/A

### Definition of Done

- [ ] Jenkins builds pass

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
