### PR TITLE
Add E2E tests for secrets rotation

### DIFF
--- a/bin/test-workflow/7_app_deploy.sh
+++ b/bin/test-workflow/7_app_deploy.sh
@@ -62,6 +62,10 @@ pushd ../../helm/conjur-app-deploy > /dev/null
     --set app-secrets-provider-p2f.secretsProvider.image.tag=$SECRETS_PROVIDER_TAG \
     --set app-secrets-provider-p2f.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-p2f \
     --set app-secrets-provider-p2f.app.platform=$PLATFORM"
+  secrets_provider_rotation_options="--set app-secrets-provider-rotation.enabled=true \
+    --set app-secrets-provider-rotation.secretsProvider.image.tag=$SECRETS_PROVIDER_TAG \
+    --set app-secrets-provider-rotation.conjur.authnLogin=$CONJUR_AUTHN_LOGIN_PREFIX/test-app-secrets-provider-rotation \
+    --set app-secrets-provider-rotation.app.platform=$PLATFORM"
 
   declare -A app_options
   app_options[summon-sidecar]="$summon_sidecar_options"
@@ -73,6 +77,7 @@ pushd ../../helm/conjur-app-deploy > /dev/null
   app_options[secrets-provider-init-jwt]="$secrets_provider_init_jwt_options"
   app_options[secrets-provider-p2f]="$secrets_provider_p2f_options"
   app_options[secrets-provider-p2f-jwt]="$secrets_provider_p2f_jwt_options"
+  app_options[secrets-provider-rotation]="$secrets_provider_rotation_options"
 
   # restore array of apps to install
   declare -a install_apps=($(split_on_comma_delimiter $INSTALL_APPS))

--- a/bin/test-workflow/policy/app-policy.yml
+++ b/bin/test-workflow/policy/app-policy.yml
@@ -144,6 +144,25 @@
       resources: *secrets-provider-p2f-variables
 
 - !policy
+  id: test-secrets-provider-rotation-app-db
+  annotations:
+    description: This policy contains the creds to access the secrets provider app DB
+
+  body:
+    - !group
+
+    - &secrets-provider-rotation-variables
+      - !variable password
+      - !variable url
+      - !variable username
+      - !variable counter
+
+    - !permit
+      role: !group
+      privileges: [ read, execute ]
+      resources: *secrets-provider-rotation-variables
+
+- !policy
   id: test-secrets-provider-p2f-jwt-app-db
   annotations:
     description: This policy contains the creds to access the secrets provider app DB

--- a/bin/test-workflow/policy/load_policies.sh
+++ b/bin/test-workflow/policy/load_policies.sh
@@ -37,6 +37,7 @@ readonly APPS=(
   "test-secrets-provider-init-app"
   "test-secrets-provider-init-jwt-app"
   "test-secrets-provider-p2f-app"
+  "test-secrets-provider-rotation-app"
   "test-secrets-provider-p2f-jwt-app"
   "test-secrets-provider-standalone-app"
 )
@@ -72,6 +73,11 @@ for app_name in "${APPS[@]}"; do
     # The authenticator sidecar injects the full pg connection string into the
     # app environment using Summon
     conjur variable values add "$app_name-db/url" "$PROTOCOL://$db_address/test_app"
+  fi
+
+  if [[ "$app_name" = "test-secrets-provider-rotation-app" ]]; then
+    # The rotation test uses an additional value which will be changed later
+    conjur variable values add "$app_name-db/counter" "0"
   fi
 
   # Add some secrets that can be used in demos

--- a/bin/test-workflow/policy/templates/app-grants.template.yml
+++ b/bin/test-workflow/policy/templates/app-grants.template.yml
@@ -56,6 +56,12 @@
     - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/oc-test-app-secrets-provider-p2f
 
 - !grant
+  role: !group test-secrets-provider-rotation-app-db
+  members:
+    - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/test-app-secrets-provider-rotation
+    - !host conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps/oc-test-app-secrets-provider-rotation
+
+- !grant
   role: !group test-secrets-provider-p2f-jwt-app-db
   members:
     - !host conjur/authn-jwt/{{ AUTHENTICATOR_ID }}/apps/system:serviceaccount:app-test:test-app-secrets-provider-p2f-jwt

--- a/bin/test-workflow/policy/templates/app-identities-policy.template.yml
+++ b/bin/test-workflow/policy/templates/app-identities-policy.template.yml
@@ -70,6 +70,14 @@
           authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
           kubernetes: "{{ IS_KUBERNETES }}"
       - !host
+        id: test-app-secrets-provider-rotation
+        annotations:
+          authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+          authn-k8s/service-account: test-app-secrets-provider-rotation
+          authn-k8s/deployment: test-app-secrets-provider-rotation
+          authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
+          kubernetes: "{{ IS_KUBERNETES }}"
+      - !host
         id: test-app-secrets-provider-standalone
         annotations:
           authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
@@ -110,6 +118,13 @@
         annotations:
           authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
           authn-k8s/service-account: oc-test-app-secrets-provider-p2f
+          authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
+          kubernetes: "{{ IS_OPENSHIFT }}"
+      - !host
+        id: oc-test-app-secrets-provider-rotation
+        annotations:
+          authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+          authn-k8s/service-account: oc-test-app-secrets-provider-rotation
           authn-k8s/authentication-container-name: cyberark-secrets-provider-for-k8s
           kubernetes: "{{ IS_OPENSHIFT }}"
       - !host

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -40,6 +40,7 @@ Usage: ./start [options]:
                                 - secretless-broker
                                 - secrets-provider-init
                                 - secrets-provider-p2f
+                                - secrets-provider-rotation
                                 - secrets-provider-standalone
                               If the '--jwt' flag is used, supported apps include:
                                 - summon-sidecar-jwt
@@ -61,7 +62,10 @@ function cleanup {
   fi
 }
 
-declare -a supported_authn_k8s_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init" "secrets-provider-p2f")
+declare -a supported_authn_k8s_apps=(
+  "summon-sidecar" "secretless-broker" "secrets-provider-standalone"
+  "secrets-provider-init" "secrets-provider-p2f" "secrets-provider-rotation"
+)
 declare -a supported_jwt_apps=("summon-sidecar-jwt" "secretless-broker-jwt" "secrets-provider-init-jwt" "secrets-provider-p2f-jwt")
 declare -a run_in_ci_apps=("summon-sidecar" "secretless-broker" "secrets-provider-standalone" "secrets-provider-init")
 # Default: Test all authn-k8s applications

--- a/helm/conjur-app-deploy/Chart.yaml
+++ b/helm/conjur-app-deploy/Chart.yaml
@@ -40,6 +40,10 @@ dependencies:
       repository: "file://charts/app-secrets-provider-p2f"
       version: ">= 0.0.1"
       condition: app-secrets-provider-p2f-jwt.enabled
+    - name: app-secrets-provider-rotation
+      repository: "file://charts/app-secrets-provider-rotation"
+      version: ">= 0.0.1"
+      condition: app-secrets-provider-rotation.enabled
     - name: app-secretless-broker
       repository: "file://charts/app-secretless-broker"
       version: ">= 0.0.1"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/Chart.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: app-secrets-provider-rotation
+home: https://www.conjur.org
+version: 0.1.0
+description: A Helm chart deploying an application with a Secrets Provider sidecar container in Push-to-File mode
+icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
+keywords:
+  - security
+  - "secrets management"
+sources:
+  - https://github.com/cyberark/conjur-authn-k8s-client
+  - https://github.com/cyberark/secrets-provider-for-k8s
+  - https://github.com/cyberark/conjur-oss-helm-chart
+  - https://github.com/cyberark/conjur
+maintainers:
+  - name: Conjur Maintainers
+    email: conj_maintainers@cyberark.com

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/README.md
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/README.md
@@ -1,0 +1,2 @@
+# Helm Chart to Deploy an Application that uses a Secrets Provider for K8S sidecar container in Push-to-File mode with secrets rotation
+

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/templates/NOTES.txt
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/templates/NOTES.txt
@@ -1,0 +1,5 @@
+The Application deployment is complete.
+The following have been deployed:
+- A sample application with a Secrets Provider sidecar container in Push-to-File mode with secrets rotation
+
+Application is now available at test-app-secrets-provider-rotation.{{ .Release.Namespace }}.svc.cluster.local

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/templates/rbac.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/templates/rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-app-secrets-provider-rotation-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-app-secrets-provider-rotation-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: test-app-secrets-provider-rotation
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: test-app-secrets-provider-rotation-role
+  apiGroup: ""

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/templates/test_app_secrets_provider_rotation.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/templates/test_app_secrets_provider_rotation.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-secrets-provider-rotation
+  labels:
+    app: test-app-secrets-provider-rotation
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: test-app-secrets-provider-rotation
+  type: {{ .Values.global.appServiceType }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-app-secrets-provider-rotation
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app-secrets-provider-rotation
+  name: test-app-secrets-provider-rotation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-secrets-provider-rotation
+  template:
+    metadata:
+      labels:
+        app: test-app-secrets-provider-rotation
+      annotations:
+        conjur.org/container-mode: "sidecar"
+        conjur.org/secrets-refresh-enabled: "true"
+        conjur.org/secrets-refresh-interval: "10s"
+        conjur.org/debug-logging: "true"
+        conjur.org/authn-identity: {{ quote .Values.conjur.authnLogin }}
+        conjur.org/secrets-destination: "file"
+        conjur.org/conjur-secrets.rotation-app: |
+          - test-secrets-provider-rotation-app-db/url
+          - test-secrets-provider-rotation-app-db/username
+          - test-secrets-provider-rotation-app-db/password
+        conjur.org/secret-file-path.rotation-app: "./application.yaml"
+        conjur.org/secret-file-format.rotation-app: template
+        conjur.org/secret-file-template.rotation-app: |
+          spring:
+            datasource:
+              platform: postgres
+              url: jdbc:{{ printf `{{ secret "url" }}` }}
+              username: {{ printf `{{ secret "username" }}` }}
+              password: {{ printf `{{ secret "password" }}` }}
+            jpa:
+              generate-ddl: true
+              hibernate:
+                ddl-auto: update
+        conjur.org/conjur-secrets.dummy: |
+          - test-secrets-provider-rotation-app-db/counter
+        conjur.org/secret-file-path.dummy: "./dummy.yaml"
+        conjur.org/secret-file-format.dummy: template
+        conjur.org/secret-file-template.dummy: |
+          counter: {{ printf `{{ secret "counter" }}` }}
+    spec:
+      serviceAccountName: test-app-secrets-provider-rotation
+      containers:
+      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
+        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+        name: test-app
+        command: [ "java", "-jar", "/app.jar", {{ printf "--spring.config.location=file:%s/application.yaml" .Values.app.secretsMountPath }} ]
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /pets
+            port: http
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: secrets
+          mountPath: {{ .Values.app.secretsMountPath }}
+      - image: {{ printf "%s:%s" .Values.secretsProvider.image.repository .Values.secretsProvider.image.tag }}
+        imagePullPolicy: {{ .Values.secretsProvider.image.pullPolicy }}
+        name: cyberark-secrets-provider-for-k8s
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.global.conjur.conjurConnConfigMap }}
+        volumeMounts:
+        - name: conjur-access-token
+          mountPath: /run/conjur
+        - name: conjur-certs
+          mountPath: /etc/conjur/ssl
+        - name: podinfo
+          mountPath: /conjur/podinfo
+        - name: secrets
+          mountPath: /conjur/secrets
+      {{- if eq .Values.app.platform "kubernetes" }}
+      imagePullSecrets:
+        - name: dockerpullsecret
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
+      {{- end }}
+      volumes:
+      - name: conjur-access-token
+        emptyDir:
+          medium: Memory
+      - name: conjur-certs
+        emptyDir:
+          medium: Memory
+      - name: podinfo
+        downwardAPI:
+          items:
+          - path: annotations
+            fieldRef:
+              fieldPath: metadata.annotations
+      - name: secrets
+        emptyDir:
+          medium: Memory

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/test-schema
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/test-schema
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# This script tests the restrictions on chart values
+# as defined in the 'values.schema.json' file.
+#
+# Requirements:
+#   - Helm v3.5.3 or later
+
+# Run this script from the directory in which this script resides
+# regardless of where it is invoked.
+cd "$(dirname "$0")"
+chart_dir="$(pwd)"
+
+source ../../../common/utils.sh
+
+# Default required settings
+readonly DEFAULT_AUTHN_LOGIN="conjur.authnLogin=host/conjur/authn-k8s/my-id/my-group/my-app"
+
+# Global test state
+num_passed=0
+num_failed=0
+test_failed=false
+
+function global_conjur_conn_configmap_name_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "global.conjur.conjurConnConfigMap=$1"
+}
+
+function global_app_service_type_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "global.appServiceType=$1"
+}
+
+function app_image_repository_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "app.image.repository=$1"
+}
+
+function app_image_pull_policy_test() {
+    helm lint . --strict \
+        --set "$DEFAULT_AUTHN_LOGIN" \
+        --set "app.image.pullPolicy=$1"
+}
+
+function main() {
+    banner $BOLD "Running Helm schema tests for chart \"$chart_dir\""
+    check_helm_version
+
+    announce "Conjur Connect ConfigMap name with dashes is accepted"
+    global_conjur_conn_configmap_name_test "name-with-dashes"
+    update_results "$?"
+
+    announce "Conjur Connect ConfigMap name with dotted name is accepted"
+    global_conjur_conn_configmap_name_test "dotted.serviceaccount.name"
+    update_results "$?"
+
+    announce "Valid app image Docker repository accepted"
+    app_image_repository_test "my-org/abc_123"
+    update_results "$?"
+
+    announce "App image Docker repository with '#' is rejected"
+    app_image_repository_test "my-org/abc#123"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    declare -a pull_policy_types=("Always" "Never" "IfNotPresent")
+    for policy in "${pull_policy_types[@]}"; do
+        announce "App image pullPolicy of $policy is accepted"
+        app_image_pull_policy_test "$policy"
+        update_results "$?"
+    done
+
+    announce "App image pullPolicy of lower case 'always' is rejected"
+    app_image_pull_policy_test "always"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    announce "ServiceAccount name with 253 characters is rejected"
+    conjur_authn_configmap_name_test "name-with-more-than-253-chars----------40--------50--------60--------70--------80--------90--------100-------110-------120--------130-------140-------150-------160-------170-------180-------190-------200-------210-------220-------230-------240-------2503"
+    update_results "$?" "$EXPECT_FAILURE"
+
+    display_final_results
+    if [ "$num_failed" -ne 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/test-unit
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/test-unit
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Runs a Helm unit test using the 'helm-unittest' Helm plugin.
+# Reference: https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md
+
+# Run this script from the directory in which this script resides
+# regardless of where it is invoked.
+cd "$(dirname "$0")"
+chart_dir="$(pwd)"
+
+source ../../../common/utils.sh
+
+banner $BOLD "Running Helm unit tests for chart \"$chart_dir\""
+run_helm_unittest

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/tests/test_app_secrets_provider_rotation_test.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/tests/test_app_secrets_provider_rotation_test.yaml
@@ -1,0 +1,68 @@
+suite: test test_app_secrets_provider_rotation
+
+templates:
+  - test_app_secrets_provider_rotation.yaml
+
+tests:
+  #=======================================================================
+  - it: should use default values for Service 
+  #=======================================================================
+    set:
+
+    documentIndex: 0
+
+    asserts:
+     - isKind:
+         of: Service
+
+     - equal:
+          path: spec.type
+          value: NodePort
+     - equal:
+          path: metadata.name
+          value:  test-app-secrets-provider-rotation
+     - equal:
+          path: metadata.labels.app
+          value:  test-app-secrets-provider-rotation
+
+  #=======================================================================
+  - it: should use default values for ServiceAccount
+  #=======================================================================
+    set:
+
+    documentIndex: 1
+
+    asserts:
+     - hasDocuments:
+          count: 3
+     - isKind:
+         of: ServiceAccount
+
+  #=======================================================================
+  - it: should use default values for Deployment 
+  #=======================================================================
+    set:
+
+    documentIndex: 2
+
+    asserts:
+     - isKind:
+          of: Deployment
+     - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/cyberark/demo-app:latest"
+     - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"
+     - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: "/mounted/secrets"
+     - equal:
+          path: spec.template.spec.containers[1].image
+          value: "docker.io/cyberark/secrets-provider-for-k8s:latest"
+     - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: "Always"
+     - equal:
+          path: spec.template.spec.containers[1].envFrom[0].configMapRef.name
+          value: "conjur-connect"

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/values.schema.json
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/values.schema.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "properties": {
+      "app": {
+        "properties": {
+          "image": {
+            "properties": {
+              "repository": {
+                "type": "string",
+                "pattern": "^[a-z0-9:./_-]+$"
+              },
+              "tag": {
+                "type": "string"
+              },
+              "pullPolicy": {
+                "type": "string",
+                "pattern": "^(Always|Never|IfNotPresent)$"
+              }
+            }
+          }
+        }
+      },
+      "conjur": {
+        "properties": {
+          "authnLogin": {
+            "type": "string"
+          }
+        }
+      },
+      "secretsProvider": {
+        "properties": {
+          "image": {
+            "properties": {
+              "repository": {
+                "type": "string"
+              },
+              "tag": {
+                "type": "string"
+              },
+              "pullPolicy": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/values.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/values.yaml
@@ -1,0 +1,27 @@
+# Default values for the Application with Secrets Provider sidecar container in Push-to-File mode Helm chart
+# This is a YAML-formatted file.
+
+global:
+  conjur:
+    # name of the ConfigMap created by the conjur-config-namespace-prep chart
+    conjurConnConfigMap: "conjur-connect"
+  appServiceType: "NodePort"
+
+app:
+  image:
+    repository: "docker.io/cyberark/demo-app"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+  platform: "kubernetes"
+  secretsMountPath: "/mounted/secrets"
+
+secretsProvider:
+  image:
+    repository: "docker.io/cyberark/secrets-provider-for-k8s"
+    tag: "latest"
+    # supported values: "Always", "IfNotPresent", "Never"
+    pullPolicy: "Always"
+
+conjur:
+  authnLogin: ""

--- a/helm/conjur-app-deploy/values.yaml
+++ b/helm/conjur-app-deploy/values.yaml
@@ -39,5 +39,8 @@ app-secrets-provider-p2f:
 app-secrets-provider-p2f-jwt:
   enabled: false
 
+app-secrets-provider-rotation:
+  enabled: false
+
 app-secrets-provider-standalone:
   enabled: false


### PR DESCRIPTION
### Desired Outcome

Implement end-to-end smoke tests for secrets rotation in secrets provider.

### Implemented Changes

- Added helm charts and bash tests for secrets rotation in secrets provider.
- **New test must be run manually with `./bin/test-workflow/start -a secrets-provider-rotation`. They're currently not run in the CI.**

### Connected Issue/Story

CyberArk internal issue link: [ONYX-16912](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16912)

### Definition of Done

- [x] Tests exist for secrets rotation

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
