### PR TITLE
Added automated release process to project pipeline.

### DIFF
--- a/.github/workflows/e2e-workflow.yaml
+++ b/.github/workflows/e2e-workflow.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Install Helm
         uses: azure/setup-helm@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.23.2] - 2022-03-23
+### Changed
+- Update to automated release process.[cyberark/conjur-authn-k8s-client#457](https://github.com/cyberark/conjur-authn-k8s-client/pull/457)
+
 ## [0.23.1] - 2022-02-11
 ### Added
 - Authenticator client logs request IP address after login error.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,13 +171,12 @@ You can use the kubectl edit command to edit the images in the deployment and re
 
 ## Releases
 
-Releases should be created by maintainers only. To create a tag and release,
-follow the instructions in this section.
+Releases should be created by maintainers only. To create and promote a
+release, follow the instructions in this section.
 
-### Update the version, changelog, and notices
+### Update the changelog and notices
 1. Create a new branch for the version bump.
-1. Based on the unreleased content, determine the new version number and update
-   the [version.go](pkg/authenticator/version.go) file.
+1. Based on the changelog content, determine the new version number and update.
 1. Determine the new version number and update the Helm `Chart.yaml` files in the `helm/conjur-*/` directories.
 1. Review the git log and ensure the [changelog](CHANGELOG.md) contains all
    relevant recent changes with references to GitHub issues or PRs, if possible.
@@ -187,18 +186,10 @@ follow the instructions in this section.
 1. Commit these changes - `Bump version to x.y.z` is an acceptable commit
    message - and open a PR for review.
 
-### Add a git tag
-1. Once your changes have been reviewed and merged into master, tag the version
-   using `git tag -s v0.1.1`. Note this requires you to be  able to sign releases.
-   Consult the [github documentation on signing commits](https://help.github.com/articles/signing-commits-with-gpg/)
-   on how to set this up. `vx.y.z` is an acceptable tag message.
-1. Push the tag: `git push vx.y.z` (or `git push origin vx.y.z` if you are working
-   from your local machine).
-
-### Publish the git release
-1. In the GitHub UI, create a release from the new tag and copy the change log
-   for the new version into the GitHub release description. The Jenkins pipeline 
-   will auto-publish new images to DockerHub.
+### Release and Promote
+1. Merging into main/master branches will automatically trigger a release. If successful, this release can be promoted at a later time.
+1. Jenkins build parameters can be utilized to promote a successful release or manually trigger aditional releases as needed.
+1. Reference the [internal automated release doc](https://github.com/conjurinc/docs/blob/master/reference/infrastructure/automated_releases.md#release-and-promotion-process) for releasing and promoting.
 ### Publish the Red Hat image
 1. Visit the [Red Hat project page](https://connect.redhat.com/project/795581/view) once the images have
    been pushed and manually choose to publish the latest release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,13 @@ EXPOSE 8080
 
 RUN apt-get update && apt-get install -y jq
 
+# Use latest dependency for automated release process
+RUN go get github.com/cyberark/conjur-opentelemetry-tracer@latest
+
 RUN go mod download
+
+# Add required cyberark/conjur-opentelemetry-tracer package to go.mod
+RUN go mod tidy
 
 RUN go get -u github.com/jstemmer/go-junit-report
 

--- a/Dockerfile.helm-unit-test
+++ b/Dockerfile.helm-unit-test
@@ -21,6 +21,9 @@ RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
 RUN mkdir -p /conjur-authn-k8s-client
 WORKDIR /conjur-authn-k8s-client
 
+# Workaround for CVE-2022-24765 when running git inside a docker container
+RUN git config --global --add safe.directory /conjur-authn-k8s-client
+
 LABEL name="conjur-k8s-helm-unit-test"
 LABEL vendor="CyberArk"
 LABEL version="$VERSION"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -13,6 +13,10 @@ RUN apk add -u curl \
 
 COPY go.mod go.sum /conjur-authn-k8s-client/
 
+# Use latest dependency for automated release process
+RUN go get github.com/cyberark/conjur-opentelemetry-tracer@latest
 RUN go mod download
 
 COPY . .
+# Add required cyberark/conjur-opentelemetry-tracer package to go.mod
+RUN go mod tidy

--- a/bin/build
+++ b/bin/build
@@ -14,24 +14,22 @@ function build_docker_images {
   # dev build (env GOOS=darwin GOARCH=amd64 go build) of project binaries
   IMAGE_NAME=conjur-authn-k8s-client
   TAG=dev
-  VERSION="$(short_version_tag)"
+  VERSION=$(<VERSION)
+  readonly VERSION="${VERSION//"v"}"
 
   echo "---"
   echo "Building ${IMAGE_NAME} with tag ${TAG} <<"
 
   docker build --tag "${IMAGE_NAME}:${TAG}" \
-               --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
                --target "authenticator-client" \
                .
 
   docker build --tag "${IMAGE_NAME}-redhat:${TAG}" \
-               --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
                --build-arg VERSION="$VERSION" \
                --target "authenticator-client-redhat" \
                .
 
   docker build --tag conjur-k8s-cluster-test:${TAG} \
-               --build-arg TAG_SUFFIX="$(git_tag_suffix)" \
                --build-arg VERSION="$VERSION" \
                --target "k8s-cluster-test" \
                .

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -18,7 +18,7 @@ function gen_versions() {
   local version=$1
   while [[ $version = *.* ]]; do
     version=${version%.*}
-    echo $version
+    echo "${version}"
   done
 }
 
@@ -38,12 +38,23 @@ function git_commit_short() {
 }
 
 function push_conjur-k8s-cluster-test() {
-    echo "Pushing Helm test image to Dockerhub..."
-    source_image=conjur-k8s-cluster-test:dev
-    destination_image_name=conjur-k8s-cluster-test
-    echo "Tagging and pushing $REGISTRY/$destination_image_name:$tag"
-    docker tag $source_image "$REGISTRY/$destination_image_name:$tag"
-    docker push "$REGISTRY/$destination_image_name:$tag"
+  echo "Pushing Helm test image to Dockerhub..."
+  local source_image=conjur-k8s-cluster-test:${SOURCE_TAG}
+  local destination_image_name=conjur-k8s-cluster-test
+  echo "Tagging and pushing ${REGISTRY}/${destination_image_name}:${REMOTE_TAG}"
+  docker tag "${source_image}" "${REGISTRY}/${destination_image_name}:${REMOTE_TAG}"
+  docker push "${REGISTRY}/${destination_image_name}:${REMOTE_TAG}"
+}
+
+function tag_and_push() {
+  local source="$1"
+  shift
+  local target="$1"
+  shift
+
+  echo "Tagging and pushing $target..."
+  docker tag "${source}" "${target}"
+  docker push "${target}"
 }
 
 function retrieve_cyberark_ca_cert() {
@@ -62,7 +73,7 @@ function retrieve_cyberark_ca_cert() {
   #
   # The certificate file must have the .crt extension to be imported
   # by `update-ca-certificates`.
-  if command -v security &> /dev/null
+  if command -v security &>/dev/null
   then
     security find-certificate \
       -a -c "CyberArk Enterprise Root CA" \

--- a/bin/publish
+++ b/bin/publish
@@ -1,63 +1,147 @@
 #!/bin/bash -e
 
+# The following is used to:
+# Publish images on pre-release and tag as edge
+# Promote pre-releases to releases and tag as latest
+
 . bin/build_utils
 
-REDHAT_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb/conjur-openshift-authenticator-client'
+function print_help() {
+  echo "Build Usage: $0 --internal"
+  echo "Release Usage: $0 --edge"
+  echo "Promote Usage: $0 --promote --source <VERSION> --target <VERSION>"
+  echo " --internal: publish images to registry.tld"
+  echo " --edge: publish docker images to docker hub"
+  echo " --source <VERSION>: specify version number of local image"
+  echo " --target <VERSION>: specify version number of remote image"
+}
 
-readonly REGISTRY="cyberark"
-
-if [[ $1 = "--edge" ]]; then
-    tag=edge
-    push_conjur-k8s-cluster-test
-    exit 0
+# Fail if no arguments are given.
+if [[ $# -lt 1 ]]; then
+  print_help
+  exit 1
 fi
 
-# We take the version from the TAG_NAME variable - removing the "v" prefix
-readonly VERSION="${TAG_NAME//"v"}"
+PUBLISH_INTERNAL=false
+PUBLISH_EDGE=false
+PROMOTE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --internal)
+    PUBLISH_INTERNAL=true
+    ;;
+  --edge)
+    PUBLISH_EDGE=true
+    ;;
+  --promote)
+    PROMOTE=true
+    ;;
+  --source)
+    SOURCE_ARG="$2"
+    shift
+    ;;
+  --target)
+    TARGET_ARG="$2"
+    shift
+    ;;
+  --help)
+    print_help
+    exit 1
+    ;;
+  *)
+    echo "Unknown option: ${1}"
+    print_help
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+REDHAT_REMOTE_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb/conjur-openshift-authenticator-client'
+readonly REGISTRY="cyberark"
+readonly REDHAT_LOCAL_IMAGE="conjur-authn-k8s-client-redhat"
 
 # we changed the name to `conjur-authn-k8s-client`. Leaving `conjur-kubernetes-authenticator`
 # for backwards-compatibility.
-readonly DESTINATION_IMAGES=(
+readonly DOCKER_IMAGES=(
   "conjur-kubernetes-authenticator"
   "conjur-authn-k8s-client"
 )
 
-readonly TAGS=(
-  "$VERSION"
-  "latest"
-)
+  # Version derived from CHANGLEOG and automated release library
+  VERSION=$(<VERSION)
+  readonly VERSION
 
-if [[ -z "${TAG_NAME:-}" ]]; then
-  echo "This script should only run in a tag-triggered build controlled by the JenkinsFile"
-  exit 1
+if [[ ${PUBLISH_INTERNAL} = true ]]; then
+  echo "Publishing built images internally to registry.tld."
+  SOURCE_TAG=dev
+  REMOTE_TAG=$VERSION
+
+  tag_and_push "conjur-authn-k8s-client:${SOURCE_TAG}" "registry.tld/conjur-authn-k8s-client:${REMOTE_TAG}"
+
+  tag_and_push ${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG} "registry.tld/${REDHAT_LOCAL_IMAGE}:${REMOTE_TAG}"
 fi
 
-echo "Pushing to Dockerhub..."
-source_image=conjur-authn-k8s-client:dev
-for destination_image_name in "${DESTINATION_IMAGES[@]}"; do
-  for tag in "${TAGS[@]}" $(gen_versions "$VERSION"); do
-    echo "Tagging and pushing $REGISTRY/$destination_image_name:$tag"
-    docker tag $source_image "$REGISTRY/$destination_image_name:$tag"
-    docker push "$REGISTRY/$destination_image_name:$tag"
+if [[ ${PUBLISH_EDGE} = true ]]; then
+  echo "Performing docker edge release."
+  SOURCE_TAG=dev
+  REMOTE_TAG=edge
+  readonly TAGS=(
+    "$REMOTE_TAG"
+    "$VERSION"
+  )
+
+  push_conjur-k8s-cluster-test
+
+  for image in "${DOCKER_IMAGES[@]}"; do
+    echo "Tagging and pushing ${image} to docker hub."
+    for tag in "${TAGS[@]}"; do
+      tag_and_push "conjur-authn-k8s-client:${SOURCE_TAG}" "${REGISTRY}/${image}:${tag}"
+    done
   done
-done
-
-echo "Pushing to RedHat container registry..."
-source_redhat_image=conjur-authn-k8s-client-redhat:dev
-docker tag $source_redhat_image "$REDHAT_IMAGE:$VERSION"
-
-if docker login scan.connect.redhat.com -u unused -p "$REDHAT_API_KEY"; then
-  # you can't push the same tag twice to redhat registry, so ignore errors
-  if ! docker push "${REDHAT_IMAGE}:${VERSION}"; then
-    echo 'RedHat push FAILED! (maybe the image was pushed already?)'
-    exit 0
-  fi
-else
-  echo 'Failed to log in to scan.connect.redhat.com'
-  exit 1
 fi
 
-for tag in "${TAGS[@]}" $(gen_versions "$VERSION"); do
-    push_conjur-k8s-cluster-test
-done
+if [[ ${PROMOTE} = true ]]; then
+  if [[ -z ${SOURCE_ARG:-} || -z ${TARGET_ARG:-} ]]; then
+  echo "When promoting, --source and --target flags are required."
+    print_help
+    exit 1
+  fi
 
+  # Update vars to utilize build_utils
+  SOURCE_TAG=$SOURCE_ARG
+  REMOTE_TAG=$TARGET_ARG
+
+  # Promotes image based on flag values provided
+  echo "Promoting image from ${SOURCE_TAG} to ${REMOTE_TAG}"
+  readonly TAGS=(
+    "$REMOTE_TAG"
+    "latest"
+  )
+
+  for image in "${DOCKER_IMAGES[@]}"; do
+    echo "Tagging and pushing ${image} to docker hub."
+    for tag in "${TAGS[@]}" $(gen_versions "${REMOTE_TAG}"); do
+      tag_and_push "conjur-authn-k8s-client:${SOURCE_TAG}" "${REGISTRY}/${image}:${tag}"
+    done
+  done
+
+  echo "Pushing to RedHat container registry..."
+  docker tag "${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}"
+
+  if docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"; then
+    # you can't push the same tag twice to redhat registry, so ignore errors
+    if ! docker push "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}"; then
+      echo 'RedHat push FAILED! (maybe the image was pushed already?)'
+      exit 0
+    fi
+  else
+    echo 'Failed to log in to scan.connect.redhat.com'
+    exit 1
+  fi
+
+  for REMOTE_TAG in "${TAGS[@]}" $(gen_versions "${REMOTE_TAG}"); do
+    push_conjur-k8s-cluster-test
+  done
+fi

--- a/bin/test-workflow/0_prep_env.sh
+++ b/bin/test-workflow/0_prep_env.sh
@@ -96,7 +96,7 @@ if [[ "$CONJUR_PLATFORM" == "gke" ]]; then
   export DEPLOY_MASTER_CLUSTER=true
   export CONFIGURE_CONJUR_MASTER=true
 elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
-  export HOST_IP="${HOST_IP:-$(curl http://169.254.169.254/latest/meta-data/public-ipv4)}"
+  export HOST_IP="${HOST_IP:-$(curl https://checkip.amazonaws.com)}"
   export CONJUR_MASTER_PORT="${CONJUR_MASTER_PORT:-40001}"
   export CONJUR_FOLLOWER_PORT="${CONJUR_FOLLOWER_PORT:-40002}"
   export CONJUR_APPLIANCE_URL="https://${HOST_IP}:${CONJUR_MASTER_PORT}"

--- a/bin/test-workflow/1_deploy_conjur.sh
+++ b/bin/test-workflow/1_deploy_conjur.sh
@@ -96,7 +96,6 @@ function setup_conjur_open_source {
   popd > /dev/null
 }
 
-mkdir -p temp
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   setup_conjur_open_source
 else

--- a/bin/test-workflow/start
+++ b/bin/test-workflow/start
@@ -211,6 +211,9 @@ test_app_workflow="
 ./7_app_deploy.sh &&
 ./8_app_verify_authentication.sh"
 
+# Setup temp testing environment before tests are executed.
+mkdir -p temp
+
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   if [[ "$CONJUR_PLATFORM" == "openshift" && "$RUN_CLIENT_CONTAINER" == "true" ]]; then
     source "./0_prep_env.sh"

--- a/bin/validate-helm
+++ b/bin/validate-helm
@@ -383,6 +383,9 @@ function main() {
     exit 1
   fi
 
+  # Setup temp testing environment before tests are executed.
+  mkdir -p "$TEST_WORKFLOW_DIR/temp"
+
   # Create the KinD cluster and deploy Conjur OSS if requested
   if [ "$create_kind" = true ] ; then
     if ! create_cluster_and_conjur; then

--- a/dev/Dockerfile.debug
+++ b/dev/Dockerfile.debug
@@ -7,6 +7,8 @@ RUN go install github.com/cespare/reflex@latest
 
 WORKDIR /work
 COPY .  /work/
+
+RUN go get github.com/cyberark/conjur-opentelemetry-tracer@latest
 RUN go mod download
 
 COPY dev/dev.sh /work/

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/cyberark/conjur-authn-k8s-client
 
-go 1.17
+go 1.16
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/cyberark/conjur-opentelemetry-tracer v0.0.0-20220113161145-73452511df0c
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0


### PR DESCRIPTION
- Project pipeline moved to azure-linux executor allowing public IP
access for workflow tests.

- Reconfigured bin/publish to perform releases and promotions
of contianer images based on optional flag parameters.

- Added additional functions in bin/build_utils for the automated releases.

- Maintained legacy bin/build_utils functions that are currently no longer in
use, but might provide useful in the future.

- Added submodule for conjur-opentelemetry-tracer upstream dependency.

- Moved temp directory creation to /bin/test-workflow/start. The temp directory
must be created by the jenkins user to prevent permission issues within
the directory. This also removes the possibility of a race condition when parallel
test stages are running and allows for developers to skip tests
during the development process.

### Desired Outcome

Add project to automated release process.

### Implemented Changes

- Jenkins executor is now an Azure instance to allow for public facing IP access.
 
- Version file is automatically generated from the CHANGELOG, this is utilized for automated
releases.

- Github pre-release are automatically generated with the option to promote said pre-release
to a GitHub release for customers.

- Docker Software Bill of Materials is generated on releases and is stored as an artifact. This can
be utilized to regenerate the go.mod file.

- Container images are tagged as edge for pre-releases.

- Images that are promoted (released) are tagged as latest. 

### Connected Issue/Story

N/A

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
