### PR TITLE
adding proxy support + fixing build script

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# go to repo root folder for execution
+cd $(dirname $0)/..
+
 . bin/build_utils
 
 function main() {

--- a/pkg/authenticator/common/client.go
+++ b/pkg/authenticator/common/client.go
@@ -34,7 +34,7 @@ func NewHTTPSClient(CACert []byte, certPEMBlock, keyPEMBlock []byte) (*http.Clie
 	}
 	// Doubt this is necessary because there's only one
 	//tlsConfig.BuildNameToCertificate()
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	transport := &http.Transport{TLSClientConfig: tlsConfig, Proxy: http.ProxyFromEnvironment}
 
 	return &http.Client{Transport: transport, Timeout: time.Second * 10}, nil
 }


### PR DESCRIPTION

# Desired Outcome

Conjur API uses the net/http module which supports proxy.
When creating a new HTTPS client we ignore proxy configuration at http.Transport
Implemented Changes

build.sh doesn't work since the script path is not at root folder

# Implemented Changes

http.ProxyFromEnvironment was added to http.Transport - we now support http_proxy, https_proxy, no_proxy from env params.

build.sh script was amended with correct path - script will cd to repo root
