### PR TITLE
Fix false positive tests in test stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,11 +115,16 @@ pipeline {
     stage('Run Tests') {
       steps {
         sh './bin/test'
-        sh 'cp ./test/c.out ./c.out'
+      }
+      post {
+        always {
+          sh './bin/coverage'
+          sh 'cp ./test/c.out ./c.out'
 
-        junit 'test/junit.xml'
-        cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'test/coverage.xml', conditionalCoverageTargets: '70, 0, 70', failUnhealthy: true, failUnstable: true, maxNumberOfBuilds: 0, lineCoverageTargets: '70, 70, 70', methodCoverageTargets: '70, 0, 70', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
-        ccCoverage("gocov", "--prefix github.com/cyberark/conjur-authn-k8s-client")
+          junit 'test/junit.xml'
+          cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'test/coverage.xml', conditionalCoverageTargets: '70, 0, 70', failUnhealthy: true, failUnstable: true, maxNumberOfBuilds: 0, lineCoverageTargets: '70, 70, 70', methodCoverageTargets: '70, 0, 70', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+          ccCoverage("gocov", "--prefix github.com/cyberark/conjur-authn-k8s-client")
+        }
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,12 +199,6 @@ pipeline {
           }
         }
         stage('Enterprise in Jenkins') {
-          environment {
-            // githubLatestReleaseVersion returns with a newline on the end of
-            // the string, so we use `replaceAll` to remove the extra whitespace.
-            CONJUR_APPLIANCE_TAG = githubLatestReleaseVersion('conjurinc', 'appliance', 'latest').replaceAll("\\s","")
-          }
-
           stages {
             stage('Test app in GKE') {
               steps {

--- a/bin/coverage
+++ b/bin/coverage
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eox pipefail
+
+junit_output_file="./test/junit.output"
+
+rm -f junit.xml
+
+echo "Building junit image..."
+docker build -f Dockerfile.junit -t conjur-authn-k8s-client-junit:latest .
+
+echo "Creating junit report..."
+
+docker run --rm \
+  -v "$PWD"/:/conjur-authn-k8s-client/ \
+  conjur-authn-k8s-client-junit:latest \
+  bash -exc "
+    cat ./junit.output | go-junit-report > ./junit.xml
+    cat ./c.out.tmp | grep -v authenticator_test_server.go > ./c.out
+    gocov convert ./c.out | gocov-xml > ./coverage.xml
+  "

--- a/bin/test
+++ b/bin/test
@@ -14,7 +14,6 @@ echo "Building unit test image..."
 docker build -f Dockerfile.test -t conjur-authn-k8s-client-test-runner:latest .
 
 echo "Running unit tests..."
-set +e
   docker run --rm -t --volume "$PWD"/test/:/conjur-authn-k8s-client/test/ \
              conjur-authn-k8s-client-test-runner:latest \
              -coverpkg ./... \
@@ -23,20 +22,3 @@ set +e
              ./pkg/... \
              | tee -a "$junit_output_file"
   echo "Unit test exit status: $?"
-set -e
-
-rm -f junit.xml
-
-echo "Building junit image..."
-docker build -f Dockerfile.junit -t conjur-authn-k8s-client-junit:latest .
-
-echo "Creating junit report..."
-
-docker run --rm \
-  -v "$PWD"/:/conjur-authn-k8s-client/ \
-  conjur-authn-k8s-client-junit:latest \
-  bash -exc "
-    cat ./junit.output | go-junit-report > ./junit.xml
-    cat ./c.out.tmp | grep -v authenticator_test_server.go > ./c.out
-    gocov convert ./c.out | gocov-xml > ./coverage.xml
-  "


### PR DESCRIPTION
### Desired Outcome

Several of our CI pipelines follow [this pattern](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/bin/test_unit#L31) where the script that runs unit tests sets +e to prevent unit test failure from stopping the script from running. I believe this was done to ensure that the junit tests would run even if the tests failed, but it's having the unfortunate side effect of showing the unit testing phase as green in Jenkins when a unit test fails, making it a bit unclear what's going on.

### Implemented Changes

Break the junit logic into a separate script that can be run independently from the unit tests in a "post-always" block in the Jenkinsfile and return the error code when unit test(s) fail.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
