### PR TITLE
Update to allow parsing of go.mod in downstream projects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,12 @@ require (
 )
 
 require (
-	// Requires latest version for automated release process
-	github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-336
+	// Version number used here is ignored
+	github.com/cyberark/conjur-opentelemetry-tracer v1.55.55
 	github.com/davecgh/go-spew v1.1.1 // indirect
 )
 
 replace gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c => gopkg.in/yaml.v3 v3.0.1
+
+// DO NOT EDIT: CHANGES TO THE BELOW LINE WILL BREAK AUTOMATED RELEASES
+replace github.com/cyberark/conjur-opentelemetry-tracer => github.com/cyberark/conjur-opentelemetry-tracer latest


### PR DESCRIPTION
### Desired Outcome

Projects that include conjur-authn-k8s-client as a library will break with a version set to `latest` in `go.mod`.  This is an issue in the parser used even though it will be validly substituted.  Automated releases rely on pulling the latest version of internally managed projects.  This change will allow `go mod tidy` to properly parse the `go.mod` from this project and use the latest version of conjur-opentelemetry-tracer.

### Implemented Changes

- Use `replace` in go.mod to pull in the latest version without breaking parsing

### Definition of Done
Downstream projects successfully build using conjur-authn-k8s-client as a library

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
