### PR TITLE
ONYX-16318: Move JWT token path to annotation in p2f

### DIFF
--- a/helm/conjur-app-deploy/charts/app-secrets-provider-p2f-jwt/templates/test_app_secrets_provider_p2f.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-p2f-jwt/templates/test_app_secrets_provider_p2f.yaml
@@ -37,6 +37,7 @@ spec:
         conjur.org/container-mode: "init"
         conjur.org/debug-logging: "true"
         conjur.org/secrets-destination: "file"
+        conjur.org/jwt-token-path: /var/run/secrets/tokens/{{ .Values.secretsProvider.jwt.tokenFile }}
         conjur.org/conjur-secrets.p2f-app: |
           - test-secrets-provider-p2f-jwt-app-db/url
           - test-secrets-provider-p2f-jwt-app-db/username
@@ -78,8 +79,6 @@ spec:
         imagePullPolicy: Always
         name: cyberark-secrets-provider-for-k8s
         env:
-          - name: JWT_TOKEN_PATH
-            value: /var/run/secrets/tokens/{{ .Values.secretsProvider.jwt.tokenFile }}
           - name: MY_POD_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
In automation of secrets provider with JWT in Push 2 file mod. Move JWT_TOKEN_PATH to annotation 
conjur.org/jwt-token-path

