### PR TITLE
Make appliance tag a configurable test input

### DIFF
--- a/bin/test-workflow/0_prep_env.sh
+++ b/bin/test-workflow/0_prep_env.sh
@@ -60,6 +60,7 @@ export TEST_APP_TAG="${TEST_APP_TAG:-latest}"
 export INSTALL_APPS="${INSTALL_APPS:-summon-sidecar,secretless-broker,secrets-provider-k8s}"
 export SECRETS_PROVIDER_TAG="${SECRETS_PROVIDER_TAG:-edge}"
 export SECRETLESS_BROKER_TAG="${SECRETLESS_BROKER_TAG:-latest}"
+export CONJUR_APPLIANCE_TAG="${CONJUR_APPLIANCE_TAG:-5.0-stable}"
 
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   conjur_service="conjur-oss"
@@ -73,7 +74,7 @@ if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   fi
 else
   export TEST_APP_NAMESPACE_NAME="${TEST_APP_NAMESPACE_NAME:-app-test-$UNIQUE_TEST_ID}"
-  export CONJUR_APPLIANCE_IMAGE="${CONJUR_APPLIANCE_IMAGE:-registry2.itci.conjur.net/conjur-appliance:5.0-stable}"
+  export CONJUR_APPLIANCE_IMAGE="${CONJUR_APPLIANCE_IMAGE:-registry2.itci.conjur.net/conjur-appliance:$CONJUR_APPLIANCE_TAG}"
   export CONJUR_ADMIN_PASSWORD="MySecretP@ss1"
 
   if [[ "$CONJUR_PLATFORM" == "gke" ]]; then

--- a/bin/test-workflow/1_deploy_conjur.sh
+++ b/bin/test-workflow/1_deploy_conjur.sh
@@ -9,6 +9,7 @@ source utils.sh
 trap dump_conjur_namespace_upon_error EXIT
 
 function setup_conjur_enterprise {
+
   docker pull "$CONJUR_APPLIANCE_IMAGE"
 
   announce "Deploying Conjur Enterprise"
@@ -51,9 +52,9 @@ CONJUR_MASTER_PORT=\"${CONJUR_MASTER_PORT}\"
 CONJUR_FOLLOWER_PORT=\"${CONJUR_FOLLOWER_PORT}\"
 CONJUR_AUTHENTICATORS=authn-k8s/\"${AUTHENTICATOR_ID}\",authn-jwt/\"${AUTHENTICATOR_ID}\",authn
         """ > .env
-        ./bin/dap --provision-master
+        ./bin/dap --provision-master --version "${CONJUR_APPLIANCE_TAG}"
         ./bin/dap --import-custom-certificates
-        ./bin/dap --provision-follower
+        ./bin/dap --provision-follower --version "${CONJUR_APPLIANCE_TAG}"
       popd > /dev/null
 
     popd > /dev/null


### PR DESCRIPTION
### Desired Outcome

The desired outcome of this PR is twofold:

1) To validate the `authn-k8s-client` against the latest Conjur release
2) To make it easier to run tests with different Conjur enterprise images

### Implemented Changes

This PR makes the Conjur enterprise appliance tag a test suite input configured with an environment variable `CONJUR_APPLIANCE_TAG`. This tag is configured in Jenkins to use the latest internal release of the Conjur Enterprise image.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-25164](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-25164)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- x ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
