### PR TITLE
Update the Red Hat image for cve-2022-1271

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.23.5] - 2022-06-14
+### Security
+- Update the Red Hat ubi image in Dockerfile
+  [cyberark/conjur-authn-k8s-client#471](https://github.com/cyberark/conjur-authn-k8s-client/pull/471)
+
 ## [0.24.4] - 2022-05-31
 
 ## [0.23.3] - 2022-05-19

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ ENTRYPOINT [ "/usr/local/bin/authenticator" ]
 FROM registry.access.redhat.com/ubi8/ubi as authenticator-client-redhat
 MAINTAINER CyberArk Software Ltd.
 
+RUN yum -y distro-sync
+
     # Add Limited user
 RUN groupadd -r authenticator \
              -g 777 && \


### PR DESCRIPTION
### Desired Outcome

Built images should not have critical or high security vulnerabilities.

### Implemented Changes

Updated the Red Hat UBI base image.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
