### PR TITLE
Publish latest tag to Redhat on promote

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -145,6 +145,10 @@ if [[ ${PROMOTE} = true ]]; then
 
     # scan image with preflight tool
     scan_redhat_image "${REDHAT_REMOTE_IMAGE}:${REMOTE_TAG}" "${REDHAT_CERT_PID}"
+
+    # Push latest tag to RH
+    docker tag "${INTERNAL_REGISTRY}/${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "${REDHAT_REMOTE_IMAGE}:latest"
+    docker push "${REDHAT_REMOTE_IMAGE}:latest"
   else
     echo 'Failed to log in to quay.io'
     exit 1


### PR DESCRIPTION
### Desired Outcome

Fix tagging of Redhat images.

### Implemented Changes

Currently we are only publishing the version tagged image, so `latest` is never updated when new images are pushed to the RH registry

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
