### PR TITLE
Pin helm-unittest plugin to v0.2.11

### DIFF
--- a/Dockerfile.helm-unit-test
+++ b/Dockerfile.helm-unit-test
@@ -8,10 +8,15 @@ RUN apk add --no-cache bash bind-tools coreutils curl git ncurses openssl
 # Install helm
 RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
-# Install helm unittest plugin
+# Install helm unittest plugin. The latest version, v0.3.1, fails tests
+# that render with the $.Files.Get template function, which is used by
+# the Cluster Prep Helm chart.
+# https://github.com/helm-unittest/helm-unittest/issues/135
+#
+# Pinning helm-unittest to v0.2.11 until this is fixed.
 RUN mv /etc/os-release /etc/os-release.bak && \
     touch /etc/os-release && \
-    helm plugin install https://github.com/quintush/helm-unittest && \
+    helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.2.11 && \
     mv /etc/os-release.bak /etc/os-release
 
 # Install yq

--- a/helm/common/utils.sh
+++ b/helm/common/utils.sh
@@ -82,8 +82,14 @@ function meets_min_version() {
 # Install the 'helm-unittest' plugin if it hasn't been install already
 function run_helm_unittest() {
     if [[ ! "$(helm plugin list | awk '/^unittest\t/{print $1}')" ]]; then
+        # The latest version of helm-unittest, v0.3.1, fails tests that render
+        # with the $.Files.Get template function, which is used by the Cluster
+        # Prep Helm chart.
+        # https://github.com/helm-unittest/helm-unittest/issues/135
+        #
+        # Pinning helm-unittest to v0.2.11 until this is fixed.
         echo "Installing 'helm-unittest' Helm plugin"
-        helm plugin install https://github.com/quintush/helm-unittest
+        helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.2.11
     fi
 
     # Run a Helm unit test


### PR DESCRIPTION
### Desired Outcome

Fix failing build due to Helm unittest failures.

### Implemented Changes

The latest version of helm-unittest, v0.3.1, fails tests that render templates with the `$.Files.Get` function. This is used by our Cluster Prep chart, so pinning until this is fixed.

This [bug](https://github.com/helm-unittest/helm-unittest/issues/135) is known and a fix is in the works.

### Connected Issue/Story

CNJR-1231

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
