### PR TITLE
Update summon-sidecar E2E test to use namespace-label authn-k8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.23.8] - 2022-08-31
+### Changed
+- Update Cluster Prep Helm chart to support namespace label-based authentication.
+  [cyberark/conjur-authn-k8s-client#482](https://github.com/cyberark/conjur-authn-k8s-client/pull/482)
+
 ## [0.23.7] - 2022-07-12
 ### Changed
 - Updated dev/Dockerfile.debug and removed bin/test-workflow/test-app-summon/Dockerfile.builder
@@ -245,7 +250,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix an issue where sidecar fails when not run as root user.
 
-[Unreleased]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.23.7...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.23.8...HEAD
+[0.23.8]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.23.7...v0.23.8
 [0.23.7]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.23.6...v0.23.7
 [0.23.6]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.23.5...v0.23.6
 [0.23.5]: https://github.com/cyberark/conjur-authn-k8s-client/compare/v0.23.3...v0.23.5

--- a/bin/test-workflow/0_prep_env.sh
+++ b/bin/test-workflow/0_prep_env.sh
@@ -62,6 +62,10 @@ export SECRETS_PROVIDER_TAG="${SECRETS_PROVIDER_TAG:-edge}"
 export SECRETLESS_BROKER_TAG="${SECRETLESS_BROKER_TAG:-latest}"
 export CONJUR_APPLIANCE_TAG="${CONJUR_APPLIANCE_TAG:-5.0-stable}"
 
+# Used to test namespace-label identity scope end-to-end against live K8s infra
+# See design document: https://github.com/cyberark/conjur/pull/2603
+export TEST_APP_NAMESPACE_LABEL="${TEST_APP_NAMESPACE_LABEL:-conjur.org/project=authn-k8s-e2e}"
+
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   conjur_service="conjur-oss"
   if [[ "$PLATFORM" == "openshift" ]]; then

--- a/bin/test-workflow/2_admin_load_conjur_policies.sh
+++ b/bin/test-workflow/2_admin_load_conjur_policies.sh
@@ -15,6 +15,7 @@ if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
 fi
 
 check_env_var TEST_APP_NAMESPACE_NAME
+check_env_var TEST_APP_NAMESPACE_LABEL
 check_env_var CONJUR_VERSION
 check_env_var CONJUR_ACCOUNT
 check_env_var CONJUR_APPLIANCE_URL
@@ -94,7 +95,8 @@ pushd policy > /dev/null
     sed "s#{{ APP_VALIDATOR_NAMESPACE_NAME }}#$app_validator_namespace#g" |
     sed "s#{{ IS_OPENSHIFT }}#$is_openshift#g" |
     sed "s#{{ IS_KUBERNETES }}#$is_kubernetes#g" |
-    sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g" > ./generated/"$TEST_APP_NAMESPACE_NAME".app-identities-policy.yml
+    sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g" |
+    sed "s#{{ TEST_APP_NAMESPACE_LABEL }}#$TEST_APP_NAMESPACE_LABEL#g" > ./generated/"$TEST_APP_NAMESPACE_NAME".app-identities-policy.yml
 
   sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/app-identities-policy-jwt.template.yml |
     sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE_NAME#g"  > ./generated/"$TEST_APP_NAMESPACE_NAME".app-identities-policy-jwt.yml

--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -28,7 +28,7 @@ pushd ../../helm/conjur-config-cluster-prep > /dev/null
   if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
     conjur_url="$CONJUR_APPLIANCE_URL"
     get_cert_options="-v -i -s -u"
-    additional_options=""
+    additional_options="--set authnK8s.serviceAccount.create=false --set authnK8s.serviceAccount.name=conjur-oss"
   else
     conjur_url="$CONJUR_FOLLOWER_URL"
     if [[ "$CONJUR_PLATFORM" == "gke" ]]; then

--- a/bin/test-workflow/5_app_namespace_prep.sh
+++ b/bin/test-workflow/5_app_namespace_prep.sh
@@ -6,6 +6,7 @@ cd "$(dirname "$0")" || ( echo "cannot cd into dir" && exit 1 )
 source utils.sh
 
 check_env_var TEST_APP_NAMESPACE_NAME
+check_env_var TEST_APP_NAMESPACE_LABEL
 check_env_var CONJUR_NAMESPACE_NAME
 
 TIMEOUT="${TIMEOUT:-5m0s}"
@@ -31,4 +32,7 @@ pushd ../../helm/conjur-config-namespace-prep > /dev/null
         --set authnK8s.namespace="$CONJUR_NAMESPACE_NAME" \
         --set conjurConfigMap.authnMethod=$AUTHN_STRATEGY
 
+    # Used to test namespace-label identity scope end-to-end against live K8s infra
+    # See design document: https://github.com/cyberark/conjur/pull/2603
+    $cli label namespace "$TEST_APP_NAMESPACE_NAME" "$TEST_APP_NAMESPACE_LABEL"
 popd > /dev/null

--- a/bin/test-workflow/policy/templates/app-identities-policy.template.yml
+++ b/bin/test-workflow/policy/templates/app-identities-policy.template.yml
@@ -40,7 +40,9 @@
       - !host
         id: test-app-summon-sidecar
         annotations:
-          authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+          # Used to test namespace-label identity scope end-to-end against live K8s infra
+          # See design document: https://github.com/cyberark/conjur/pull/2603
+          authn-k8s/namespace-label-selector: {{ TEST_APP_NAMESPACE_LABEL }}
           authn-k8s/service-account: test-app-summon-sidecar
           authn-k8s/deployment: test-app-summon-sidecar
           authn-k8s/authentication-container-name: authenticator

--- a/bin/test-workflow/utils.sh
+++ b/bin/test-workflow/utils.sh
@@ -271,7 +271,7 @@ function split_on_comma_delimiter {
 }
 
 function uninstall_helm_release {
-  release_name=i"$1"
+  release_name="$1"
   namespace="$2"
 
   if [ "$(helm list -q -n "$namespace" | grep "^$release_name$")" = "$release_name" ]; then
@@ -315,6 +315,7 @@ function run_command_with_platform {
     -e SAMPLE_APP_BACKEND_DB_PASSWORD \
     -e TEST_APP_DATABASE \
     -e TEST_APP_NAMESPACE_NAME \
+    -e TEST_APP_NAMESPACE_LABEL \
     -e CONJUR_APPLIANCE_IMAGE \
     -e CONJUR_FOLLOWER_URL \
     -e DEPLOY_MASTER_CLUSTER \

--- a/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
+++ b/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
@@ -62,6 +62,9 @@ rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["pods", "serviceaccounts"]
     verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
   - apiGroups: ["extensions"]
     resources: ["deployments", "replicasets"]
     verbs: ["get", "list"]

--- a/helm/conjur-config-cluster-prep/templates/clusterrole.yaml
+++ b/helm/conjur-config-cluster-prep/templates/clusterrole.yaml
@@ -19,6 +19,9 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods", "serviceaccounts"]
   verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get"]
 - apiGroups: ["extensions"]
   resources: [ "deployments", "replicasets"]
   verbs: ["get", "list"]


### PR DESCRIPTION
### Desired Outcome

Update our end-to-end test workflow to validate Authn-K8s namespace label selector restriction.

### Implemented Changes

- Update Cluster Prep Helm chart ClusterRole to provide `get` permission on namespaces.
- The `test-app-summon-sidecar` host is configured with the `namespace-label-selector` resource restriction. If the `summon-sidecar` app succeeds, then namespace label-based Authn-K8s is functional.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
