### PR TITLE
Dump K8S pod logs on failure

### DIFF
--- a/bin/test-workflow/8_app_verify_authentication.sh
+++ b/bin/test-workflow/8_app_verify_authentication.sh
@@ -22,8 +22,10 @@ function finish {
   if [ $? -eq 0 ]; then
     announce "Test PASSED!!!!"
   else
-    announce "Test FAILED!!!! Displaying resources in application Namespace"
+    announce "Test FAILED!!!! Displaying Kubernetes Resources"
     dump_kubernetes_resources "$TEST_APP_NAMESPACE_NAME"
+    dump_kubernetes_resources "$CONJUR_NAMESPACE_NAME"
+    dump_local_docker_logs
     dump_authentication_policy
   fi
 

--- a/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
+++ b/helm/conjur-config-cluster-prep/generated/conjur-config-cluster-prep.yaml
@@ -15,6 +15,24 @@ metadata:
     conjur.org/name: "conjur-serviceaccount"
     helm.sh/chart: conjur-config-cluster-prep-0.2.0
 ---
+# Source: conjur-config-cluster-prep/templates/serviceaccountsecret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: conjur-serviceaccount-service-account-token
+  labels:
+    release: cluster-prep
+    heritage: Helm
+    app.kubernetes.io/name: "conjur-serviceaccount-token"
+    app.kubernetes.io/component: "conjur-kubernetes-identity"
+    app.kubernetes.io/instance: "conjur-serviceaccount"
+    app.kubernetes.io/part-of: "conjur-config"
+    conjur.org/name: "conjur-serviceaccount-token"
+    helm.sh/chart: conjur-config-cluster-prep-0.2.0
+  annotations:
+    kubernetes.io/service-account.name: conjur-serviceaccount
+type: kubernetes.io/service-account-token
+---
 # Source: conjur-config-cluster-prep/templates/golden_configmap.yaml
 # The Golden ConfigMap keeps a reference copy of Conjur configuration information
 # that will be used for subsequent operations such as preparing application Namespaces

--- a/helm/conjur-config-cluster-prep/templates/serviceaccountsecret.yaml
+++ b/helm/conjur-config-cluster-prep/templates/serviceaccountsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.authnK8s.serviceAccount.name | default "conjur-serviceaccount" | printf "%.200s" }}-service-account-token
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: "conjur-serviceaccount-token"
+    app.kubernetes.io/component: "conjur-kubernetes-identity"
+    app.kubernetes.io/instance: "conjur-serviceaccount"
+    app.kubernetes.io/part-of: "conjur-config"
+    conjur.org/name: "conjur-serviceaccount-token"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  annotations:
+    kubernetes.io/service-account.name: {{ .Values.authnK8s.serviceAccount.name | default "conjur-serviceaccount" }}
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
### Desired Outcome
Ability to determine why containers are failing during CI.

### Implemented Changes
Log Kubernetes container outputs to the Jenkins CI console log on failure.

### Connected Issue/Story
CyberArk internal issue link: ONYX-26951

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
