### PR TITLE
Added checks for missing fields in Golden ConfigMap

### DIFF
--- a/helm/conjur-config-namespace-prep/generated/conjur-config-namespace-prep.yaml
+++ b/helm/conjur-config-namespace-prep/generated/conjur-config-namespace-prep.yaml
@@ -1,7 +1,7 @@
 ---
 # Source: conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
-# The Conjur Connection Configmap contains references to Conjur credentials,
-# taken from the "Golden Configmap". These can be used to enable Conjur
+# The Conjur Connection ConfigMap contains references to Conjur credentials,
+# taken from the "Golden ConfigMap". These can be used to enable Conjur
 # authentication for applications to retrieve secrets securely.
 apiVersion: v1
 kind: ConfigMap

--- a/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
+++ b/helm/conjur-config-namespace-prep/templates/conjur_connect_configmap.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.conjurConfigMap.create }}
-# The Conjur Connection Configmap contains references to Conjur credentials,
-# taken from the "Golden Configmap". These can be used to enable Conjur
+# The Conjur Connection ConfigMap contains references to Conjur credentials,
+# taken from the "Golden ConfigMap". These can be used to enable Conjur
 # authentication for applications to retrieve secrets securely.
 {{ $config := required "Both authnK8s.namespace and authnK8s.configMap are required" .Values.authnK8s -}}
 
@@ -19,10 +19,10 @@ metadata:
     app.kubernetes.io/part-of: "conjur-config"
     conjur.org/name: "conjur-connect-configmap"
 data:
-  CONJUR_ACCOUNT: {{ get $g "conjurAccount" }}
-  CONJUR_APPLIANCE_URL: {{ get $g "conjurApplianceUrl" }}
+  CONJUR_ACCOUNT: {{ get $g "conjurAccount" | required "conjurAccount must be set in Golden ConfigMap" }}
+  CONJUR_APPLIANCE_URL: {{ get $g "conjurApplianceUrl" | required "conjurApplianceUrl must be set in Golden ConfigMap" }}
   CONJUR_AUTHN_URL: {{ printf "%s/%s/%s" (get $g "conjurApplianceUrl" | trimSuffix "/") (.Values.conjurConfigMap.authnMethod) (get $g "authnK8sAuthenticatorID") }}
   CONJUR_SSL_CERTIFICATE: |- 
-{{ get $g "conjurSslCertificate" | indent 4 }}
-  CONJUR_AUTHENTICATOR_ID: {{ get $g "authnK8sAuthenticatorID" }}
+{{ get $g "conjurSslCertificate" | required "conjurSslCertificate must be set in Golden ConfigMap" | indent 4 }}
+  CONJUR_AUTHENTICATOR_ID: {{ get $g "authnK8sAuthenticatorID" | required "authnK8sAuthenticatorID must be set in Golden ConfigMap" }}
 {{- end }}

--- a/helm/conjur-config-namespace-prep/tests/conjur_connect_configmap_test.yaml
+++ b/helm/conjur-config-namespace-prep/tests/conjur_connect_configmap_test.yaml
@@ -6,6 +6,8 @@ templates:
 defaults: &defaultRequired
   authnK8s.goldenConfigMap: conjur-configmap
   authnK8s.namespace: golden
+  conjurConfigMap.authnStrategy: authn-k8s
+  test.mock.enable: true
 
 tests:
   #=======================================================================
@@ -23,8 +25,6 @@ tests:
     set:
       # Set required values
       <<: *defaultRequired
-      test.mock.enable: true
-      conjurConfigMap.authnStrategy: "authn-k8s"
 
     asserts:
       # Confirm that a ConfigMap has been created
@@ -78,8 +78,6 @@ tests:
   #=======================================================================
   - it: should fail if both Golden ConfigMap and NameSpace are not set
   #=======================================================================
-
-
     set:
       # Do not set the required values
       #authnK8s.goldenConfigMap: conjur-configmap
@@ -103,3 +101,63 @@ tests:
       - equal:
           path: metadata.name
           value: "my-awesome-configmap"
+
+
+  #=======================================================================
+  - it: should fail if conjurAccount is not set in Golden ConfigMap
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Clear entry for conjurAccount
+      test.mock.conjurAccount:
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "conjurAccount must be set in Golden ConfigMap"
+
+
+  #=======================================================================
+  - it: should fail if conjurApplianceUrl is not set in Golden ConfigMap
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Clear entry for conjurApplianceUrl
+      test.mock.conjurApplianceUrl:
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "conjurApplianceUrl must be set in Golden ConfigMap"
+
+
+  #=======================================================================
+  - it: should fail if authnK8sAuthenticatorID is not set in Golden ConfigMap
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Clear entry for conjurAuthenticatorID
+      test.mock.authnK8sAuthenticatorID:
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "authnK8sAuthenticatorID must be set in Golden ConfigMap"
+
+
+  #=======================================================================
+  - it: should fail if conjurSslCertificate is not set in Golden ConfigMap
+  #=======================================================================
+    set:
+      # Set required values
+      <<: *defaultRequired
+
+      # Clear entry for conjurSslCertificate
+      test.mock.conjurSslCertificate:
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "conjurSslCertificate must be set in Golden ConfigMap"


### PR DESCRIPTION
### Desired Outcome

The Namespace Prep Helm chart fails and emits a clear error message whenever expected fields are missing in the Golden ConfigMap.

### Implemented Changes

Added calls to `required` when fields are read from the Golden ConfigMap.

### Connected Issue/Story

N/A

### Definition of Done

- [x] Helm unittest passes for Namespace Prep Helm chart

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
