### PR TITLE
Fix incorrect Red Hat image name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.0.1] - 2022-06-23
+
 ## [0.23.6] - 2022-06-16
 ### Security
 - Added replace statement for gopkg.in/yaml.v3 prior to v3.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ To run the test suite, run `./bin/build` and `./bin/test`.
 
 ### Demo Workflow 
 
-To run a sample deployment of the Helm charts located in `/helm`, run `./bin/test-workflow`. This
+To run a sample deployment of the Helm charts located in `/helm`, run `./bin/test-workflow/start`. This
 will download and run the `conjur-oss-helm-chart` project example, then consecutively install the 
 `helm/conjur-config-cluster-prep`, `helm/conjur-config-namespace-prep`, and `helm/conjur-app-deploy` charts, in that order.
 

--- a/bin/publish
+++ b/bin/publish
@@ -58,7 +58,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-REDHAT_REMOTE_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb/conjur-openshift-authenticator-client'
+REDHAT_REMOTE_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb/conjur-openshift-authenticator'
 readonly REGISTRY="cyberark"
 readonly REDHAT_LOCAL_IMAGE="conjur-authn-k8s-client-redhat"
 readonly INTERNAL_REGISTRY="registry.tld"
@@ -82,6 +82,20 @@ if [[ ${PUBLISH_INTERNAL} = true ]]; then
   tag_and_push "conjur-authn-k8s-client:${SOURCE_TAG}" "${INTERNAL_REGISTRY}/conjur-authn-k8s-client:${REMOTE_TAG}"
 
   tag_and_push ${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG} "${INTERNAL_REGISTRY}/${REDHAT_LOCAL_IMAGE}:${REMOTE_TAG}"
+
+  echo "Pushing to RedHat container registry..."
+  docker tag "${INTERNAL_REGISTRY}/${REDHAT_LOCAL_IMAGE}:${REMOTE_TAG}" "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}"
+
+  if docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"; then
+    # you can't push the same tag twice to redhat registry, so ignore errors
+    if ! docker push "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}"; then
+      echo 'RedHat push FAILED! (maybe the image was pushed already?)'
+      exit 0
+    fi
+  else
+    echo 'Failed to log in to scan.connect.redhat.com'
+    exit 1
+  fi
 fi
 
 if [[ ${PUBLISH_EDGE} = true ]]; then


### PR DESCRIPTION
### Desired Outcome

The conjur-authn-k8s-client image does not appear to be getting pushed to RedHat's platform successfully so we can not complete the [last few release steps](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CONTRIBUTING.md#publish-the-red-hat-image) that involve logging into RedHat's platform and publishing the image.

Investigate the CI pipeline and see if there are any sources of error when pushing to RedHat.

### Implemented Changes

- Fixed incorrect image name for Red Hat container image push
- Also fixed a typo in the CONTRIBUTING.md doc re/ the test scripts

### Connected Issue/Story

CyberArk internal issue link: [ONYX-21631](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-21631)

### Definition of Done

- [ ] Red Hat image is successfully pushed to the Partner Connect portal

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
