### PR TITLE
Trims trailing slash chars from appliance URL in config Helm charts

### DIFF
--- a/helm/conjur-config-cluster-prep/templates/golden_configmap.yaml
+++ b/helm/conjur-config-cluster-prep/templates/golden_configmap.yaml
@@ -32,7 +32,7 @@ data:
 
     # Conjur Configuration 
     conjurAccount: {{ .Values.conjur.account }}
-    conjurApplianceUrl: {{ required "A valid conjur.applianceUrl is required!" .Values.conjur.applianceUrl }}
+    conjurApplianceUrl: {{ required "A valid conjur.applianceUrl is required!" .Values.conjur.applianceUrl | trimSuffix "/" }}
     {{- if .Values.conjur.certificateFilePath }}
     {{- if .Values.conjur.certificateBase64 }}
     {{- fail "Only one of 'certificateFilePath' or 'certificateBase64' may be set!" }}

--- a/helm/conjur-config-cluster-prep/tests/golden_configmap_test.yaml
+++ b/helm/conjur-config-cluster-prep/tests/golden_configmap_test.yaml
@@ -67,6 +67,21 @@ tests:
           value: default
 
   #=======================================================================
+  - it: should trim any trailing '/' from Conjur Appliance URL
+  #=======================================================================
+    set:
+      # Set required values, and include a trailing '/' for appliance URL
+      conjur.applianceUrl: "https://conjur.example.com/"
+      conjur.certificateFilePath: "tests/test-cert.pem"
+      authnK8s.authenticatorID: "my-authenticator-id"
+
+    asserts:
+      # Confirm that trailing '/' has been trimmed
+      - equal:
+          path: data.conjurApplianceUrl
+          value: "https://conjur.example.com"
+
+  #=======================================================================
   - it: should fail if Conjur Appliance URL is not set
   #=======================================================================
     set:

--- a/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
+++ b/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
@@ -21,7 +21,7 @@ metadata:
 data:
   CONJUR_ACCOUNT: {{ get $g "conjurAccount" }}
   CONJUR_APPLIANCE_URL: {{ get $g "conjurApplianceUrl" }}
-  CONJUR_AUTHN_URL: {{ printf "%s/%s/%s" (get $g "conjurApplianceUrl") (.Values.conjurConfigMap.authnStrategy) (get $g "authnK8sAuthenticatorID") }}
+  CONJUR_AUTHN_URL: {{ printf "%s/%s/%s" (get $g "conjurApplianceUrl" | trimSuffix "/") (.Values.conjurConfigMap.authnStrategy) (get $g "authnK8sAuthenticatorID") }}
   CONJUR_SSL_CERTIFICATE: |- 
 {{ get $g "conjurSslCertificate" | indent 4 }}
   CONJUR_AUTHENTICATOR_ID: {{ get $g "authnK8sAuthenticatorID" }}

--- a/helm/conjur-config-namespace-prep/tests/conjur_connect_configmap_test.yaml
+++ b/helm/conjur-config-namespace-prep/tests/conjur_connect_configmap_test.yaml
@@ -56,6 +56,26 @@ tests:
 
 
   #=======================================================================
+  - it: should trim any trailing '/' characters from the appliance URL
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+      test.mock.enable: true
+      conjurConfigMap.authnStrategy: "authn-k8s"
+
+      # Set an authenticator ID and an appliance URL with a trailing '/'
+      test.mock.conjurApplianceUrl: "https://test.example.com/"
+      test.mock.authnK8sAuthenticatorID: "test-authenticator-id"
+
+    asserts:
+      # Confirm that trailing '/' character has been trimmed
+      - equal:
+          path: data.CONJUR_AUTHN_URL
+          value: "https://test.example.com/authn-k8s/test-authenticator-id"
+
+
+  #=======================================================================
   - it: should fail if both Golden ConfigMap and NameSpace are not set
   #=======================================================================
 


### PR DESCRIPTION


### Desired Outcome

For both cluster prep and Namespace prep Helm charts, any trailing '/' characters are trimmed from the appliance URL set by the user or read from the Golden ConfigMap, respectively.

### Implemented Changes

For both cluster prep and Namespace prep Helm charts, the `trimSuffix` Sprig function is used to trim any trailing '/' characters from appliance URLs that are supplied by the user or read from the Golden ConfigMap, respectively.

**NOTE:** Trimming the '/' characters in the Namespace prep Helm chart isn't absolutely necessary, but it's added just as a defensive SW measure.

### Connected Issue/Story

N/A

### Definition of Done

- [x] Helm `unittest` works for cluster prep
- [x] Helm `unittest` works for Namespace prep

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
