### PR TITLE
Enable test coverage reporting with Cobertura and CodeClimate

### DIFF
--- a/Dockerfile.junit
+++ b/Dockerfile.junit
@@ -2,7 +2,7 @@ FROM golang:1.17-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-junit-processor"
 
-WORKDIR /test
+WORKDIR /conjur-authn-k8s-client/test
 
 RUN apk add -u curl \
                gcc \
@@ -11,4 +11,8 @@ RUN apk add -u curl \
                musl-dev \
                bash
 
-RUN go get -u github.com/jstemmer/go-junit-report
+# gocov converts native coverage output to gocov's JSON interchange format
+# gocov-xml converts gocov format to XML for use with Jenkins/Cobertura
+RUN go get -u github.com/jstemmer/go-junit-report && \
+    go get github.com/axw/gocov/gocov && \
+    go get github.com/AlekSi/gocov-xml

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,6 +2,17 @@ FROM golang:1.17-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-test-runner"
 
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 ENTRYPOINT [ "go", "test", "-v", "-timeout", "3m" ]
 WORKDIR /conjur-authn-k8s-client
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,8 +107,11 @@ pipeline {
     stage('Run Tests') {
       steps {
         sh './bin/test'
+        sh 'cp ./test/c.out ./c.out'
 
         junit 'test/junit.xml'
+        cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'test/coverage.xml', conditionalCoverageTargets: '70, 0, 70', failUnhealthy: true, failUnstable: true, maxNumberOfBuilds: 0, lineCoverageTargets: '70, 70, 70', methodCoverageTargets: '70, 0, 70', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+        ccCoverage("gocov", "--prefix github.com/cyberark/conjur-authn-k8s-client")
       }
     }
 

--- a/bin/test
+++ b/bin/test
@@ -5,7 +5,7 @@ set -eox pipefail
 rm -rf test
 mkdir test
 
-junit_output_file="test/junit.output"
+junit_output_file="./test/junit.output"
 
 rm -f "$junit_output_file"
 touch "$junit_output_file"
@@ -15,7 +15,10 @@ docker build -f Dockerfile.test -t conjur-authn-k8s-client-test-runner:latest .
 
 echo "Running unit tests..."
 set +e
-  docker run --rm -t conjur-authn-k8s-client-test-runner:latest \
+  docker run --rm -t --volume "$PWD"/test/:/conjur-authn-k8s-client/test/ \
+             conjur-authn-k8s-client-test-runner:latest \
+             -coverpkg ./... \
+             -coverprofile "./test/c.out.tmp" \
              ./cmd/... \
              ./pkg/... \
              | tee -a "$junit_output_file"
@@ -25,14 +28,15 @@ set -e
 rm -f junit.xml
 
 echo "Building junit image..."
-
 docker build -f Dockerfile.junit -t conjur-authn-k8s-client-junit:latest .
 
 echo "Creating junit report..."
 
 docker run --rm \
-  -v $PWD/test:/test \
+  -v "$PWD"/:/conjur-authn-k8s-client/ \
   conjur-authn-k8s-client-junit:latest \
   bash -exc "
     cat ./junit.output | go-junit-report > ./junit.xml
+    cat ./c.out.tmp | grep -v authenticator_test_server.go > ./c.out
+    gocov convert ./c.out | gocov-xml > ./coverage.xml
   "


### PR DESCRIPTION
### Desired Outcome

Report Go unit test coverage of `pkg/` and `cmd/` files to Cobertura and CodeClimate.

### Implemented Changes

- Add Go test coverage tools to `Dockerfile.junit`
- Update `bin/test` to convert Go coverage report to format consumable by Cobertura
- Add CodeClimate reporting to `Jenkinsfile` 
- Use `go test` flag `-coverpkg`, which allows tests to record coverage for source files in other packages.
  - Some packages use a `tests` sub-package for test files, which leaves the parent package with 0% coverage.
  - Some packages, like `common` and `config`,  should register coverage from tests in packages that use their common functionality.

See: [Resulting Cobertura coverage report in Jenkins](https://jenkins.conjur.net/job/cyberark--conjur-authn-k8s-client/job/enable-coverage-report/9/cobertura/)

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14776](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14776)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes