### PR TITLE
update e2e tests for sidecar injector

### DIFF
--- a/bin/test-workflow/4_admin_cluster_prep.sh
+++ b/bin/test-workflow/4_admin_cluster_prep.sh
@@ -62,24 +62,8 @@ clean_web_hooks
 pushd "sidecar-injector-$UNIQUE_TEST_ID/helm/cyberark-sidecar-injector" > /dev/null
 # Rename the chart to a shorted name due to an SSL overflow issue with long
 # [service].[namespace] names
-sed -i 's/cyberark-sidecar-injector/sidecar-injector/g' Chart.yaml
-pushd templates
+sed -i.bak 's/cyberark-sidecar-injector/sidecar-injector/g' Chart.yaml && rm Chart.yaml.bak
 
-cat > serviceaccountsecret.yaml << EOF
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/service-account-token
-metadata:
-  name: {{ include "cyberark-sidecar-injector.name" . }}-service-account-token
-  labels:
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-  annotations:
-    kubernetes.io/service-account.name: {{ include "cyberark-sidecar-injector.name" . }}
-EOF
-
-popd > /dev/null
 set_namespace $CONJUR_NAMESPACE_NAME
 
 helm --namespace $CONJUR_NAMESPACE_NAME install cyberark-sidecar-injector \

--- a/bin/test-workflow/6_app_deploy_backend.sh
+++ b/bin/test-workflow/6_app_deploy_backend.sh
@@ -69,11 +69,6 @@ ret_val=0
 helm "${args[@]}" || ret_val=$?
 if [[ "$ret_val" != 0 ]]; then
   announce "checking stateful set test-app-backend"
-  echo "!!!ServiceAccounts:in namespace :$CONJUR_NAMESPACE_NAME"
-  "$cli" get -n "$CONJUR_NAMESPACE_NAME" serviceaccounts
-  echo "!!!Secrets:in namespace $CONJUR_NAMESPACE_NAME:"
-  "$cli" get -n "$CONJUR_NAMESPACE_NAME" secrets
-  "$cli" get -n "$CONJUR_NAMESPACE_NAME" secrets cyberark-sidecar-injector-service-account-token -o yaml
   $cli version
   $cli get statefulset -n "$TEST_APP_NAMESPACE_NAME"
   $cli describe statefulset test-app-backend -n "$TEST_APP_NAMESPACE_NAME"

--- a/bin/test-workflow/cleanup_helm.sh
+++ b/bin/test-workflow/cleanup_helm.sh
@@ -6,6 +6,7 @@ uninstall_helm_release "cluster-prep-$UNIQUE_TEST_ID" "$CONJUR_NAMESPACE_NAME"
 uninstall_helm_release "namespace-prep-$UNIQUE_TEST_ID" "$TEST_APP_NAMESPACE_NAME"
 uninstall_helm_release app-backend-pg "$TEST_APP_NAMESPACE_NAME"
 uninstall_helm_release test-apps "$TEST_APP_NAMESPACE_NAME"
+uninstall_helm_release cyberark-sidecar-injector "$CONJUR_NAMESPACE_NAME"
 if [[ "$CONJUR_OSS_HELM_INSTALLED" == "true" ]]; then
   uninstall_helm_release "$HELM_RELEASE" "$CONJUR_NAMESPACE_NAME"
 fi

--- a/bin/test-workflow/stop
+++ b/bin/test-workflow/stop
@@ -22,11 +22,13 @@ if [[ "${CONJUR_OSS_HELM_INSTALLED}" == "true" ]]; then
       fi
 
       rm -rf 'temp/conjur-oss-helm-chart-$UNIQUE_TEST_ID'
+      rm -rf 'temp/sidecar-injector-$UNIQUE_TEST_ID'
     "
   else 
     ./cleanup_helm.sh
     ./cleanup_namespaces.sh
     rm -rf "temp/conjur-oss-helm-chart-$UNIQUE_TEST_ID"
+    rm -rf "temp/sidecar-injector-$UNIQUE_TEST_ID"
   fi
 
 elif [[ "$CONJUR_PLATFORM" == "gke" ]]; then
@@ -41,6 +43,7 @@ elif [[ "$CONJUR_PLATFORM" == "gke" ]]; then
   "
 
   rm -rf "temp/kubernetes-conjur-deploy-$UNIQUE_TEST_ID"
+  rm -rf "temp/sidecar-injector-$UNIQUE_TEST_ID"
 
 elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
   pushd "temp/conjur-intro-$UNIQUE_TEST_ID" > /dev/null
@@ -58,5 +61,6 @@ elif [[ "$CONJUR_PLATFORM" == "jenkins" ]]; then
   "
 
   rm -rf "temp/conjur-intro-$UNIQUE_TEST_ID"
+  rm -rf "temp/sidecar-injector-$UNIQUE_TEST_ID"
 
 fi


### PR DESCRIPTION
### Desired Outcome

Update the E2E tests for sidecar injector

### Implemented Changes

- Update the `sed` line in `4_admin_cluster_prep.sh` to be compatible with mac
- Removed adding serviceaccountsecret.yaml as this is now in the sidecar injector repo
- Added cleanup of the sidecar injector Helm chart.
- removed extra debug lones 
 

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
