### PR TITLE
ONYX-15085: Allow usage of cluster-prep helm without ServiceAccount a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Available images:
 
 ## What's inside ?
 
-The Conjur Kubernetes authenticator client is designed to have a light footprint both in terms of storage and memory consumption. It has very few components:
+The Conjur authenticator client is designed to have a light footprint both in terms of storage and memory consumption. It has very few components:
 
 + A static binary for the authenticator
 + The `sleep` binary from busybox for debugging
@@ -48,7 +48,7 @@ The client's process logs its flow to `stdout` and `stderr`.
 + Exponential backoff is exercised when an error occurs
 + Client will re-login when certificate has expired
 
-1. Client goes through login by presenting certificate signing request (CSR) -> Server (authn-k8s running inside the Conjur Enterprise) injects signed client certificate out of band into requesting pod
+1. Client goes through login by presenting certificate signing request (CSR) -> Server (authn-k8s or authn-jwt running inside the Conjur Enterprise) injects signed client certificate out of band into requesting pod
 1. Client picks up signed client certificate, deletes it from disk and uses to authenticator via mutual TLS -> Server responds with auth token (retrieved via authn-local) encrypted with the public key of the client.
 1. Client decrypts the auth token and writes it to to the shared memory volume (`/run/conjur/access-token`)
 1. Client proceeds to authenticate time and time again

--- a/bin/test-workflow/5_app_namespace_prep.sh
+++ b/bin/test-workflow/5_app_namespace_prep.sh
@@ -29,6 +29,6 @@ pushd ../../helm/conjur-config-namespace-prep > /dev/null
         --create-namespace \
         --set authnK8s.goldenConfigMap="conjur-configmap" \
         --set authnK8s.namespace="$CONJUR_NAMESPACE_NAME" \
-        --set conjurConfigMap.authnStrategy=$AUTHN_STRATEGY
+        --set conjurConfigMap.authnMethod=$AUTHN_STRATEGY
 
 popd > /dev/null

--- a/helm/conjur-config-cluster-prep/Chart.yaml
+++ b/helm/conjur-config-cluster-prep/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: conjur-config-cluster-prep
 home: https://www.conjur.org
-version: 0.1.1
+version: 0.1.2
 description: A Helm chart for preparing a Kubernetes cluster to use
              the Conjur Kubernetes authenticator (authn-k8s)
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/conjur-config-cluster-prep/README.md
+++ b/helm/conjur-config-cluster-prep/README.md
@@ -209,9 +209,9 @@ The steps are as follows:
    kubectl exec -it conjur-oss-7ddbb984c9-j96nb  -- bash -c "apt-get update;apt-get install openssl;openssl x509 -fingerprint -noout -in /opt/conjur/etc/ssl/cert/tls.crt"
    ```
 
-1. Create a Namespace for the authn-k8s authenticator.
+1. Create a Namespace for the conjur authenticator.
 
-   __NOTE: If a Conjur Namespace already exists, and only one authn-k8s
+   __NOTE: If a Conjur Namespace already exists, and only one conjur
      authenticator is being used in this cluster, then that Conjur Namespace
      can be reused as the authenticator Namespace).__
 
@@ -414,7 +414,7 @@ The following table lists the configurable parameters of the Conjur Open Source 
 |`conjur.applianceUrl:`|Conjur Appliance URL||Yes|
 |`conjur.ssl.certificateFile`|Path to a Conjur certificate file||Either certificateFile or certificateBase64|
 |`conjur.ssl.certificateBase64`|Base64-encoded Conjur certificate file||Either certificateFile or certificateBase64|
-|`authnK8s.authenticatorID`|Conjur authn-k8s authenticator ID to use for authentication||Yes|
+|`authnK8s.authenticatorID`|Conjur authenticator ID to use for authentication||Yes|
 |`authnK8s.configMap.create`|Flag to generate the Golden ConfigMap |`true`||
 |`authnK8s.configMap.name`|The name of the Conjur ConfigMap|`"conjur-configmap"`||
 |`authnK8s.clusterRole.create`|Flag to generate the ClusterRole |`true`||

--- a/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
+++ b/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/instance: "conjur-serviceaccount"
     app.kubernetes.io/part-of: "conjur-config"
     conjur.org/name: "conjur-serviceaccount"
-    helm.sh/chart: conjur-config-cluster-prep-0.1.1
+    helm.sh/chart: conjur-config-cluster-prep-0.1.2
 ---
 # Source: conjur-config-cluster-prep/templates/golden_configmap.yaml
 # The Golden ConfigMap keeps a reference copy of Conjur configuration information
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: "conjur-golden-configmap"
     app.kubernetes.io/part-of: "conjur-config"
     conjur.org/name: "conjur-golden-configmap"
-    helm.sh/chart: conjur-config-cluster-prep-0.1.1
+    helm.sh/chart: conjur-config-cluster-prep-0.1.2
 data:
   # authn-k8s Configuration 
   authnK8sAuthenticatorID: <Insert-Authenticator-ID-Here>
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/instance: "conjur-clusterrole"
     app.kubernetes.io/part-of: "conjur-config"
     conjur.org/name: "conjur-clusterrole"
-    helm.sh/chart: conjur-config-cluster-prep-0.1.1
+    helm.sh/chart: conjur-config-cluster-prep-0.1.2
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["pods", "serviceaccounts"]

--- a/helm/conjur-config-cluster-prep/templates/golden_configmap.yaml
+++ b/helm/conjur-config-cluster-prep/templates/golden_configmap.yaml
@@ -20,14 +20,10 @@ data:
     authnK8sAuthenticatorID: {{ required "A valid authnK8s.authenticatorID is required!" .Values.authnK8s.authenticatorID }}
     {{- if eq .Values.authnK8s.clusterRole.create true }}
     authnK8sClusterRole: {{ .Values.authnK8s.clusterRole.name | default "conjur-clusterrole" }}
-    {{- else }}
-    authnK8sClusterRole: {{ required "A valid authnK8s.clusterRole.name is required!" .Values.authnK8s.clusterRole.name }}
     {{- end }}
     authnK8sNamespace: {{ .Release.Namespace }}
     {{- if eq .Values.authnK8s.serviceAccount.create true }}
     authnK8sServiceAccount: {{ .Values.authnK8s.serviceAccount.name | default "conjur-serviceaccount" }}
-    {{- else }}
-    authnK8sServiceAccount: {{ required "A valid authnK8s.serviceAccount.name is required!" .Values.authnK8s.serviceAccount.name }}
     {{- end }}
 
     # Conjur Configuration 

--- a/helm/conjur-config-cluster-prep/tests/golden_configmap_test.yaml
+++ b/helm/conjur-config-cluster-prep/tests/golden_configmap_test.yaml
@@ -221,21 +221,6 @@ tests:
           value: "my-awesome-clusterrole"
 
   #=======================================================================
-  - it: should fail if ClusterRole creation is disabled and ClusterRole
-        name is not set
-  #=======================================================================
-    set:
-      # Set required values
-      <<: *defaultRequired
-
-      # Disable ClusterRole creation, but don't set ClusterRole name
-      authnK8s.clusterRole.create: false
-
-    asserts:
-      - failedTemplate:
-          errorMessage: "A valid authnK8s.clusterRole.name is required!"
-
-  #=======================================================================
   - it: should allow ServiceAccount name to be set explicitly
   #=======================================================================
     set:
@@ -249,18 +234,3 @@ tests:
       - equal:
           path: data.authnK8sServiceAccount
           value: "my-awesome-serviceaccount"
-
-  #=======================================================================
-  - it: should fail if ServiceAccount creation is disabled and
-        ServiceAccount name is not set
-  #=======================================================================
-    set:
-      # Set required values
-      <<: *defaultRequired
-
-      # Disable ClusterRole creation, but don't set ClusterRole name
-      authnK8s.serviceAccount.create: false
-
-    asserts:
-      - failedTemplate:
-          errorMessage: "A valid authnK8s.serviceAccount.name is required!"

--- a/helm/conjur-config-namespace-prep/Chart.yaml
+++ b/helm/conjur-config-namespace-prep/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: conjur-config-namespace-prep
 home: https://www.conjur.org
-version: 0.1.1
+version: 0.1.2
 description: A Helm chart which prepares a Namespace for using CyberArk Conjur authenticator clients
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
 keywords:

--- a/helm/conjur-config-namespace-prep/README.md
+++ b/helm/conjur-config-namespace-prep/README.md
@@ -69,6 +69,7 @@ The following table lists the configurable parameters of the Conjur Namespace-pr
 |`authnRoleBinding.name`|Name for the RoleBinding generated if the `create` flag is set to `true`.|`"conjur-RoleBinding"`|
 |`authnRoleBinding.create`|Flag to generate the ConfigMap with credentials for accessing Conjur instance.|`true`|
 |`authnRoleBinding.name`|Name for the ConfigMap generated if the `create` flag is set to `true`|`"conjur-configmap"`|
+|`conjurConfigMap.authnMethod`|Authentication method to conjur. Can be either `"authn-k8s"` or `"authn-jwt"`|`"authn-k8s"`|
 
 ## Examples
 

--- a/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
+++ b/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
@@ -21,7 +21,7 @@ metadata:
 data:
   CONJUR_ACCOUNT: {{ get $g "conjurAccount" }}
   CONJUR_APPLIANCE_URL: {{ get $g "conjurApplianceUrl" }}
-  CONJUR_AUTHN_URL: {{ printf "%s/%s/%s" (get $g "conjurApplianceUrl" | trimSuffix "/") (.Values.conjurConfigMap.authnStrategy) (get $g "authnK8sAuthenticatorID") }}
+  CONJUR_AUTHN_URL: {{ printf "%s/%s/%s" (get $g "conjurApplianceUrl" | trimSuffix "/") (.Values.conjurConfigMap.authnMethod) (get $g "authnK8sAuthenticatorID") }}
   CONJUR_SSL_CERTIFICATE: |- 
 {{ get $g "conjurSslCertificate" | indent 4 }}
   CONJUR_AUTHENTICATOR_ID: {{ get $g "authnK8sAuthenticatorID" }}

--- a/helm/conjur-config-namespace-prep/values.schema.json
+++ b/helm/conjur-config-namespace-prep/values.schema.json
@@ -23,7 +23,7 @@
                 "name": {
                     "type": "string"
                 },
-                "authnStrategy": {
+                "authnMethod": {
                     "type": "string"
                 }
             }

--- a/helm/conjur-config-namespace-prep/values.yaml
+++ b/helm/conjur-config-namespace-prep/values.yaml
@@ -10,7 +10,7 @@ authnRoleBinding:
 conjurConfigMap:
   create: true
   name: conjur-connect
-  authnStrategy: authn-k8s
+  authnMethod: authn-k8s
 
 test:
   mock:


### PR DESCRIPTION
This fixes will allow usage of the cluster-prep helm chart in least privilege  way for authn-jwt where cluster role binding and ServiceAccount not needed

For example


```
helm install "cluster-prep" cyberark/conjur-config-cluster-prep  -n "<CONJUR_NAMESPACE>" \ 
     --create-namespace \ 
     --set conjur.account="<CONJUR_ACCOUNT>" \ 
     --set conjur.applianceUrl="<CONJUR_URL>" \ 
     --set conjur.certificateFilePath="<CA FILE PATH>" \  
     --set authnK8s.authenticatorID="<JWT VENDOR NAME>" \
     --set authnK8s.clusterRole.create=false \  
     --set authnK8s.serviceAccount.create=false
```

