### PR TITLE
Fix Redhat registry pushing

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -58,11 +58,14 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-REDHAT_REMOTE_IMAGE='scan.connect.redhat.com/ospid-1c46a2de-1d88-40e6-a433-7114ad0099cb/conjur-openshift-authenticator'
-REDHAT_CERT_PID="5e621f6502235d3f505f6093"
 readonly REGISTRY="cyberark"
 readonly REDHAT_LOCAL_IMAGE="conjur-authn-k8s-client-redhat"
 readonly INTERNAL_REGISTRY="registry.tld"
+readonly REDHAT_REGISTRY="quay.io"
+readonly REDHAT_CERT_PID="5e621f6502235d3f505f6093"
+
+REDHAT_REMOTE_IMAGE="${REDHAT_REGISTRY}/redhat-isv-containers/${REDHAT_CERT_PID}"
+REDHAT_USER="redhat-isv-containers+${REDHAT_CERT_PID}-robot"
 
 # we changed the name to `conjur-authn-k8s-client`. Leaving `conjur-kubernetes-authenticator`
 # for backwards-compatibility.
@@ -133,7 +136,7 @@ if [[ ${PROMOTE} = true ]]; then
   echo "Pushing to RedHat container registry..."
   docker tag "${INTERNAL_REGISTRY}/${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}"
 
-  if docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"; then
+  if docker login "${REDHAT_REGISTRY}" -u "${REDHAT_USER}" -p "${REDHAT_API_KEY}"; then
     # you can't push the same tag twice to redhat registry, so ignore errors
     if ! docker push "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}"; then
       echo 'RedHat push FAILED! (maybe the image was pushed already?)'
@@ -143,7 +146,7 @@ if [[ ${PROMOTE} = true ]]; then
     # scan image with preflight tool
     scan_redhat_image "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}" "${REDHAT_CERT_PID}"
   else
-    echo 'Failed to log in to scan.connect.redhat.com'
+    echo 'Failed to log in to quay.io'
     exit 1
   fi
 


### PR DESCRIPTION
### Desired Outcome

Push images to quay.io (instead of scan.connect.redhat.com) for preflight scanning

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
