### PR TITLE
Adds poststart hook to delay app startup until SP P2F completes

### DIFF
--- a/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/templates/test_app_secrets_provider_rotation.yaml
+++ b/helm/conjur-app-deploy/charts/app-secrets-provider-rotation/templates/test_app_secrets_provider_rotation.yaml
@@ -66,22 +66,6 @@ spec:
     spec:
       serviceAccountName: test-app-secrets-provider-rotation
       containers:
-      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
-        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
-        name: test-app
-        command: [ "java", "-jar", "/app.jar", {{ printf "--spring.config.location=file:%s/application.yaml" .Values.app.secretsMountPath }} ]
-        ports:
-        - name: http
-          containerPort: 8080
-        readinessProbe:
-          httpGet:
-            path: /pets
-            port: http
-          initialDelaySeconds: 15
-          timeoutSeconds: 5
-        volumeMounts:
-        - name: secrets
-          mountPath: {{ .Values.app.secretsMountPath }}
       - image: {{ printf "%s:%s" .Values.secretsProvider.image.repository .Values.secretsProvider.image.tag }}
         imagePullPolicy: {{ .Values.secretsProvider.image.pullPolicy }}
         name: cyberark-secrets-provider-for-k8s
@@ -97,6 +81,13 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ .Values.global.conjur.conjurConnConfigMap }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - until [ -f /conjur/secrets/application.yaml ]; do sleep 1; done
         volumeMounts:
         - name: conjur-access-token
           mountPath: /run/conjur
@@ -106,6 +97,44 @@ spec:
           mountPath: /conjur/podinfo
         - name: secrets
           mountPath: /conjur/secrets
+      - image: {{ printf "%s:%s" .Values.app.image.repository .Values.app.image.tag }}
+        imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+        name: test-app
+        command: [ "java", "-jar", "/app.jar", {{ printf "--spring.config.location=file:%s/application.yaml" .Values.app.secretsMountPath }} ]
+        ports:
+        - name: http
+          containerPort: 8080
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - |-
+              datefile=/mounted/secrets/prev_write_date.txt
+              secretfile=/mounted/secrets/application.yaml
+              touch "$datefile"
+              prev_date="$(cat $datefile)"
+              current_date="$(date -r $secretfile)"
+              if [ "$prev_date" != "$current_date" ]; then
+                echo "$current_date" > "$datefile"
+                if [ "$prev_date" != "" ]; then
+                  exit 1
+                fi
+              fi
+          failureThreshold: 1
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /pets
+            port: http
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: secrets
+          mountPath: {{ .Values.app.secretsMountPath }}
       {{- if eq .Values.app.platform "kubernetes" }}
       imagePullSecrets:
         - name: dockerpullsecret


### PR DESCRIPTION
### Desired Outcome

For the application Helm chart for the Secrets Provider running in Push-to-File mode with secret rotation support, it is desirable that we include:

- A Kubernetes postStart lifecycle hook that delays startup of the application until the SP has finished creating the secret file(s).
- A liveness probe for the application container that forces the application container to be restarted whenever the date of the secrets files change.

### Implemented Changes

The following changes are made to the `app-secrets-provider-rotation` Helm chart in order to delay the application container from starting until after the Secrets Provider sidecar container has finished creating the secret file(s) in the secrets shared volume:

- A 'postStart' lifecycle hook is added to the SP container definition.
- The SP container definition is moved before the app container definition. THe SP container def must appear first in order for the 'postStart' lifecycle hook to take effect before the app container starts.

Also, a liveness probe is added which uses the secret file date to determine if the application should be restarted.

These are being added as a reference for customers who are interested in sequencing the SP sidecar container and their app container startup, and who might need to have their application restarted whenever changes occur in the rendered secret files.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
