### PR TITLE
Fixes build errors related to application postgres backend deployment

### DIFF
--- a/bin/test-workflow/6_app_deploy_backend.sh
+++ b/bin/test-workflow/6_app_deploy_backend.sh
@@ -45,18 +45,15 @@ helm repo update
 args=(install "$app_name" bitnami/postgresql -n "$TEST_APP_NAMESPACE_NAME" --wait --timeout "$TIMEOUT" \
     --set image.repository="postgres" \
     --set image.tag="9.6" \
-    --set postgresqlDataDir="/data/pgdata" \
-    --set persistence.mountPath="/data/" \
     --set fullnameOverride="test-app-backend" \
     --set tls.enabled=true \
     --set volumePermissions.enabled=true \
     --set tls.certificatesSecret="test-app-backend-certs" \
     --set tls.certFilename="server.crt" \
     --set tls.certKeyFilename="server.key" \
-    --set securityContext.fsGroup="999" \
-    --set postgresqlDatabase="test_app" \
-    --set postgresqlUsername="test_app" \
-    --set postgresqlPassword="$SAMPLE_APP_BACKEND_DB_PASSWORD")
+    --set auth.database="test_app" \
+    --set auth.username="test_app" \
+    --set auth.password="$SAMPLE_APP_BACKEND_DB_PASSWORD")
 
 # For Openshift the runAsUser and fsgroup values are different than Kubernetes,
 # and we opt to use the dynamic settings. See the below link for nore info. 


### PR DESCRIPTION
### Desired Outcome

The E2E workflow scripts should not fail when deploying a Postgres backend database for our sample applications. The Helm install used for this is currently failing to deploy healthy Pods.

### Background

The bitnami/postgresql Helm chart that we use for deploying a postgres backend database for our sample applications in our E2E workflow scripts has recently had a new release published. Some of the Helm chart values
that we had been using are out-of-date, and as a result, our Helm installs are failing.

### Implemented Changes

This change updates some of the Helm chart values that we use for this deployment, and eliminates some settings that we probably don't need (i.e. the less "knobs" we use, the more robust we are to changes to those "knobs").

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
