### PR TITLE
Remove Palm Tree team from project ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @cyberark/community-and-integrations-team @cyberark/palmtree
+* @cyberark/community-and-integrations-team
 
 # Changes to .trivyignore require Security Architect approval
 .trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects


### PR DESCRIPTION
The Palm Tree team are no longer code-owners of this project
and thus should be removed from the CODEOWNERS file
