### PR TITLE
Bump client version to 0.23.1 and Config Helm chart versions to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.23.1] - 2022-02-11
+### Added
+- Authenticator client logs request IP address after login error.
+  [cyberark/conjur-authn-k8s-client#439](https://github.com/cyberark/conjur-authn-k8s-client/pull/439)
+
+### Changed
+- If Cluster Prep Helm chart value `authnK8s.clusterRole.create` or
+  `authnK8s.serviceAccount.create` is `false`, their corresponding `name` is no
+  longer required, as these objects are not required for Authn-JWT.
+  [cyberark/conjur-authn-k8s-client#445](https://github.com/cyberark/conjur-authn-k8s-client/pull/445)
+  [cyberark/conjur-authn-k8s-client#452](https://github.com/cyberark/conjur-authn-k8s-client/pull/452)
+
+### Fixed
+- Fixes bug in Namespace Prep Helm chart's `conjur_connect_configmap.yaml`,
+  which silently accepted missing values from the referenced Golden ConfigMap.
+  [cyberark/conjur-authn-k8s-client#447](https://github.com/cyberark/conjur-authn-k8s-client/pull/447)
+
 ## [0.23.0] - 2022-01-14
 ### Added
 - Add support for tracing with OpenTelemetry. This adds a new function to the authenticator, `AuthenticateWithContext`. The existing funtion, `Authenticate()` is deprecated and will be removed in a future upddate. [cyberark/conjur-authn-k8s-client#423](https://github.com/cyberark/conjur-authn-k8s-client/pull/423)
@@ -199,7 +216,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix an issue where sidecar fails when not run as root user.
 
-[Unreleased]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.23.1...HEAD
+[0.23.1]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.20.0...v0.21.0

--- a/helm/conjur-app-deploy/Chart.yaml
+++ b/helm/conjur-app-deploy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: conjur-app-deploy
 home: https://www.conjur.org
-version: 0.1.1
+version: 0.1.2
 description: A Helm chart deploying an application with a Summon sidecar
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
 keywords:

--- a/helm/conjur-config-cluster-prep/Chart.yaml
+++ b/helm/conjur-config-cluster-prep/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: conjur-config-cluster-prep
 home: https://www.conjur.org
-version: 0.1.2
+version: 0.1.3
 description: A Helm chart for preparing a Kubernetes cluster to use
              the Conjur Kubernetes authenticator (authn-k8s)
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg

--- a/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
+++ b/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/instance: "conjur-serviceaccount"
     app.kubernetes.io/part-of: "conjur-config"
     conjur.org/name: "conjur-serviceaccount"
-    helm.sh/chart: conjur-config-cluster-prep-0.1.2
+    helm.sh/chart: conjur-config-cluster-prep-0.1.3
 ---
 # Source: conjur-config-cluster-prep/templates/golden_configmap.yaml
 # The Golden ConfigMap keeps a reference copy of Conjur configuration information
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: "conjur-golden-configmap"
     app.kubernetes.io/part-of: "conjur-config"
     conjur.org/name: "conjur-golden-configmap"
-    helm.sh/chart: conjur-config-cluster-prep-0.1.2
+    helm.sh/chart: conjur-config-cluster-prep-0.1.3
 data:
   # authn-k8s Configuration 
   authnK8sAuthenticatorID: <Insert-Authenticator-ID-Here>
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/instance: "conjur-clusterrole"
     app.kubernetes.io/part-of: "conjur-config"
     conjur.org/name: "conjur-clusterrole"
-    helm.sh/chart: conjur-config-cluster-prep-0.1.2
+    helm.sh/chart: conjur-config-cluster-prep-0.1.3
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["pods", "serviceaccounts"]

--- a/helm/conjur-config-namespace-prep/Chart.yaml
+++ b/helm/conjur-config-namespace-prep/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: conjur-config-namespace-prep
 home: https://www.conjur.org
-version: 0.1.2
+version: 0.1.3
 description: A Helm chart which prepares a Namespace for using CyberArk Conjur authenticator clients
 icon: https://www.cyberark.com/wp-content/uploads/2015/12/cybr-aim.jpg
 keywords:

--- a/pkg/authenticator/version.go
+++ b/pkg/authenticator/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the authn-k8s-client
-var Version = "0.23.0"
+var Version = "0.23.1"
 
 // TagSuffix field denotes the specific build type for the client. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
### Desired Outcome

Release the Authenticator client.

### Implemented Changes

- Update `CHANGELOG.md` to include missing entries
- Update `version.go` from 0.23.0 to 0.23.1
- Update Configuration Helm Chart versions from 0.1.2 to 0.1.3
  - Re-generate raw manifests
- No dependency updates, no need to update `NOTICES.txt`

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
