### PR TITLE
Add handling for test image publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ if (params.MODE == "PROMOTE") {
     // Pull existing images from internal registry in order to promote
     sh "docker pull registry.tld/conjur-authn-k8s-client:${sourceVersion}"
     sh "docker pull registry.tld/conjur-authn-k8s-client-redhat:${sourceVersion}"
+    sh "docker pull cyberark/conjur-authn-k8s-cluster-test:${sourceVersion}"
     // Promote source version to target version.
     sh "summon ./bin/publish --promote --source ${sourceVersion} --target ${targetVersion}"
   }

--- a/bin/publish
+++ b/bin/publish
@@ -97,8 +97,9 @@ if [[ ${PUBLISH_EDGE} = true ]]; then
 
   for image in "${DOCKER_IMAGES[@]}"; do
     echo "Tagging and pushing ${image} to docker hub."
-    for tag in "${TAGS[@]}"; do
-      tag_and_push "conjur-authn-k8s-client:${SOURCE_TAG}" "${REGISTRY}/${image}:${tag}"
+    for REMOTE_TAG in "${TAGS[@]}"; do
+      tag_and_push "conjur-authn-k8s-client:${SOURCE_TAG}" "${REGISTRY}/${image}:${REMOTE_TAG}"
+      push_conjur-k8s-cluster-test
     done
   done
 fi


### PR DESCRIPTION
Intermediate versions of `cyberark/conjur-authn-k8s-cluster-test` need to be published for edge releases, then promoted to latest and proper versions on promotion.  The publish was missing from the edge release section.