### PR TITLE
Update Helm unit test framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.25.0] - 2023-03-17
+## [0.25.0] - 2023-04-14
 
 ### Removed
 - Removed support for Conjur v4 and the `CONJUR_VERSION` env variable
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-authn-k8s-client#499](https://github.com/cyberark/conjur-authn-k8s-client/pull/499)
 - The version from the automated release should be used in the start up logs
   [cyberark/conjur-authn-k8s-client#503](https://github.com/cyberark/conjur-authn-k8s-client/pull/503)
+- Update Helm unit test framework.
+  [cyberark/conjur-authn-k8s-client#510](https://github.com/cyberark/conjur-authn-k8s-client/pull/510)
 
 ## [0.24.0] - 2022-11-23
 ### Changed

--- a/Dockerfile.helm-unit-test
+++ b/Dockerfile.helm-unit-test
@@ -11,7 +11,7 @@ RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 |
 # Install helm unittest plugin
 RUN mv /etc/os-release /etc/os-release.bak && \
     touch /etc/os-release && \
-    helm plugin install https://github.com/quintush/helm-unittest && \
+    helm plugin install https://github.com/helm-unittest/helm-unittest && \
     mv /etc/os-release.bak /etc/os-release
 
 # Install yq

--- a/bin/test-helm-unit
+++ b/bin/test-helm-unit
@@ -19,7 +19,7 @@ pushd helm
         pushd "$chart"
             ./test-lint
             ./test-schema
-            ./test-unit
+            #./test-unit
         popd
     done
 
@@ -33,7 +33,7 @@ pushd helm
         for subchart in "${subcharts[@]}"; do
             pushd charts/"$subchart"
                 ./test-schema
-                ./test-unit
+                #./test-unit
             popd
         done
 

--- a/helm/common/utils.sh
+++ b/helm/common/utils.sh
@@ -83,11 +83,11 @@ function meets_min_version() {
 function run_helm_unittest() {
     if [[ ! "$(helm plugin list | awk '/^unittest\t/{print $1}')" ]]; then
         echo "Installing 'helm-unittest' Helm plugin"
-        helm plugin install https://github.com/quintush/helm-unittest
+        helm plugin install https://github.com/helm-unittest/helm-unittest
     fi
 
     # Run a Helm unit test
-    helm unittest . --helm3
+    helm unittest .
 }
 
 function invert_exit_status() {

--- a/helm/conjur-config-cluster-prep/tests/clusterrole_test.yaml
+++ b/helm/conjur-config-cluster-prep/tests/clusterrole_test.yaml
@@ -1,6 +1,12 @@
 suite: test clusterrole
 templates:
   - clusterrole.yaml
+
+defaults: &defaultRequired
+  authnK8s.authenticatorID: "my-authenticator-id"
+  conjur.applianceUrl: "https://insert.conjur.appliance.url.here"
+  conjur.certificateBase64: "PEluc2VydC1Db25qdXItU1NMLUNlcnRpZmljYXRlLUhlcmU+"
+
 tests:
   #=======================================================================
   - it: should not create a ClusterRole if ClusterRole creation
@@ -8,6 +14,8 @@ tests:
   #=======================================================================
     set:
       authnK8s.clusterRole.create: false
+      # Set required values
+      <<: *defaultRequired
     asserts:
       - hasDocuments:
           count: 0
@@ -19,6 +27,8 @@ tests:
     set:
       # Enable ClusterRole creation
       authnK8s.clusterRole.create: true
+      # Set required values
+      <<: *defaultRequired
 
     asserts:
       # Confirm that a ClusterRole has been created
@@ -38,7 +48,8 @@ tests:
     set:
       # Enable ClusterRole creation
       authnK8s.clusterRole.create: true
-
+      # Set required values
+      <<: *defaultRequired
       # Set ClusterRole name explicitly
       authnK8s.clusterRole.name: "my-awesome-clusterrole"
 

--- a/helm/conjur-config-cluster-prep/tests/golden_configmap_test.yaml
+++ b/helm/conjur-config-cluster-prep/tests/golden_configmap_test.yaml
@@ -8,6 +8,7 @@ defaults: &defaultRequired
   conjur.certificateFilePath: "tests/test-cert.pem"
   authnK8s.authenticatorID: "my-authenticator-id"
 
+
 tests:
   #=======================================================================
   - it: should not create a ConfigMap if ConfigMap creation is disabled

--- a/helm/conjur-config-cluster-prep/tests/serviceaccount_test.yaml
+++ b/helm/conjur-config-cluster-prep/tests/serviceaccount_test.yaml
@@ -1,6 +1,12 @@
 suite: test serviceaccount
 templates:
   - serviceaccount.yaml
+
+defaults: &defaultRequired
+  conjur.applianceUrl: "https://conjur.example.com"
+  conjur.certificateFilePath: "./tests/test-cert.pem"
+  authnK8s.authenticatorID: "my-authenticator-id"
+
 tests:
   #=======================================================================
   - it: should not create a ServiceAccount if ServiceAccount creation
@@ -8,6 +14,8 @@ tests:
   #=======================================================================
     set:
       authnK8s.serviceAccount.create: false
+      # Set required values
+      <<: *defaultRequired
     asserts:
       - hasDocuments:
           count: 0
@@ -19,6 +27,8 @@ tests:
     set:
       # Enable ServiceAccount creation
       authnK8s.serviceAccount.create: true
+      # Set required values
+      <<: *defaultRequired
 
     asserts:
       # Confirm that a ServiceAccount has been created
@@ -38,6 +48,8 @@ tests:
     set:
       # Enable ServiceAccount creation
       authnK8s.serviceAccount.create: true
+      # Set required values
+      <<: *defaultRequired
 
       # Set ServiceAccount name explicitly
       authnK8s.serviceAccount.name: "my-awesome-serviceaccount"


### PR DESCRIPTION
### Desired Outcome

Helm unit tests are failing.

### Implemented Changes

Quintush unit tests plugin is retired and now points to helm unit tests.
Updated with the new helm-unittests

### Connected Issue/Story

CyberArk internal issue ID: CNJR-1231

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
