### PR TITLE
Upgrade base image in Dockerfiles to 1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.24.2] - 2023-03-09
+### Changed
+- Upgrade base image in Dockerfiles to 1.19 and necessary dependencies
+  [cyberark/conjur-authn-k8s-client#502ß](https://github.com/cyberark/conjur-authn-k8s-client/pull/502)
+
 ## [0.24.1] - 2023-01-27
 ### Changed
 - Add a wait for the master before provisioning the follower in the CI tests.

--- a/Dockerfile.helm-unit-test
+++ b/Dockerfile.helm-unit-test
@@ -1,6 +1,6 @@
 # =================== CONTAINER FOR HELM UNIT TEST ===================
 
-FROM golang:alpine3.17 as conjur-k8s-helm-unit-test
+FROM golang:1.19-alpine as conjur-k8s-helm-unit-test
 
 # Install packages for installing Helm and Helm unittest plugin
 RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl

--- a/Dockerfile.junit
+++ b/Dockerfile.junit
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine
+FROM golang:1.19-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-junit-processor"
 
@@ -13,6 +13,6 @@ RUN apk add -u curl \
 
 # gocov converts native coverage output to gocov's JSON interchange format
 # gocov-xml converts gocov format to XML for use with Jenkins/Cobertura
-RUN go get -u github.com/jstemmer/go-junit-report && \
-    go get github.com/axw/gocov/gocov && \
-    go get github.com/AlekSi/gocov-xml
+RUN go install github.com/jstemmer/go-junit-report/v2@latest && \
+    go install github.com/axw/gocov/gocov@latest && \
+    go install github.com/AlekSi/gocov-xml@latest

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine
+FROM golang:1.19-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="conjur-authn-k8s-client-test-runner"
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,24 @@
 module github.com/cyberark/conjur-authn-k8s-client
 
-go 1.16
+go 1.19
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
+)
+
+require (
+	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.opentelemetry.io/otel/exporters/jaeger v1.7.0 // indirect
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.7.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.7.0 // indirect
+	go.opentelemetry.io/otel/trace v1.7.0 // indirect
+	golang.org/x/sys v0.1.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-336 h1:eyFRQDVVxjUqIO3lSGT6wH+GgIJHVmVxFZh6N1tWmUk=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-336/go.mod h1:Uq08XFlzJrRf7KbQO6mmIlwMsL1PSeYcldj34F8yGEc=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-394 h1:Ffl+3eKkawBUtaRC2O0rTT3KGvr/NzaO6BB7HI0fly4=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-394/go.mod h1:IU6D7QQezwoCi6GaKa+79ZrBNyJzFCbIAep0VrLHK6o=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-859 h1:Mm/kEw/EeJvGAxnWVmSfRHSWxCe7MAkOV0nUG//4NJo=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-859/go.mod h1:knGjmz7WYYptFxOwbMTHD56oslEQrNTq2mDW9qix0fc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -34,8 +32,8 @@ go.opentelemetry.io/otel/sdk v1.7.0/go.mod h1:uTEOTwaqIVuTGiJN7ii13Ibp75wJmYUDe3
 go.opentelemetry.io/otel/trace v1.7.0 h1:O37Iogk1lEkMRXewVtZ1BBTVn5JEp8GrJvP92bJqC6o=
 go.opentelemetry.io/otel/trace v1.7.0/go.mod h1:fzLSB9nqR2eXzxPXb2JW9IKE+ScyXA48yyE4TNvoHqU=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220111092808-5a964db01320 h1:0jf+tOCoZ3LyutmCOWpVni1chK4VfFLhRsDK7MhqGRY=
-golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### Desired Outcome

This pull request address both upgrading the 'golang.org/x/sys' dependency to resolve CVE-2022-29526 and updating the Dockerfiles to 1.19 to uphold the 'boringcrypto' fix as well as keeping everything up-to-date.

### Implemented Changes

- updated CHANGELOG
- upgraded image in Dockerfile to 1.19
- upgraded image in Dockerfile.helm-unit-test to 1.19
- upgraded image in Dockerfile.junit to 1.19 & corresponding syntax fix
- upgraded image in Dockerfile.test to 1.19
- upgraded go.mod and go.sum

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [X] These changes are part of a larger initiative that will be reviewed later, or
- [] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
