### PR TITLE
Validate log messages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,12 @@ pipeline {
           steps { sh './bin/parse-changelog.sh' }
         }
 
+        stage('Log messages') {
+          steps {
+            validateLogMessages()
+          }
+        }
+
         stage('Cluster-Prep Schema') {
           steps { sh './bin/validate-schema ./helm/conjur-config-cluster-prep/values.schema.json'}
         }


### PR DESCRIPTION
### Desired Outcome

Add a Jenkins step to validate log message files such as [this](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/pkg/log/messages/error_messages.go) and alert to any mismatches between the IDs of the `const` variables and the IDs in the actual message string.
It is common to copy and paste lines from these files and simply change the message and increment the number in the variable name, but forget to change the ID in the message string. This script would detect this automatically.
An example of where this mistake happened can be found [here](https://github.com/cyberark/secrets-provider-for-k8s/pull/449#discussion_r837549729)

### Implemented Changes

- Added a Jenkins step that finds files matching "*messages.go" and parses them for log messages. It then verifies that all log messages are consistent between the variable name and the error code in the message string.

### Connected Issue/Story

N/A

### Definition of Done

- [x] Script returns error when there are mismatched error codes
- [x] Script returns successfully when there are no mismatches

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
