### PR TITLE
Adds check for cert filepath being in cluster prep chart dirs/subdirs

### DIFF
--- a/helm/conjur-config-cluster-prep/README.md
+++ b/helm/conjur-config-cluster-prep/README.md
@@ -242,6 +242,17 @@ command is run using a local copy of the Helm chart. You can use
 
 - Helm Install Using A Conjur Certificate From a File
 
+  _**NOTE: The certificate file MUST exist within the Helm chart's
+   root directory or its subdirectories.**_
+
+  _**NOTE: Setting the Conjur certificate via the `conjur.certificateFilePath`
+   chart value will not work if you are using `helm install ...` command
+   with a `cyberark/conjur-config-cluster-prep` chart reference
+   (see [Helm install documentation](https://helm.sh/docs/helm/helm_install/)
+   for a description of chart references). In this case, the
+   `conjur.certificateBase64` chart value must be used instead to set the
+   Conjur certificate.**_
+
   ```
   helm install my-conjur-release . \
        --set conjur.applianceUrl="https://conjur.example.com" \
@@ -412,8 +423,8 @@ The following table lists the configurable parameters of the Conjur Open Source 
 |---------|-----------|-------|---------|
 |`conjur.account`|Conjur account to be used by the Kubernetes authenticator|`"default"`||
 |`conjur.applianceUrl:`|Conjur Appliance URL||Yes|
-|`conjur.ssl.certificateFile`|Path to a Conjur certificate file||Either certificateFile or certificateBase64|
-|`conjur.ssl.certificateBase64`|Base64-encoded Conjur certificate file||Either certificateFile or certificateBase64|
+|`conjur.ssl.certificateFile`|Path to a Conjur certificate file. The certificate file must exist within the Helm chart's root directory or its subdirectories. ||Either certificateFile or certificateBase64 must be supplied|
+|`conjur.ssl.certificateBase64`|Base64-encoded Conjur certificate file||Either certificateFile or certificateBase64 must be supplied|
 |`authnK8s.authenticatorID`|Conjur authenticator ID to use for authentication||Yes|
 |`authnK8s.configMap.create`|Flag to generate the Golden ConfigMap |`true`||
 |`authnK8s.configMap.name`|The name of the Conjur ConfigMap|`"conjur-configmap"`||

--- a/helm/conjur-config-cluster-prep/templates/golden_configmap.yaml
+++ b/helm/conjur-config-cluster-prep/templates/golden_configmap.yaml
@@ -33,8 +33,12 @@ data:
     {{- if .Values.conjur.certificateBase64 }}
     {{- fail "Only one of 'certificateFilePath' or 'certificateBase64' may be set!" }}
     {{- end }}
-    conjurSslCertificate: {{ .Files.Get .Values.conjur.certificateFilePath | quote }}
-    conjurSslCertificateBase64: {{ .Files.Get .Values.conjur.certificateFilePath | b64enc | quote }}
+    {{- $conjurCert := .Files.Get .Values.conjur.certificateFilePath }}
+    {{ if not $conjurCert }}
+    {{- fail "If you are using helm install with a (remote) chart reference, please use conjur.certficateBase64 instead of conjur.certificateFilePath. If you are using helm install with a local chart directory, then conjur.certificateFilePath must point to an existing file within the chart directory/subdirectories" }}
+    {{- end }}
+    conjurSslCertificate: {{ $conjurCert | quote }}
+    conjurSslCertificateBase64: {{ $conjurCert | b64enc | quote }}
     {{- else }}
     conjurSslCertificateBase64: {{ required "Either conjur.certificateFilePath or conjur.certificateBase64 are required!" .Values.conjur.certificateBase64 | quote }}
     conjurSslCertificate: {{ .Values.conjur.certificateBase64 | b64dec | quote }}

--- a/helm/conjur-config-cluster-prep/tests/golden_configmap_test.yaml
+++ b/helm/conjur-config-cluster-prep/tests/golden_configmap_test.yaml
@@ -157,6 +157,32 @@ tests:
           pattern: "^LS[0-9a-zA-Z=]*JUSUZJQ0FURS0tLS0tCg==$"
 
   #=======================================================================
+  - it: should fail if certificate file path points to file outside of chart repo
+  #=======================================================================
+    set:
+      # Set required values, with cert file path pointing to file outside of repo
+      conjur.applianceUrl: "https://conjur.example.com"
+      conjur.certificateFilePath: "../foobar"
+      authnK8s.authenticatorID: "my-authenticator-id"
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "If you are using helm install with a (remote) chart reference, please use conjur.certficateBase64 instead of conjur.certificateFilePath. If you are using helm install with a local chart directory, then conjur.certificateFilePath must point to an existing file within the chart directory/subdirectories"
+
+  #=======================================================================
+  - it: should fail if certificate file path points to non-existent file inside repo
+  #=======================================================================
+    set:
+      # Set required values, with cert file path pointing to non-existent file inside repo
+      conjur.applianceUrl: "https://conjur.example.com"
+      conjur.certificateFilePath: "non-existent-file"
+      authnK8s.authenticatorID: "my-authenticator-id"
+
+    asserts:
+     - failedTemplate:
+         errorMessage: "If you are using helm install with a (remote) chart reference, please use conjur.certficateBase64 instead of conjur.certificateFilePath. If you are using helm install with a local chart directory, then conjur.certificateFilePath must point to an existing file within the chart directory/subdirectories"
+
+  #=======================================================================
   - it: should allow Conjur certificate to be set as Base-64 encoded value
   #=======================================================================
     set:


### PR DESCRIPTION
### Desired Outcome

When a user does a Helm install of the cluster prep Helm chart, and uses a `conjur.certificateFilePath` value that points to a file that is either outside of the Helm chart directory/subdirectory, or is non-existent, then an error should be displayed clearly indicating what the error is, rather than creating a Golden ConfigMap with empty fields for Conjur certificate.

### Implemented Changes

Added a check into the Golden ConfigMap template in the Helm chart that Helm was actually able to find the file pointed to by `conjur.certificateFilePath`.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
