### PR TITLE
Scan OpenShift image after pushing to Red Hat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ To run the test suite, run `./bin/build` and `./bin/test`.
 
 ### Demo Workflow 
 
-To run a sample deployment of the Helm charts located in `/helm`, run `./bin/test-workflow`. This
+To run a sample deployment of the Helm charts located in `/helm`, run `./bin/test-workflow/start`. This
 will download and run the `conjur-oss-helm-chart` project example, then consecutively install the 
 `helm/conjur-config-cluster-prep`, `helm/conjur-config-namespace-prep`, and `helm/conjur-app-deploy` charts, in that order.
 

--- a/bin/publish
+++ b/bin/publish
@@ -58,7 +58,8 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-REDHAT_REMOTE_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb/conjur-openshift-authenticator-client'
+REDHAT_REMOTE_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb/conjur-openshift-authenticator'
+REDHAT_CERT_PID="5e621f6502235d3f505f6093"
 readonly REGISTRY="cyberark"
 readonly REDHAT_LOCAL_IMAGE="conjur-authn-k8s-client-redhat"
 readonly INTERNAL_REGISTRY="registry.tld"
@@ -138,6 +139,9 @@ if [[ ${PROMOTE} = true ]]; then
       echo 'RedHat push FAILED! (maybe the image was pushed already?)'
       exit 0
     fi
+
+    # scan image with preflight tool
+    scan_redhat_image "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}" "${REDHAT_CERT_PID}"
   else
     echo 'Failed to log in to scan.connect.redhat.com'
     exit 1


### PR DESCRIPTION
### Desired Outcome

The conjur-authn-k8s-client image does not appear to be getting pushed to RedHat's platform successfully so we can not complete the [last few release](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/CONTRIBUTING.md#publish-the-red-hat-image%20steps) that involve logging into RedHat's platform and publishing the image.

Investigate the CI pipeline and see if there are any sources of error when pushing to RedHat.

### Implemented Changes

- Added a script to the release-tools repository in https://github.com/conjurinc/release-tools/pull/38 which scans the OpenShift images using Red Hat's newly mandatory [preflight](https://github.com/redhat-openshift-ecosystem/openshift-preflight) tool.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-21631](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-21631)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
