### PR TITLE
Fix version of bitnami/postgresql helm

### DIFF
--- a/bin/test-workflow/6_app_deploy_backend.sh
+++ b/bin/test-workflow/6_app_deploy_backend.sh
@@ -42,7 +42,7 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
 
 
-args=(install "$app_name" bitnami/postgresql -n "$TEST_APP_NAMESPACE_NAME" --wait --timeout "$TIMEOUT" \
+args=(install "$app_name" bitnami/postgresql --version 10.16.2 -n "$TEST_APP_NAMESPACE_NAME" --wait --timeout "$TIMEOUT" \
     --set image.repository="postgres" \
     --set image.tag="9.6" \
     --set postgresqlDataDir="/data/pgdata" \


### PR DESCRIPTION
Fix version of bitanmi postgresql version so pipelines will pass and won't be broker by any changes of bitnami.

If there is a better solution that will also work in openshift i will close this PR.