### PR TITLE
Bugfixes: Enterprise-in-GKE test not deploying test apps

### DIFF
--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -227,6 +227,7 @@ elif [[ "$CONJUR_PLATFORM" == "gke" ]]; then
   eval "$conjur_init"
   run_command_with_platform "$conjur_prep"
   run_command_with_platform "$cluster_prep"
+  run_command_with_platform "$test_app_workflow"
 elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
   eval "$conjur_init"
   eval "$conjur_prep"

--- a/helm/conjur-config-cluster-prep/templates/golden_configmap.yaml
+++ b/helm/conjur-config-cluster-prep/templates/golden_configmap.yaml
@@ -18,13 +18,9 @@ metadata:
 data:
     # authn-k8s Configuration 
     authnK8sAuthenticatorID: {{ required "A valid authnK8s.authenticatorID is required!" .Values.authnK8s.authenticatorID }}
-    {{- if eq .Values.authnK8s.clusterRole.create true }}
     authnK8sClusterRole: {{ .Values.authnK8s.clusterRole.name | default "conjur-clusterrole" }}
-    {{- end }}
     authnK8sNamespace: {{ .Release.Namespace }}
-    {{- if eq .Values.authnK8s.serviceAccount.create true }}
     authnK8sServiceAccount: {{ .Values.authnK8s.serviceAccount.name | default "conjur-serviceaccount" }}
-    {{- end }}
 
     # Conjur Configuration 
     conjurAccount: {{ .Values.conjur.account }}


### PR DESCRIPTION
### Desired Outcome

In recent CI runs, the stage running end-to-end tests against Conjur Enterprise in GKE succeed without installing the Namespace Prep Helm chart or deploying the test apps.

From a [passing Jenkins run](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur-authn-k8s-client/detail/test-openshift-next/1/pipeline/163#step-172-log-1706):
```
++++++++++++++++++++++++++++++++++++++

Installing cluster prep chart

++++++++++++++++++++++++++++++++++++++
. . .
The Conjur/Authenticator Namespace preparation is complete.
 The following have been deployed:
- Golden ConfigMap
- Authenticator ClusterRole
++++++++++++++++++++++++++++++++++++++

Removing test environment

++++++++++++++++++++++++++++++++++++++
```

Updating this led to another bug:
[Jenkins logs](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur-authn-k8s-client/detail/cluster-prep-before-conjur-prep/2/pipeline#step-175-log-252):
```
++++++++++++++++++++++++++++++++++++++

Installing namespace prep chart

++++++++++++++++++++++++++++++++++++++
Release "namespace-prep-7bc09deb-9" does not exist. Installing it now.
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(RoleBinding.subjects[0]): missing required field "name" in io.k8s.api.rbac.v1.Subject
```

The `authnK8sServiceAccount` field in the Golden ConfigMap template is wrapped in a conditional, and is only created if the Cluster Prep Helm chart was told to create a serviceAccount. The chart's `values.yml` file states:

```
# If 'authnK8s.serviceAccount.create` is set to `true`, then this defaults
# to "conjur-serviceaccount". If 'authnK8s.serviceAccount.create` is set
# to `false`, then this is a required value.
# name: conjur-serviceaccount
# name:
```

In cases where `authnK8s.serviceAccount.create` is set to `false`, the provided `name` was not being used for the `authnK8sServiceAccount` field in the Golden ConfigMap.

### Implemented Changes

- End-to-end test stage for Enterprise-in-GKE now installs Namespace prep Helm chart and deploys test apps
- When `authnK8s.serviceAccount.create` is set to `false`, the Golden ConfigMap template uses `authnK8s.serviceAccount.name` to fill its `authnK8sServiceAccount` field.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
