### PR TITLE
Adding a wait for the master before deploying the follower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.24.1] - 2022-12-02
+## [0.24.1] - 2023-01-27
+### Changed
+- Add a wait for the master before provisioning the follower in the CI tests.
+  [cyberark/conjur-authn-k8s-client#499](https://github.com/cyberark/conjur-authn-k8s-client/pull/499)
 
 ## [0.24.0] - 2022-11-23
 ### Changed

--- a/bin/test-workflow/1_deploy_conjur.sh
+++ b/bin/test-workflow/1_deploy_conjur.sh
@@ -56,6 +56,7 @@ CONJUR_AUTHENTICATORS=authn-k8s/\"${AUTHENTICATOR_ID}\",authn-jwt/\"${AUTHENTICA
         """ > .env
         ./bin/dap --provision-master --version "${CONJUR_APPLIANCE_TAG}"
         ./bin/dap --import-custom-certificates
+        ./bin/dap --wait-for-master
         ./bin/dap --provision-follower --version "${CONJUR_APPLIANCE_TAG}"
       popd > /dev/null
 


### PR DESCRIPTION
### Desired Outcome

Seeing the following error with the latest CI runs.

```[2023-01-27T15:00:50.184Z] Running Command (on conjur-master-1.mycompany.local): docker exec cyberark-dap evoke seed follower conjur-follower.mycompany.local > /opt/cyberark/dap/seeds/follower-seed.tar
[2023-01-27T15:00:55.464Z] psql: could not connect to server: No such file or directory
[2023-01-27T15:00:55.464Z]     Is the server running locally and accepting
[2023-01-27T15:00:55.464Z]     connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
```

### Implemented Changes

Added a wait for the master before provisioning the follower

### Connected Issue/Story



### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
