### PR TITLE
Use latest yq release (CVE-2022-28948)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ LABEL description="The authentication client required to expose secrets from a C
 
 # =================== CONTAINER FOR HELM TEST ===================
 
-FROM alpine:3.14 as k8s-cluster-test
+FROM golang:alpine3.17 as k8s-cluster-test
 
 # Install packages for testing
 RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl openssl-dev
@@ -144,8 +144,15 @@ RUN git clone https://github.com/ztombol/bats-support /bats/bats-support && \
     git clone https://github.com/ztombol/bats-file /bats/bats-file
 
 # Install yq
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq && \
-    chmod +x /usr/local/bin/yq
+# Build from source to get the latest version due to CVE-2022-4172
+RUN git clone https://github.com/mikefarah/yq /yq && \
+    cd /yq && \
+    go build && \
+    mv yq /usr/bin/yq && \
+    rm -rf /yq && \
+    chmod +x /usr/bin/yq
+# RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
+#     chmod +x /usr/bin/yq
 
 RUN mkdir -p /tests
 WORKDIR /tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ RUN git clone https://github.com/ztombol/bats-support /bats/bats-support && \
     git clone https://github.com/ztombol/bats-file /bats/bats-file
 
 # Install yq
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64 -O /usr/local/bin/yq && \
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
 
 RUN mkdir -p /tests

--- a/Dockerfile.helm-unit-test
+++ b/Dockerfile.helm-unit-test
@@ -1,6 +1,6 @@
 # =================== CONTAINER FOR HELM UNIT TEST ===================
 
-FROM alpine:3.14 as conjur-k8s-helm-unit-test
+FROM golang:alpine3.17 as conjur-k8s-helm-unit-test
 
 # Install packages for installing Helm and Helm unittest plugin
 RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl
@@ -15,8 +15,15 @@ RUN mv /etc/os-release /etc/os-release.bak && \
     mv /etc/os-release.bak /etc/os-release
 
 # Install yq
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
+# Build from source to get the latest version due to CVE-2022-4172
+RUN git clone https://github.com/mikefarah/yq /yq && \
+    cd /yq && \
+    go build && \
+    mv yq /usr/bin/yq && \
+    rm -rf /yq && \
     chmod +x /usr/bin/yq
+# RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
+#     chmod +x /usr/bin/yq
 
 RUN mkdir -p /conjur-authn-k8s-client
 WORKDIR /conjur-authn-k8s-client

--- a/bin/test-workflow/Dockerfile
+++ b/bin/test-workflow/Dockerfile
@@ -30,3 +30,7 @@ ARG HELM_CLI_VERSION
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 RUN chmod 700 get_helm.sh
 RUN ./get_helm.sh --no-sudo --version ${HELM_CLI_VERSION:-v3.5.2}
+
+# Add the WORKDIR as a safe directory so git commands
+# can be run in containers using this image
+RUN git config --global --add safe.directory /src


### PR DESCRIPTION
### Desired Outcome

Address failing builds due to high severity CVE-2022-28948 loading in from yq

### Implemented Changes

* Use latest release of yq (or build from source)
* Add /src folder as git safe directory (from https://github.com/cyberark/conjur-authn-k8s-client/pull/500)

NOTE: using latest fixes the intended CVE but there is still a high severity CVE found: CVE-2022-41721. It should be fixed with this [PR](https://github.com/mikefarah/yq/pull/1540) in the next yq release which I assume will appear in the next week or so. In the meantime we could add a .trivyignore entry to get passing builds. (cc @andytinkham)

Alternatively I've updated the dockerfile to build yq from source which has the CVE fix already (requires using golang:alpine image for helm test image)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
